### PR TITLE
refactor selection store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,13 +66,13 @@ function onKeydown(event) {
       event.preventDefault();
       if (!layers.exists) return;
       if (shift && !ctrl) {
-        if (!selection.exists) return;
+        if (!selection.hasSelection) return;
         const newTail = layers.aboveId(selection.tailId) ?? layers.uppermostId;
         selectSvc.selectRange(selection.anchorId, newTail);
         selection.setScrollRule({ type: 'follow-up', target: newTail });
       } else if (!ctrl) {
         const nextId = layers.aboveId(selection.anchorId) ?? selection.anchorId;
-        selection.selectOnly(nextId);
+        selection.selectOne(nextId);
         selection.setScrollRule({ type: 'follow-up', target: nextId });
       }
       return;
@@ -80,25 +80,25 @@ function onKeydown(event) {
       event.preventDefault();
       if (!layers.exists) return;
       if (shift && !ctrl) {
-        if (!selection.exists) return;
+        if (!selection.hasSelection) return;
         const newTail = layers.belowId(selection.tailId) ?? layers.lowermostId;
         selectSvc.selectRange(selection.anchorId, newTail);
         selection.setScrollRule({ type: 'follow-down', target: newTail });
       } else if (!ctrl) {
         const nextId = layers.belowId(selection.anchorId) ?? selection.anchorId;
-        selection.selectOnly(nextId);
+        selection.selectOne(nextId);
         selection.setScrollRule({ type: 'follow-down', target: nextId });
       }
       return;
     case 'Delete':
     case 'Backspace':
       event.preventDefault();
-      if (!selection.exists) return;
+      if (!selection.hasSelection) return;
       output.setRollbackPoint();
-      const belowId = layers.belowId(layers.lowermostIdOf(selection.asArray));
+      const belowId = layers.belowId(layers.lowermostIdOf(selection.ids));
       layerSvc.deleteSelected();
       const newSelect = layers.layersById[belowId] ? belowId : layers.lowermostId;
-      selection.selectOnly(newSelect);
+      selection.selectOne(newSelect);
       selection.setScrollRule({ type: "follow", target: newSelect });
       output.commit();
       return;
@@ -126,7 +126,7 @@ function onKeydown(event) {
     if (key === 'a') {
       event.preventDefault();
       const anchor = layers.uppermostId, tail = layers.lowermostId;
-      selection.set(layers.order, anchor, tail);
+      selection.replace(layers.order, anchor, tail);
     } else if (key === 'z' && !shift) {
       event.preventDefault();
       output.undo();
@@ -173,7 +173,7 @@ onMounted(async () => {
     layers.create({});
     layers.create({});
   }
-  selection.selectOnly(layers.idsTopToBottom[0]);
+  selection.selectOne(layers.idsTopToBottom[0]);
 
   nextTick(() => stageService.recalcScale(document.getElementById('stage')?.parentElement?.parentElement || document.body));
 

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flex items-center gap-2 p-2 flex-wrap">
     <button @click="onAdd" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">+ 레이어</button>
-    <button @click="onMerge" :disabled="selection.size < 2" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">병합</button>
-    <button @click="onCopy" :disabled="!selection.exists" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">복사</button>
+    <button @click="onMerge" :disabled="selection.count < 2" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">병합</button>
+    <button @click="onCopy" :disabled="!selection.hasSelection" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">복사</button>
     <button @click="onRemoveEmpty" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">Remove empty</button>
-    <button @click="onSplit" :disabled="selection.size !== 1" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">Split divided</button>
+    <button @click="onSplit" :disabled="selection.count !== 1" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">Split divided</button>
     <div class="flex-1"></div>
     <button @click="undo" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">↶ Undo</button>
     <button @click="redo" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">Redo ↷</button>
@@ -24,24 +24,24 @@ const selection = useSelectionStore();
 
 const onAdd = () => {
     output.setRollbackPoint();
-    const above = selection.size ? layers.uppermostIdOf(selection.asArray) : null;
+    const above = selection.count ? layers.uppermostIdOf(selection.ids) : null;
     const id = layers.create({});
     if (above !== null) {
         layers.reorder([id], above, false);
     }
-    selection.selectOnly(id);
+    selection.selectOne(id);
     output.commit();
 };
 const onMerge = () => {
     output.setRollbackPoint();
     const id = layerSvc.mergeSelected();
-    selection.selectOnly(id);
+    selection.selectOne(id);
     output.commit();
 };
 const onCopy = () => {
     output.setRollbackPoint();
     const ids = layerSvc.copySelected();
-    selection.set(ids, ids?.[0] ?? null, null);
+    selection.replace(ids, ids?.[0] ?? null, null);
     output.commit();
 };
 const onRemoveEmpty = () => {

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -25,7 +25,7 @@
       <svg class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
           <!-- 1. 기본 선택 윤곽 (하늘색) -->
           <path id="selectionOutline"
-                v-if="selection.exists"
+                v-if="selection.hasSelection"
                 :d="selectionPath"
                 :fill="OVERLAY_CONFIG.SELECTED.FILL_COLOR"
                 :stroke="OVERLAY_CONFIG.SELECTED.STROKE_COLOR"

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -20,7 +20,7 @@ const layers = useLayerStore();
 const selection = useSelectionStore();
 const selectedAreaPixelCount = computed(() => {
     const pixelSet = new Set();
-    for (const id of selection.asArray) {
+    for (const id of selection.ids) {
         const layer = layers.get(id);
         if (!layer) continue;
         layer.forEachPixel((x, y) => pixelSet.add(coordsToKey(x, y)));

--- a/src/components/StageToolbar.vue
+++ b/src/components/StageToolbar.vue
@@ -38,12 +38,12 @@ const toolStore = useToolStore();
 const selection = useSelectionStore();
 
 const selectables = ref([]);
-watch(() => selection.size, (size) => {
-  selectables.value = size === 1 ? 
+watch(() => selection.count, (count) => {
+  selectables.value = count === 1 ?
     [{ type: 'draw', name: 'Draw' }, { type: 'erase', name: 'Erase' }] :
     [{ type: 'select', name: 'Select' }, { type: 'globalErase', name: 'Global Erase' }];
   if (!selectables.value.includes(toolStore.static)) {
-    toolStore.setStatic(size === 1 ? 'draw' : 'select');
+    toolStore.setStatic(count === 1 ? 'draw' : 'select');
   }
 }, { immediate: true });
 

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -38,7 +38,7 @@ export const usePixelService = defineStore('pixelService', () => {
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
 
             if (toolStore.isGlobalErase) {
-                if (selection.exists) removePixelsFromSelected([[pixel.x, pixel.y]]);
+                if (selection.hasSelection) removePixelsFromSelected([[pixel.x, pixel.y]]);
                 else removePixelsFromAll([[pixel.x, pixel.y]]);
             } else if (toolStore.isDraw || toolStore.isErase) {
                 if (toolStore.isErase) removePixelsFromSelection([[pixel.x, pixel.y]]);
@@ -66,7 +66,7 @@ export const usePixelService = defineStore('pixelService', () => {
             toolStore.visited.add(k);
             const delta = [[pixel.x, pixel.y]];
             if (toolStore.isGlobalErase) {
-                if (selection.exists) removePixelsFromSelected(delta);
+                if (selection.hasSelection) removePixelsFromSelected(delta);
                 else removePixelsFromAll(delta);
             } else if (toolStore.isDraw || toolStore.isErase) {
                 if (toolStore.isErase) removePixelsFromSelection(delta);
@@ -83,7 +83,7 @@ export const usePixelService = defineStore('pixelService', () => {
             const pixels = stage.getPixelsFromInteraction(event);
             if (pixels.length > 0) {
                 if (toolStore.isGlobalErase) {
-                    if (selection.exists) removePixelsFromSelected(pixels);
+                    if (selection.hasSelection) removePixelsFromSelected(pixels);
                     else removePixelsFromAll(pixels);
                 } else if (toolStore.isDraw || toolStore.isErase) {
                     if (toolStore.isErase) removePixelsFromSelection(pixels);
@@ -117,22 +117,22 @@ export const usePixelService = defineStore('pixelService', () => {
     }
 
     function addPixelsToSelection(pixels) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
+        if (selection.count !== 1) return;
+        const id = selection.ids[0];
         const layer = layers.layersById[id];
         if (layer) layer.addPixels(pixels);
     }
 
     function removePixelsFromSelection(pixels) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
+        if (selection.count !== 1) return;
+        const id = selection.ids[0];
         const layer = layers.layersById[id];
         if (layer) layer.removePixels(pixels);
     }
 
     function togglePointInSelection(x, y) {
-        if (selection.size !== 1) return;
-        const id = selection.asArray[0];
+        if (selection.count !== 1) return;
+        const id = selection.ids[0];
         const layer = layers.layersById[id];
         if (layer) layer.togglePixel(x, y);
     }

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -19,7 +19,7 @@ export const useSelectService = defineStore('selectService', () => {
         if (!pixel) return;
 
         const startId = layers.topVisibleIdAt(pixel.x, pixel.y);
-        toolStore.selectionBeforeDrag = new Set(selection.asArray);
+        toolStore.selectionBeforeDrag = new Set(selection.ids);
         const mode = !event.shiftKey
             ? 'select'
             : selection.has(startId)
@@ -125,7 +125,7 @@ export const useSelectService = defineStore('selectService', () => {
             const id = layers.topVisibleIdAt(pixel.x, pixel.y);
             if (id !== null) {
                 if (mode === 'select' || !mode) {
-                    selection.selectOnly(id);
+                    selection.selectOne(id);
                 } else {
                     selection.toggle(id);
                 }
@@ -140,7 +140,7 @@ export const useSelectService = defineStore('selectService', () => {
                     if (id !== null) intersectedIds.add(id);
                 }
                 const currentSelection = new Set(
-                    (mode === 'select' || !mode) ? [] : selection.asArray
+                    (mode === 'select' || !mode) ? [] : selection.ids
                 );
                 if (mode === 'add') {
                     intersectedIds.forEach(id => currentSelection.add(id));
@@ -150,9 +150,9 @@ export const useSelectService = defineStore('selectService', () => {
                     intersectedIds.forEach(id => currentSelection.add(id));
                 }
                 if (mode === 'select' || !mode) {
-                    selection.set([...currentSelection], null, null);
+                    selection.replace([...currentSelection], null, null);
                 } else {
-                    selection.set([...currentSelection], selection.anchorId, selection.tailId);
+                    selection.replace([...currentSelection], selection.anchorId, selection.tailId);
                 }
             } else if (mode === 'select' || !mode) {
                 selection.clear();
@@ -191,7 +191,7 @@ export const useSelectService = defineStore('selectService', () => {
             Math.min(anchorIndex, tailIndex),
             Math.max(anchorIndex, tailIndex) + 1
         );
-        selection.set(slice, anchorId, tailId);
+        selection.replace(slice, anchorId, tailId);
     }
 
     return { toolStart, toolMove, toolFinish, cancel, selectRange };


### PR DESCRIPTION
## Summary
- expand selection store with CRUD-style helpers and clearer getters
- update services to use new selection API and remove deleted layers from selection
- refactor components to adopt new selection helpers and naming

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a890474f0c832cb32946b25345270f