### PR TITLE
fix: correct main.js path on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@
 
 <body class="h-screen overflow-hidden bg-slate-900 text-slate-100 font-inter">
   <main id="app" class="h-full max-w-7xl mx-auto px-3 sm:px-4 py-3 flex flex-col block" v-cloak></main>
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix script path so GitHub Pages loads main.js correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7f8a30000832c83027037bb8cdd15