### PR TITLE
feat: expand layer store with CRUD helpers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,7 @@ function onKeydown(event) {
       output.setRollbackPoint();
       const belowId = layers.belowId(layers.lowermostIdOf(selection.asArray));
       layerSvc.deleteSelected();
-      const newSelect = layers.layersById[belowId] ? belowId : layers.lowermostId;
+      const newSelect = layers.nameOf(belowId) != null ? belowId : layers.lowermostId;
       selection.selectOnly(newSelect);
       selection.setScrollRule({ type: "follow", target: newSelect });
       output.commit();
@@ -162,7 +162,7 @@ onMounted(async () => {
   if (autoSegments.length) {
     for (let i = 0; i < autoSegments.length; i++) {
       const segment = autoSegments[i];
-      layers.create({
+      layers.createLayer({
         name: `Auto ${i+1}`,
         colorU32: segment.colorU32,
         visible: true,
@@ -170,8 +170,8 @@ onMounted(async () => {
       });
     }
   } else {
-    layers.create({});
-    layers.create({});
+    layers.createLayer({});
+    layers.createLayer({});
   }
   selection.selectOnly(layers.idsTopToBottom[0]);
 

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="stageStore.display!=='result'" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="stageStore.canvas.width" :height="stageStore.canvas.height" :fill="patternUrl"/>
         <g>
-          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibleOf(id)?'visible':'hidden'"></path>
+          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -150,7 +150,7 @@ function deleteLayer(id) {
     const targets = selection.has(id) ? selection.asArray : [id];
     const belowId = layers.belowId(layers.lowermostIdOf(targets));
     layers.deleteLayers(targets);
-    const newSelectId = layers.nameOf(belowId) != null ? belowId : layers.lowermostId;
+    const newSelectId = layers.get(belowId) ? belowId : layers.lowermostId;
     selection.selectOnly(newSelectId);
     if (newSelectId) {
         selection.setScrollRule({
@@ -254,7 +254,6 @@ function finishRename(id, event) {
     const element = document.querySelector(`.layer[data-id="${id}"] .nameText`);
     element.contentEditable = false;
     const oldName = layers.nameOf(id);
-    if (!oldName) return;
     const text = event.target.innerText.trim();
     editingId.value = null;
     if (text && text !== oldName) {
@@ -272,7 +271,6 @@ function finishRename(id, event) {
 
 function onNameKey(id, event) {
     const name = layers.nameOf(id);
-    if (name == null) return;
     if (event.key === 'Enter') {
         event.preventDefault();
         event.target.blur();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -5,7 +5,7 @@
       <div @click.stop="onThumbnailClick(id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 크기의 모든 레이어 선택">
         <svg :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
           <rect x="0" y="0" :width="stageStore.canvas.width" :height="stageStore.canvas.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(id)" :fill="rgbaCssU32(layers.colorOf(id))" :opacity="layers.visibleOf(id)?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          <path :d="layers.pathOf(id)" :fill="rgbaCssU32(layers.colorOf(id))" :opacity="layers.visibilityOf(id)?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
         </svg>
       </div>
       <!-- 색상 -->
@@ -15,14 +15,14 @@
       <!-- 이름/픽셀 -->
       <div class="min-w-0 flex-1">
         <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(id)" @keydown="onNameKey(id,$event)" @blur="finishRename(id,$event)">{{ layers.get(id)?.name }}</span>
+          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(id)" @keydown="onNameKey(id,$event)" @blur="finishRename(id,$event)">{{ layers.nameOf(id) }}</span>
         </div>
         <div class="text-xs text-slate-400">{{ layers.pixelCountOf(id) }} px</div>
       </div>
       <!-- 액션 -->
       <div class="flex gap-1 justify-end">
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(layers.get(id)?.visible?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
+          <img :src="(layers.visibilityOf(id)?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
           <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(id)" />
@@ -121,7 +121,7 @@ function onDrop(id, event) {
     const targetId = id;
     const rect = row.getBoundingClientRect();
     const placeBelow = (event.clientY - rect.top) > rect.height * 0.5;
-    layers.reorder(selection.asArray, targetId, placeBelow);
+    layers.reorderLayers(selection.asArray, targetId, placeBelow);
     output.commit();
 }
 
@@ -131,7 +131,7 @@ function onColorDown() {
 
 function onColorInput(id, event) {
     const colorU32 = hexToRgbaU32(event.target.value);
-    selection.has(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.get(id)?.setColorU32(colorU32);
+    selection.has(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.updateLayer(id, { colorU32 });
 }
 
 function onColorChange() {
@@ -140,8 +140,8 @@ function onColorChange() {
 
 function toggleVisibility(id) {
     output.setRollbackPoint();
-    if (selection.has(id)) layerSvc.setVisibilityForSelected(!(layers.get(id)?.visible));
-    else if (layers.get(id)) layers.get(id).visible = !layers.get(id).visible;
+    if (selection.has(id)) layerSvc.setVisibilityForSelected(!layers.visibilityOf(id));
+    else layers.toggleVisibility(id);
     output.commit();
 }
 
@@ -149,8 +149,8 @@ function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = selection.has(id) ? selection.asArray : [id];
     const belowId = layers.belowId(layers.lowermostIdOf(targets));
-    layers.remove(targets);
-    const newSelectId = layers.get(belowId) ? belowId : layers.lowermostId;
+    layers.deleteLayers(targets);
+    const newSelectId = layers.nameOf(belowId) != null ? belowId : layers.lowermostId;
     selection.selectOnly(newSelectId);
     if (newSelectId) {
         selection.setScrollRule({
@@ -253,15 +253,15 @@ function startRename(id) {
 function finishRename(id, event) {
     const element = document.querySelector(`.layer[data-id="${id}"] .nameText`);
     element.contentEditable = false;
-    const layer = layers.get(id);
-    if (!layer) return;
+    const oldName = layers.nameOf(id);
+    if (!oldName) return;
     const text = event.target.innerText.trim();
     editingId.value = null;
-    if (text && text !== layer.name) {
-        layer.name = text;
+    if (text && text !== oldName) {
+        layers.updateLayer(id, { name: text });
         output.commit();
     } else {
-        event.target.innerText = layer.name;
+        event.target.innerText = oldName;
         output.clearRollbackPoint();
     }
     selection.setScrollRule({
@@ -271,15 +271,15 @@ function finishRename(id, event) {
 }
 
 function onNameKey(id, event) {
-    const layer = layers.get(id);
-    if (!layer) return;
+    const name = layers.nameOf(id);
+    if (name == null) return;
     if (event.key === 'Enter') {
         event.preventDefault();
         event.target.blur();
     }
     if (event.key === 'Escape') {
         event.preventDefault();
-        event.target.innerText = layer.name;
+        event.target.innerText = name;
         event.target.blur();
     }
 }

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -25,9 +25,9 @@ const selection = useSelectionStore();
 const onAdd = () => {
     output.setRollbackPoint();
     const above = selection.size ? layers.uppermostIdOf(selection.asArray) : null;
-    const id = layers.create({});
+    const id = layers.createLayer({});
     if (above !== null) {
-        layers.reorder([id], above, false);
+        layers.reorderLayers([id], above, false);
     }
     selection.selectOnly(id);
     output.commit();

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -11,7 +11,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="stageStore.display==='result'" class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
         <g>
-          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibleOf(id)?'visible':'hidden'"></path>
+          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -21,7 +21,7 @@ const selection = useSelectionStore();
 const selectedAreaPixelCount = computed(() => {
     const pixelSet = new Set();
     for (const id of selection.asArray) {
-        const layer = layers.get(id);
+        const layer = layers.getLayer(id);
         if (!layer) continue;
         layer.forEachPixel((x, y) => pixelSet.add(coordsToKey(x, y)));
     }

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -119,44 +119,41 @@ export const usePixelService = defineStore('pixelService', () => {
     function addPixelsToSelection(pixels) {
         if (selection.size !== 1) return;
         const id = selection.asArray[0];
-        const layer = layers.layersById[id];
-        if (layer) layer.addPixels(pixels);
+        layers.addPixels(id, pixels);
     }
 
     function removePixelsFromSelection(pixels) {
         if (selection.size !== 1) return;
         const id = selection.asArray[0];
-        const layer = layers.layersById[id];
-        if (layer) layer.removePixels(pixels);
+        layers.removePixels(id, pixels);
     }
 
     function togglePointInSelection(x, y) {
         if (selection.size !== 1) return;
         const id = selection.asArray[0];
-        const layer = layers.layersById[id];
-        if (layer) layer.togglePixel(x, y);
+        layers.togglePixel(id, x, y);
     }
 
     function removePixelsFromSelected(pixels) {
         if (!pixels || !pixels.length) return;
-        layerSvc.forEachSelected(layer => {
+        layerSvc.forEachSelected((layer, id) => {
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (layer.has(x, y)) pixelsToRemove.push([x, y]);
             }
-            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
+            if (pixelsToRemove.length) layers.removePixels(id, pixelsToRemove);
         });
     }
 
     function removePixelsFromAll(pixels) {
         if (!pixels || !pixels.length) return;
         for (const id of layers.order) {
-            const layer = layers.layersById[id];
+            const layer = layers.getLayer(id);
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (layer.has(x, y)) pixelsToRemove.push([x, y]);
             }
-            if (pixelsToRemove.length) layer.removePixels(pixelsToRemove);
+            if (pixelsToRemove.length) layers.removePixels(id, pixelsToRemove);
         }
     }
 

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -21,7 +21,7 @@ export const useStageService = defineStore('stageService', () => {
         if (!toolStore.selectOverlayLayerIds.size) return '';
         const pixelUnionSet = new Set();
         for (const id of toolStore.selectOverlayLayerIds) {
-            layers.get(id)?.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y)));
+            layers.getLayer(id)?.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y)));
         }
         return pixelsToUnionPath(pixelUnionSet);
     });


### PR DESCRIPTION
## Summary
- add CRUD helpers (update, toggle visibility, pixel ops, delete, reorder) to layer store
- refactor services and components to use new layer helpers
- introduce `nameOf` getter and rename `visibleOf` to `visibilityOf`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a88e34a048832cb4033037e18fccc9