### PR TITLE
refactor: rename tool services and move pixel/selection helpers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ import { useStageService } from './services/stage';
 import { useLayerStore } from './stores/layers';
 import { useSelectionStore } from './stores/selection';
 import { useLayerService } from './services/layers';
+import { useSelectService } from './services/select';
 import { useOutputStore } from './stores/output';
 
 import StageToolbar from './components/StageToolbar.vue';
@@ -41,6 +42,7 @@ const stageService = useStageService();
 const layers = useLayerStore();
 const selection = useSelectionStore();
 const layerSvc = useLayerService();
+const selectSvc = useSelectService();
 const output = useOutputStore();
 
 // General key handler
@@ -65,7 +67,7 @@ function onKeydown(event) {
       if (shift && !ctrl) {
         if (!selection.exists) return;
         const newTail = layerSvc.aboveId(selection.tailId) ?? layerSvc.uppermostId();
-        layerSvc.selectRange(selection.anchorId, newTail);
+        selectSvc.selectRange(selection.anchorId, newTail);
         selection.setScrollRule({ type: 'follow-up', target: newTail });
       } else if (!ctrl) {
         const nextId = layerSvc.aboveId(selection.anchorId) ?? selection.anchorId;
@@ -79,7 +81,7 @@ function onKeydown(event) {
       if (shift && !ctrl) {
         if (!selection.exists) return;
         const newTail = layerSvc.belowId(selection.tailId) ?? layerSvc.lowermostId();
-        layerSvc.selectRange(selection.anchorId, newTail);
+        selectSvc.selectRange(selection.anchorId, newTail);
         selection.setScrollRule({ type: 'follow-down', target: newTail });
       } else if (!ctrl) {
         const nextId = layerSvc.belowId(selection.anchorId) ?? selection.anchorId;

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -40,6 +40,7 @@ import { useStageService } from '../services/stage';
 import { useLayerStore } from '../stores/layers';
 import { useSelectionStore } from '../stores/selection';
 import { useLayerService } from '../services/layers';
+import { useSelectService } from '../services/select';
 import { useOutputStore } from '../stores/output';
 import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, coordsToKey, clamp } from '../utils';
 
@@ -48,6 +49,7 @@ const stageService = useStageService();
 const layers = useLayerStore();
 const selection = useSelectionStore();
 const layerSvc = useLayerService();
+const selectSvc = useSelectService();
 const output = useOutputStore();
 
 const dragging = ref(false);
@@ -64,7 +66,7 @@ const patternUrl = computed(() => `url(#${stageService.ensureCheckerboardPattern
 
 function onLayerClick(id, event) {
     if (event.shiftKey) {
-        layerSvc.selectRange(selection.anchorId ?? id, id);
+        selectSvc.selectRange(selection.anchorId ?? id, id);
     } else if (event.ctrlKey || event.metaKey) {
         selection.toggle(id);
     } else {

--- a/src/components/StageToolbar.vue
+++ b/src/components/StageToolbar.vue
@@ -6,27 +6,29 @@
 
     <!-- Shape toggle -->
     <div class="inline-flex rounded-md overflow-hidden border border-white/15">
-      <button @click="stageStore.setToolShape('stroke')" :class="buttonClass(stageStore.isStroke, false)">Stroke</button>
-      <button @click="stageStore.setToolShape('rect')"   :class="buttonClass(stageStore.isRect, false)">Rect</button>
+      <button @click="toolStore.setToolShape('stroke')" :class="buttonClass(toolStore.isStroke, false)">Stroke</button>
+      <button @click="toolStore.setToolShape('rect')"   :class="buttonClass(toolStore.isRect, false)">Rect</button>
     </div>
 
     <!-- Tool Toggles -->
     <!-- Single Layer Mode Tools -->
-    <div v-if="stageStore.effectiveMode === 'single'" class="inline-flex rounded-md overflow-hidden border border-white/15">
-      <button @click="stageStore.setTool('draw')"  :class="buttonClass(stageStore.isDraw, false)">Draw</button>
-      <button @click="stageStore.setTool('erase')" :class="buttonClass(stageStore.isErase, false)">Erase</button>
+    <div v-if="toolStore.effectiveMode === 'single'" class="inline-flex rounded-md overflow-hidden border border-white/15">
+      <button @click="toolStore.setTool('draw')"  :class="buttonClass(toolStore.isDraw, false)">Draw</button>
+      <button @click="toolStore.setTool('erase')" :class="buttonClass(toolStore.isErase, false)">Erase</button>
     </div>
     <!-- Multi Layer Mode Tools -->
     <div v-else class="inline-flex rounded-md overflow-hidden border border-white/15">
-      <button @click="stageStore.setTool('select')" :class="buttonClass(stageStore.isSelect, false)">Select</button>
-      <button @click="stageStore.setTool('globalErase')" :class="buttonClass(stageStore.isGlobalErase, false)">Global Erase</button>
+      <button @click="toolStore.setTool('select')" :class="buttonClass(toolStore.isSelect, false)">Select</button>
+      <button @click="toolStore.setTool('globalErase')" :class="buttonClass(toolStore.isGlobalErase, false)">Global Erase</button>
     </div>
   </div>
 </template>
 
 <script setup>
 import { useStageStore } from '../stores/stage';
+import { useToolStore } from '../stores/tool';
 
 const stageStore = useStageStore();
-const buttonClass = (active, disabled) => `px-2 py-1 text-xs ${disabled?'opacity-40 pointer-events-none cursor-not-allowed':''} ${active&&!disabled?'bg-white/15':'bg-white/5 hover:bg-white/10'}`;
+const toolStore = useToolStore();
+const buttonClass = (active, disabled) => `px-2 py-1 text-xs ${disabled?'opacity-40 pointer-events-none cursor-not-allowed':''}${active&&!disabled?'bg-white/15':'bg-white/5 hover:bg-white/10'}`;
 </script>

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -79,12 +79,6 @@ export const useLayerService = defineStore('layerService', () => {
         layers.remove(selection.asArray);
     }
 
-    function selectRange(anchorId, tailId) {
-        const anchorIndex = layers.indexOf(anchorId);
-        const tailIndex = layers.indexOf(tailId);
-        const slice = layers.order.slice(Math.min(anchorIndex, tailIndex), Math.max(anchorIndex, tailIndex) + 1);
-        selection.set(slice, anchorId, tailId);
-    }
 
     function reorderGroup(selIds, targetId, placeBelow = true) {
         layers.reorder(selIds, targetId, placeBelow);
@@ -93,51 +87,6 @@ export const useLayerService = defineStore('layerService', () => {
         selection.set(selIds, newAnchorId, newAnchorId);
     }
 
-    // Pixel operations
-    function addPixelsToSelection(pixels) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
-        const layer = layers.get(id);
-        if (layer) layer.addPixels(pixels);
-    }
-
-    function removePixelsFromSelection(pixels) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
-        const layer = layers.get(id);
-        if (layer) layer.removePixels(pixels);
-    }
-
-    function togglePointInSelection(x, y) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
-        const layer = layers.get(id);
-        if (layer) layer.togglePixel(x, y);
-    }
-
-    function removePixelsFromSelected(pixels) {
-        if (!pixels || !pixels.length) return;
-        forEachSelected(layer => {
-            const pixelsToRemove = [];
-            for (const [x, y] of pixels) {
-                if (layer.has(x, y)) pixelsToRemove.push([x, y]);
-            }
-            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
-        });
-    }
-
-    function removePixelsFromAll(pixels) {
-        if (!pixels || !pixels.length) return;
-        // Remove only if layer actually has the pixel to keep reactivity minimal
-        for (const id of layers.order) {
-            const layer = layers.layersById[id];
-            const pixelsToRemove = [];
-            for (const [x, y] of pixels) {
-                if (layer.has(x, y)) pixelsToRemove.push([x, y]);
-            }
-            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
-        }
-    }
 
     // Complex ops
     function mergeSelected() {
@@ -316,12 +265,7 @@ export const useLayerService = defineStore('layerService', () => {
         setColorForSelectedU32,
         setVisibilityForSelected,
         deleteSelected,
-        selectRange,
         reorderGroup,
-        addPixelsToSelection,
-        removePixelsFromSelection,
-        togglePointInSelection,
-        removePixelsFromSelected,
         mergeSelected,
         copySelected,
         selectionPath,
@@ -330,7 +274,6 @@ export const useLayerService = defineStore('layerService', () => {
         visibleOf,
         pixelCountOf,
         topVisibleLayerIdAt,
-        removePixelsFromAll,
         removeEmptyLayers,
         splitSelectedLayer,
         selectByPixelCount

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -1,0 +1,216 @@
+import { defineStore } from 'pinia';
+import { useStageService } from './stage';
+import { useToolStore } from '../stores/tool';
+import { useSelectionStore } from '../stores/selection';
+import { useLayerStore } from '../stores/layers';
+import { useOutputStore } from '../stores/output';
+import { coordsToKey, clamp } from '../utils';
+import { useStageStore } from '../stores/stage';
+
+export const usePixelService = defineStore('pixelService', () => {
+    const stage = useStageService();
+    const toolStore = useToolStore();
+    const selection = useSelectionStore();
+    const layers = useLayerStore();
+    const output = useOutputStore();
+    const stageStore = useStageStore();
+
+    function toolStart(event) {
+        if (event.button !== 0) return;
+        const pixel = stage.clientToPixel(event);
+        if (!pixel) return;
+
+        output.setRollbackPoint();
+
+        toolStore.state.status = toolStore.toolShape;
+        toolStore.state.startPoint = { x: event.clientX, y: event.clientY };
+        toolStore.state.isDragging = false;
+
+        try {
+            event.target.setPointerCapture?.(event.pointerId);
+            toolStore.state.pointerId = event.pointerId;
+        } catch {}
+
+        if (toolStore.state.status === 'rect') {
+            toolStore.marquee.x = pixel.x;
+            toolStore.marquee.y = pixel.y;
+            toolStore.marquee.w = 0;
+            toolStore.marquee.h = 0;
+            toolStore.marquee.visible = true;
+        } else if (toolStore.state.status === 'stroke') {
+            toolStore.lastPoint = pixel;
+            toolStore.visited.clear();
+            toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
+
+            if (toolStore.isGlobalErase) {
+                if (selection.exists) removePixelsFromSelected([[pixel.x, pixel.y]]);
+                else removePixelsFromAll([[pixel.x, pixel.y]]);
+            } else if (toolStore.isDraw || toolStore.isErase) {
+                if (toolStore.isErase) removePixelsFromSelection([[pixel.x, pixel.y]]);
+                else addPixelsToSelection([[pixel.x, pixel.y]]);
+            }
+        }
+    }
+
+    function toolMove(event) {
+        if (toolStore.state.status === 'idle') return;
+
+        if (!toolStore.state.isDragging && toolStore.state.startPoint) {
+            const dx = Math.abs(event.clientX - toolStore.state.startPoint.x);
+            const dy = Math.abs(event.clientY - toolStore.state.startPoint.y);
+            if (dx > 4 || dy > 4) toolStore.state.isDragging = true;
+        }
+        if (!toolStore.state.isDragging) return;
+
+        if (toolStore.state.status === 'rect') {
+            const left = Math.min(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
+            const top = Math.min(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
+            const right = Math.max(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
+            const bottom = Math.max(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
+            const minX = Math.floor(left / stageStore.canvas.scale),
+                  maxX = Math.floor((right - 1) / stageStore.canvas.scale);
+            const minY = Math.floor(top / stageStore.canvas.scale),
+                  maxY = Math.floor((bottom - 1) / stageStore.canvas.scale);
+            const minx = clamp(minX, 0, stageStore.canvas.width - 1),
+                  maxx = clamp(maxX, 0, stageStore.canvas.width - 1);
+            const miny = clamp(minY, 0, stageStore.canvas.height - 1),
+                  maxy = clamp(maxY, 0, stageStore.canvas.height - 1);
+            toolStore.marquee.x = minx;
+            toolStore.marquee.y = miny;
+            toolStore.marquee.w = (maxx >= minx) ? (maxx - minx + 1) : 0;
+            toolStore.marquee.h = (maxy >= miny) ? (maxy - miny + 1) : 0;
+        } else if (toolStore.state.status === 'stroke') {
+            const pixel = stage.clientToPixel(event);
+            if (!pixel || !toolStore.lastPoint) {
+                toolStore.lastPoint = pixel;
+                return;
+            }
+            const line = stage.bresenhamLine(toolStore.lastPoint.x, toolStore.lastPoint.y, pixel.x, pixel.y);
+            const delta = [];
+            for (const [x, y] of line) {
+                const k = coordsToKey(x, y);
+                if (!toolStore.visited.has(k)) {
+                    toolStore.visited.add(k);
+                    delta.push([x, y]);
+                }
+            }
+            if (delta.length) {
+                if (toolStore.isGlobalErase) {
+                    if (selection.exists) removePixelsFromSelected(delta);
+                    else removePixelsFromAll(delta);
+                } else if (toolStore.isDraw || toolStore.isErase) {
+                    if (toolStore.isErase) removePixelsFromSelection(delta);
+                    else addPixelsToSelection(delta);
+                }
+            }
+            toolStore.lastPoint = pixel;
+        }
+    }
+
+    function toolFinish(event) {
+        if (toolStore.state.status === 'idle') return;
+
+        if (toolStore.state.status === 'rect') {
+            const pixels = stage.getPixelsFromInteraction(event);
+            if (pixels.length > 0) {
+                if (toolStore.isGlobalErase) {
+                    if (selection.exists) removePixelsFromSelected(pixels);
+                    else removePixelsFromAll(pixels);
+                } else if (toolStore.isDraw || toolStore.isErase) {
+                    if (toolStore.isErase) removePixelsFromSelection(pixels);
+                    else addPixelsToSelection(pixels);
+                }
+            }
+        }
+
+        try {
+            event.target?.releasePointerCapture?.(toolStore.state.pointerId);
+        } catch {}
+
+        output.commit();
+        reset();
+    }
+
+    function cancel() {
+        if (toolStore.state.status === 'idle') return;
+        output.rollbackPending();
+        reset();
+    }
+
+    function reset() {
+        toolStore.state.status = 'idle';
+        toolStore.state.pointerId = null;
+        toolStore.state.startPoint = null;
+        toolStore.state.isDragging = false;
+        toolStore.state.selectionMode = null;
+        toolStore.marquee.visible = false;
+        toolStore.lastPoint = null;
+        toolStore.visited.clear();
+        toolStore.addOverlayLayerIds.clear();
+        toolStore.removeOverlayLayerIds.clear();
+        toolStore.initialSelectionOnDrag.clear();
+    }
+
+    function forEachSelected(fn) {
+        for (const id of selection.asArray) {
+            const layer = layers.layersById[id];
+            if (layer) fn(layer, id);
+        }
+    }
+
+    function addPixelsToSelection(pixels) {
+        if (selection.size !== 1) return;
+        const id = selection.asArray[0];
+        const layer = layers.layersById[id];
+        if (layer) layer.addPixels(pixels);
+    }
+
+    function removePixelsFromSelection(pixels) {
+        if (selection.size !== 1) return;
+        const id = selection.asArray[0];
+        const layer = layers.layersById[id];
+        if (layer) layer.removePixels(pixels);
+    }
+
+    function togglePointInSelection(x, y) {
+        if (selection.size !== 1) return;
+        const id = selection.asArray[0];
+        const layer = layers.layersById[id];
+        if (layer) layer.togglePixel(x, y);
+    }
+
+    function removePixelsFromSelected(pixels) {
+        if (!pixels || !pixels.length) return;
+        forEachSelected(layer => {
+            const pixelsToRemove = [];
+            for (const [x, y] of pixels) {
+                if (layer.has(x, y)) pixelsToRemove.push([x, y]);
+            }
+            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
+        });
+    }
+
+    function removePixelsFromAll(pixels) {
+        if (!pixels || !pixels.length) return;
+        for (const id of layers.order) {
+            const layer = layers.layersById[id];
+            const pixelsToRemove = [];
+            for (const [x, y] of pixels) {
+                if (layer.has(x, y)) pixelsToRemove.push([x, y]);
+            }
+            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
+        }
+    }
+
+    return {
+        toolStart,
+        toolMove,
+        toolFinish,
+        cancel,
+        addPixelsToSelection,
+        removePixelsFromSelection,
+        togglePointInSelection,
+        removePixelsFromSelected,
+        removePixelsFromAll
+    };
+});

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -1,0 +1,225 @@
+import { defineStore } from 'pinia';
+import { useStageService } from './stage';
+import { useToolStore } from '../stores/tool';
+import { useSelectionStore } from '../stores/selection';
+import { useLayerService } from './layers';
+import { useOutputStore } from '../stores/output';
+import { coordsToKey, clamp } from '../utils';
+import { useStageStore } from '../stores/stage';
+
+export const useSelectService = defineStore('selectService', () => {
+    const stage = useStageService();
+    const toolStore = useToolStore();
+    const selection = useSelectionStore();
+    const layerSvc = useLayerService();
+    const output = useOutputStore();
+    const stageStore = useStageStore();
+
+    function toolStart(event) {
+        if (event.button !== 0) return;
+        const pixel = stage.clientToPixel(event);
+        if (!pixel) return;
+
+        const startId = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
+        toolStore.initialSelectionOnDrag = new Set(selection.asArray);
+        toolStore.state.selectionMode = (event.shiftKey && selection.has(startId)) ? 'remove' : 'add';
+
+        output.setRollbackPoint();
+
+        toolStore.state.status = toolStore.toolShape;
+        toolStore.state.startPoint = { x: event.clientX, y: event.clientY };
+        toolStore.state.isDragging = false;
+
+        try {
+            event.target.setPointerCapture?.(event.pointerId);
+            toolStore.state.pointerId = event.pointerId;
+        } catch {}
+
+        if (toolStore.state.status === 'rect') {
+            toolStore.marquee.x = pixel.x;
+            toolStore.marquee.y = pixel.y;
+            toolStore.marquee.w = 0;
+            toolStore.marquee.h = 0;
+            toolStore.marquee.visible = true;
+        } else if (toolStore.state.status === 'stroke') {
+            toolStore.lastPoint = pixel;
+            toolStore.visited.clear();
+            toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
+
+            const id = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
+            if (id !== null) {
+                if (toolStore.state.selectionMode === 'add') {
+                    if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
+                } else {
+                    if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
+                }
+            }
+        }
+    }
+
+    function toolMove(event) {
+        if (toolStore.state.status === 'idle') return;
+
+        if (!toolStore.state.isDragging && toolStore.state.startPoint) {
+            const dx = Math.abs(event.clientX - toolStore.state.startPoint.x);
+            const dy = Math.abs(event.clientY - toolStore.state.startPoint.y);
+            if (dx > 4 || dy > 4) toolStore.state.isDragging = true;
+        }
+        if (!toolStore.state.isDragging) return;
+
+        if (toolStore.state.status === 'rect') {
+            const left = Math.min(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
+            const top = Math.min(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
+            const right = Math.max(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
+            const bottom = Math.max(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
+            const minX = Math.floor(left / stageStore.canvas.scale),
+                  maxX = Math.floor((right - 1) / stageStore.canvas.scale);
+            const minY = Math.floor(top / stageStore.canvas.scale),
+                  maxY = Math.floor((bottom - 1) / stageStore.canvas.scale);
+            const minx = clamp(minX, 0, stageStore.canvas.width - 1),
+                  maxx = clamp(maxX, 0, stageStore.canvas.width - 1);
+            const miny = clamp(minY, 0, stageStore.canvas.height - 1),
+                  maxy = clamp(maxY, 0, stageStore.canvas.height - 1);
+            toolStore.marquee.x = minx;
+            toolStore.marquee.y = miny;
+            toolStore.marquee.w = (maxx >= minx) ? (maxx - minx + 1) : 0;
+            toolStore.marquee.h = (maxy >= miny) ? (maxy - miny + 1) : 0;
+
+            const pixels = [];
+            for (let yy = toolStore.marquee.y; yy < toolStore.marquee.y + toolStore.marquee.h; yy++) {
+                for (let xx = toolStore.marquee.x; xx < toolStore.marquee.x + toolStore.marquee.w; xx++) {
+                    pixels.push([xx, yy]);
+                }
+            }
+            const intersectedIds = new Set();
+            if (pixels.length > 0) {
+                for (const [x, y] of pixels) {
+                    const id = layerSvc.topVisibleLayerIdAt(x, y);
+                    if (id !== null) intersectedIds.add(id);
+                }
+            }
+            toolStore.addOverlayLayerIds.clear();
+            toolStore.removeOverlayLayerIds.clear();
+            if (toolStore.state.selectionMode === 'add') {
+                for (const id of intersectedIds) {
+                    if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
+                }
+            } else {
+                for (const id of intersectedIds) {
+                    if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
+                }
+            }
+        } else if (toolStore.state.status === 'stroke') {
+            const pixel = stage.clientToPixel(event);
+            if (!pixel || !toolStore.lastPoint) {
+                toolStore.lastPoint = pixel;
+                return;
+            }
+            const line = stage.bresenhamLine(toolStore.lastPoint.x, toolStore.lastPoint.y, pixel.x, pixel.y);
+            const delta = [];
+            for (const [x, y] of line) {
+                const k = coordsToKey(x, y);
+                if (!toolStore.visited.has(k)) {
+                    toolStore.visited.add(k);
+                    delta.push([x, y]);
+                }
+            }
+            if (delta.length) {
+                const intersectedIds = new Set();
+                for (const [x, y] of delta) {
+                    const id = layerSvc.topVisibleLayerIdAt(x, y);
+                    if (id !== null) intersectedIds.add(id);
+                }
+                if (toolStore.state.selectionMode === 'add') {
+                    for (const id of intersectedIds) {
+                        if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
+                    }
+                } else {
+                    for (const id of intersectedIds) {
+                        if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
+                    }
+                }
+            }
+            toolStore.lastPoint = pixel;
+        }
+    }
+
+    function toolFinish(event) {
+        if (toolStore.state.status === 'idle') return;
+
+        const pixel = stage.clientToPixel(event);
+        if (!toolStore.state.isDragging && pixel) {
+            const id = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
+            if (event.shiftKey) {
+                selection.toggle(id);
+            } else {
+                selection.selectOnly(id);
+            }
+            if (id !== null) {
+                selection.setScrollRule({ type: 'follow', target: id });
+            }
+        } else {
+            const pixels = stage.getPixelsFromInteraction(event);
+            if (pixels.length > 0) {
+                const intersectedIds = new Set();
+                for (const [x, y] of pixels) {
+                    const id = layerSvc.topVisibleLayerIdAt(x, y);
+                    if (id !== null) intersectedIds.add(id);
+                }
+                const currentSelection = new Set(selection.asArray);
+                if (toolStore.state.selectionMode === 'add') {
+                    intersectedIds.forEach(id => currentSelection.add(id));
+                } else {
+                    intersectedIds.forEach(id => currentSelection.delete(id));
+                }
+                if (event.shiftKey) {
+                    selection.set([...currentSelection], selection.anchorId, selection.tailId);
+                } else {
+                    selection.set([...currentSelection], null, null);
+                }
+            } else if (!event.shiftKey) {
+                selection.clear();
+            }
+        }
+
+        try {
+            event.target?.releasePointerCapture?.(toolStore.state.pointerId);
+        } catch {}
+
+        output.commit();
+        reset();
+    }
+
+    function cancel() {
+        if (toolStore.state.status === 'idle') return;
+        output.rollbackPending();
+        reset();
+    }
+
+    function reset() {
+        toolStore.state.status = 'idle';
+        toolStore.state.pointerId = null;
+        toolStore.state.startPoint = null;
+        toolStore.state.isDragging = false;
+        toolStore.state.selectionMode = null;
+        toolStore.marquee.visible = false;
+        toolStore.lastPoint = null;
+        toolStore.visited.clear();
+        stage.hoverLayerId.value = null;
+        toolStore.addOverlayLayerIds.clear();
+        toolStore.removeOverlayLayerIds.clear();
+        toolStore.initialSelectionOnDrag.clear();
+    }
+
+    function selectRange(anchorId, tailId) {
+        const anchorIndex = layerSvc.idsTopToBottom.indexOf(anchorId);
+        const tailIndex = layerSvc.idsTopToBottom.indexOf(tailId);
+        const slice = layerSvc.idsTopToBottom.slice(
+            Math.min(anchorIndex, tailIndex),
+            Math.max(anchorIndex, tailIndex) + 1
+        );
+        selection.set(slice, anchorId, tailId);
+    }
+
+    return { toolStart, toolMove, toolFinish, cancel, selectRange };
+});

--- a/src/stores/stage.js
+++ b/src/stores/stage.js
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia';
-import { useSelectionStore } from './selection';
 
 export const useStageStore = defineStore('stage', {
     state: () => ({
@@ -13,10 +12,6 @@ export const useStageStore = defineStore('stage', {
         display: 'result', // 'result' | 'original'
         imageSrc: '',
         pixelInfo: '-',
-        tool: 'draw', // 'draw'|'erase'|'select'|'globalErase'
-        toolShape: 'stroke', // 'stroke' | 'rect'
-        ctrlHeld: false,
-        shiftHeld: false,
     }),
     getters: {
         // Canvas dimensions
@@ -25,37 +20,6 @@ export const useStageStore = defineStore('stage', {
         viewBox: (state) => `0 0 ${state.canvas.width} ${state.canvas.height}`,
         // UI labels
         toggleLabel: (state) => state.display === 'original' ? '결과' : '원본',
-        // Tool state
-        isStroke: (state) => state.toolShape === 'stroke',
-        isRect: (state) => state.toolShape === 'rect',
-        // Mode state
-        currentMode() {
-            const selection = useSelectionStore();
-            return selection.size === 1 ? 'single' : 'multi';
-        },
-        effectiveMode() {
-            if (this.currentMode === 'single' && this.shiftHeld) {
-                return 'multi';
-            }
-            return this.currentMode;
-        },
-        // Effective tool state (considering modifiers)
-        effectiveTool() {
-            if (this.shiftHeld) return 'select';
-            if (this.ctrlHeld) {
-                if (this.currentMode === 'single' && (this.tool === 'draw' || this.tool === 'erase')) {
-                    return this.tool === 'draw' ? 'erase' : 'draw';
-                }
-                if (this.currentMode === 'multi' && (this.tool === 'select' || this.tool === 'globalErase')) {
-                    return this.tool === 'select' ? 'globalErase' : 'select';
-                }
-            }
-            return this.tool;
-        },
-        isDraw() { return this.effectiveTool === 'draw'; },
-        isErase() { return this.effectiveTool === 'erase'; },
-        isSelect() { return this.effectiveTool === 'select'; },
-        isGlobalErase() { return this.effectiveTool === 'globalErase'; },
     },
     actions: {
         setCanvasPosition(x, y) {
@@ -77,18 +41,6 @@ export const useStageStore = defineStore('stage', {
         },
         updatePixelInfo(text) {
             this.pixelInfo = text;
-        },
-        setTool(newTool) {
-            this.tool = newTool;
-        },
-        setToolShape(shape) {
-            this.toolShape = (shape === 'rect') ? 'rect' : 'stroke';
-        },
-        setCtrlHeld(isHeld) {
-            this.ctrlHeld = !!isHeld;
-        },
-        setShiftHeld(isHeld) {
-            this.shiftHeld = !!isHeld;
         },
     }
 });

--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -1,0 +1,69 @@
+import { defineStore } from 'pinia';
+import { useSelectionStore } from './selection';
+
+export const useToolStore = defineStore('tool', {
+    state: () => ({
+        tool: 'draw', // 'draw' | 'erase' | 'select' | 'globalErase'
+        toolShape: 'stroke', // 'stroke' | 'rect'
+        ctrlHeld: false,
+        shiftHeld: false,
+        // pointer interaction state
+        state: {
+            status: 'idle', // 'idle' | 'stroke' | 'rect'
+            startPoint: null,
+            pointerId: null,
+            isDragging: false,
+            selectionMode: null, // 'add' | 'remove'
+        },
+        marquee: { visible: false, x: 0, y: 0, w: 0, h: 0 },
+        initialSelectionOnDrag: new Set(),
+        addOverlayLayerIds: new Set(),
+        removeOverlayLayerIds: new Set(),
+        lastPoint: null,
+        visited: new Set(),
+    }),
+    getters: {
+        currentMode() {
+            const selection = useSelectionStore();
+            return selection.size === 1 ? 'single' : 'multi';
+        },
+        effectiveMode() {
+            if (this.currentMode === 'single' && this.shiftHeld) {
+                return 'multi';
+            }
+            return this.currentMode;
+        },
+        effectiveTool() {
+            if (this.shiftHeld) return 'select';
+            if (this.ctrlHeld) {
+                if (this.currentMode === 'single' && (this.tool === 'draw' || this.tool === 'erase')) {
+                    return this.tool === 'draw' ? 'erase' : 'draw';
+                }
+                if (this.currentMode === 'multi' && (this.tool === 'select' || this.tool === 'globalErase')) {
+                    return this.tool === 'select' ? 'globalErase' : 'select';
+                }
+            }
+            return this.tool;
+        },
+        isDraw() { return this.effectiveTool === 'draw'; },
+        isErase() { return this.effectiveTool === 'erase'; },
+        isSelect() { return this.effectiveTool === 'select'; },
+        isGlobalErase() { return this.effectiveTool === 'globalErase'; },
+        isStroke: (state) => state.toolShape === 'stroke',
+        isRect: (state) => state.toolShape === 'rect',
+    },
+    actions: {
+        setTool(newTool) {
+            this.tool = newTool;
+        },
+        setToolShape(shape) {
+            this.toolShape = (shape === 'rect') ? 'rect' : 'stroke';
+        },
+        setCtrlHeld(isHeld) {
+            this.ctrlHeld = !!isHeld;
+        },
+        setShiftHeld(isHeld) {
+            this.shiftHeld = !!isHeld;
+        },
+    }
+});


### PR DESCRIPTION
## Summary
- rename pixelTool/selectTool services to pixel/select with toolStart/move/finish handlers
- move pixel manipulation helpers from layer service into pixel service
- expose selectRange via new select service and update components to use it
- rename move/finish handlers to toolMove/toolFinish
- shift marquee and drag state from stage service into tool store and update stage component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a811decf34832c94dce03916532094