### PR TITLE
Refactor interaction state and keyboard handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
       <section class="rounded-xl border border-white/10 bg-sky-950/30 flex flex-col min-h-0 overflow-hidden">
         <h2 class="m-0 px-3 py-2 text-xs uppercase tracking-wide text-slate-300/90 border-b border-white/10">Display</h2>
         <stage-toolbar class="border-b border-white/10"></stage-toolbar>
-        <Stage class="flex-1 min-h-0"></Stage>
+        <Stage ref="stageComponent" class="flex-1 min-h-0"></Stage>
         <stage-info class="border-t border-white/10"></stage-info>
       </section>
 
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-import { onMounted, nextTick } from 'vue';
+import { onMounted, nextTick, ref } from 'vue';
 import { useInputStore } from './stores/input';
 import { useStageStore } from './stores/stage';
 import { useStageService } from './services/stage';
@@ -44,6 +44,7 @@ const selection = useSelectionStore();
 const layerSvc = useLayerService();
 const selectSvc = useSelectService();
 const output = useOutputStore();
+const stageComponent = ref(null);
 
 // General key handler
 function onKeydown(event) {
@@ -58,9 +59,9 @@ function onKeydown(event) {
   switch (event.key) {
     case 'Control':
     case 'Meta':
-      return stageService.ctrlKeyDown();
+      return stageComponent.value?.ctrlKeyDown();
     case 'Shift':
-      return stageService.shiftKeyDown();
+      return stageComponent.value?.shiftKeyDown();
     case 'ArrowUp':
       event.preventDefault();
       if (!layers.exists) return;
@@ -140,9 +141,9 @@ function onKeyup(event) {
   switch (event.key) {
     case 'Control':
     case 'Meta':
-      return stageService.ctrlKeyUp();
+      return stageComponent.value?.ctrlKeyUp();
     case 'Shift':
-      return stageService.shiftKeyUp();
+      return stageComponent.value?.shiftKeyUp();
   }
 }
 
@@ -179,8 +180,8 @@ onMounted(async () => {
   window.addEventListener('keydown', onKeydown);
   window.addEventListener('keyup', onKeyup);
   window.addEventListener('blur', () => {
-    stageService.ctrlKeyUp();
-    stageService.shiftKeyUp();
+    stageComponent.value?.ctrlKeyUp();
+    stageComponent.value?.shiftKeyUp();
   });
 });
 </script>

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -4,8 +4,7 @@ import { useToolStore } from '../stores/tool';
 import { useSelectionStore } from '../stores/selection';
 import { useLayerService } from './layers';
 import { useOutputStore } from '../stores/output';
-import { coordsToKey, clamp } from '../utils';
-import { useStageStore } from '../stores/stage';
+import { coordsToKey } from '../utils';
 
 export const useSelectService = defineStore('selectService', () => {
     const stage = useStageService();
@@ -13,7 +12,6 @@ export const useSelectService = defineStore('selectService', () => {
     const selection = useSelectionStore();
     const layerSvc = useLayerService();
     const output = useOutputStore();
-    const stageStore = useStageStore();
 
     function toolStart(event) {
         if (event.button !== 0) return;
@@ -21,14 +19,13 @@ export const useSelectService = defineStore('selectService', () => {
         if (!pixel) return;
 
         const startId = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
-        toolStore.initialSelectionOnDrag = new Set(selection.asArray);
+        toolStore.selectionBeforeDrag = new Set(selection.asArray);
         toolStore.state.selectionMode = (event.shiftKey && selection.has(startId)) ? 'remove' : 'add';
 
         output.setRollbackPoint();
 
         toolStore.state.status = toolStore.toolShape;
         toolStore.state.startPoint = { x: event.clientX, y: event.clientY };
-        toolStore.state.isDragging = false;
 
         try {
             event.target.setPointerCapture?.(event.pointerId);
@@ -36,22 +33,18 @@ export const useSelectService = defineStore('selectService', () => {
         } catch {}
 
         if (toolStore.state.status === 'rect') {
-            toolStore.marquee.x = pixel.x;
-            toolStore.marquee.y = pixel.y;
-            toolStore.marquee.w = 0;
-            toolStore.marquee.h = 0;
-            toolStore.marquee.visible = true;
+            toolStore.state.lastPoint = { x: event.clientX, y: event.clientY };
         } else if (toolStore.state.status === 'stroke') {
-            toolStore.lastPoint = pixel;
+            toolStore.state.lastPoint = pixel;
             toolStore.visited.clear();
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
 
             const id = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
             if (id !== null) {
                 if (toolStore.state.selectionMode === 'add') {
-                    if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
+                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else {
-                    if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
+                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             }
         }
@@ -60,87 +53,47 @@ export const useSelectService = defineStore('selectService', () => {
     function toolMove(event) {
         if (toolStore.state.status === 'idle') return;
 
-        if (!toolStore.state.isDragging && toolStore.state.startPoint) {
-            const dx = Math.abs(event.clientX - toolStore.state.startPoint.x);
-            const dy = Math.abs(event.clientY - toolStore.state.startPoint.y);
-            if (dx > 4 || dy > 4) toolStore.state.isDragging = true;
-        }
-        if (!toolStore.state.isDragging) return;
-
         if (toolStore.state.status === 'rect') {
-            const left = Math.min(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
-            const top = Math.min(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
-            const right = Math.max(toolStore.state.startPoint.x, event.clientX) - stageStore.canvas.x;
-            const bottom = Math.max(toolStore.state.startPoint.y, event.clientY) - stageStore.canvas.y;
-            const minX = Math.floor(left / stageStore.canvas.scale),
-                  maxX = Math.floor((right - 1) / stageStore.canvas.scale);
-            const minY = Math.floor(top / stageStore.canvas.scale),
-                  maxY = Math.floor((bottom - 1) / stageStore.canvas.scale);
-            const minx = clamp(minX, 0, stageStore.canvas.width - 1),
-                  maxx = clamp(maxX, 0, stageStore.canvas.width - 1);
-            const miny = clamp(minY, 0, stageStore.canvas.height - 1),
-                  maxy = clamp(maxY, 0, stageStore.canvas.height - 1);
-            toolStore.marquee.x = minx;
-            toolStore.marquee.y = miny;
-            toolStore.marquee.w = (maxx >= minx) ? (maxx - minx + 1) : 0;
-            toolStore.marquee.h = (maxy >= miny) ? (maxy - miny + 1) : 0;
-
-            const pixels = [];
-            for (let yy = toolStore.marquee.y; yy < toolStore.marquee.y + toolStore.marquee.h; yy++) {
-                for (let xx = toolStore.marquee.x; xx < toolStore.marquee.x + toolStore.marquee.w; xx++) {
-                    pixels.push([xx, yy]);
-                }
-            }
+            toolStore.state.lastPoint = { x: event.clientX, y: event.clientY };
+            const { x, y, w, h } = toolStore.marquee;
             const intersectedIds = new Set();
-            if (pixels.length > 0) {
-                for (const [x, y] of pixels) {
-                    const id = layerSvc.topVisibleLayerIdAt(x, y);
+            for (let yy = y; yy < y + h; yy++) {
+                for (let xx = x; xx < x + w; xx++) {
+                    const id = layerSvc.topVisibleLayerIdAt(xx, yy);
                     if (id !== null) intersectedIds.add(id);
                 }
             }
-            toolStore.addOverlayLayerIds.clear();
-            toolStore.removeOverlayLayerIds.clear();
+            toolStore.selectOverlayLayerIds.clear();
             if (toolStore.state.selectionMode === 'add') {
                 for (const id of intersectedIds) {
-                    if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
+                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             } else {
                 for (const id of intersectedIds) {
-                    if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
+                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             }
         } else if (toolStore.state.status === 'stroke') {
             const pixel = stage.clientToPixel(event);
-            if (!pixel || !toolStore.lastPoint) {
-                toolStore.lastPoint = pixel;
+            if (!pixel) {
+                toolStore.state.lastPoint = pixel;
                 return;
             }
-            const line = stage.bresenhamLine(toolStore.lastPoint.x, toolStore.lastPoint.y, pixel.x, pixel.y);
-            const delta = [];
-            for (const [x, y] of line) {
-                const k = coordsToKey(x, y);
-                if (!toolStore.visited.has(k)) {
-                    toolStore.visited.add(k);
-                    delta.push([x, y]);
-                }
+            const k = coordsToKey(pixel.x, pixel.y);
+            if (toolStore.visited.has(k)) {
+                toolStore.state.lastPoint = pixel;
+                return;
             }
-            if (delta.length) {
-                const intersectedIds = new Set();
-                for (const [x, y] of delta) {
-                    const id = layerSvc.topVisibleLayerIdAt(x, y);
-                    if (id !== null) intersectedIds.add(id);
-                }
+            toolStore.visited.add(k);
+            const id = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
+            if (id !== null) {
                 if (toolStore.state.selectionMode === 'add') {
-                    for (const id of intersectedIds) {
-                        if (!toolStore.initialSelectionOnDrag.has(id)) toolStore.addOverlayLayerIds.add(id);
-                    }
+                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else {
-                    for (const id of intersectedIds) {
-                        if (toolStore.initialSelectionOnDrag.has(id)) toolStore.removeOverlayLayerIds.add(id);
-                    }
+                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             }
-            toolStore.lastPoint = pixel;
+            toolStore.state.lastPoint = pixel;
         }
     }
 
@@ -148,7 +101,11 @@ export const useSelectService = defineStore('selectService', () => {
         if (toolStore.state.status === 'idle') return;
 
         const pixel = stage.clientToPixel(event);
-        if (!toolStore.state.isDragging && pixel) {
+        const start = toolStore.state.startPoint;
+        const dx = start ? Math.abs(event.clientX - start.x) : 0;
+        const dy = start ? Math.abs(event.clientY - start.y) : 0;
+        const isClick = dx <= 4 && dy <= 4;
+        if (isClick && pixel) {
             const id = layerSvc.topVisibleLayerIdAt(pixel.x, pixel.y);
             if (event.shiftKey) {
                 selection.toggle(id);
@@ -200,15 +157,12 @@ export const useSelectService = defineStore('selectService', () => {
         toolStore.state.status = 'idle';
         toolStore.state.pointerId = null;
         toolStore.state.startPoint = null;
-        toolStore.state.isDragging = false;
+        toolStore.state.lastPoint = null;
         toolStore.state.selectionMode = null;
-        toolStore.marquee.visible = false;
-        toolStore.lastPoint = null;
         toolStore.visited.clear();
-        stage.hoverLayerId.value = null;
-        toolStore.addOverlayLayerIds.clear();
-        toolStore.removeOverlayLayerIds.clear();
-        toolStore.initialSelectionOnDrag.clear();
+        toolStore.hoverLayerId = null;
+        toolStore.selectOverlayLayerIds.clear();
+        toolStore.selectionBeforeDrag.clear();
     }
 
     function selectRange(anchorId, tailId) {


### PR DESCRIPTION
## Summary
- Track pointer paths without Bresenham interpolation and update pixels only where the cursor moves
- Drive rectangular selection overlays from the tool store's `marquee` getter
- Drop `isDragging` flag and rely on `status` to control overlays and hover behavior

## Testing
- ❌ `npm test` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a8267ca330832c9c28abc5ed8ea45f