### PR TITLE
feat: add has lookup to layer store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,7 @@ function onKeydown(event) {
       output.setRollbackPoint();
       const belowId = layers.belowId(layers.lowermostIdOf(selection.asArray));
       layerSvc.deleteSelected();
-      const newSelect = layers.nameOf(belowId) != null ? belowId : layers.lowermostId;
+      const newSelect = layers.has(belowId) ? belowId : layers.lowermostId;
       selection.selectOnly(newSelect);
       selection.setScrollRule({ type: "follow", target: newSelect });
       output.commit();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -150,7 +150,7 @@ function deleteLayer(id) {
     const targets = selection.has(id) ? selection.asArray : [id];
     const belowId = layers.belowId(layers.lowermostIdOf(targets));
     layers.deleteLayers(targets);
-    const newSelectId = layers.get(belowId) ? belowId : layers.lowermostId;
+    const newSelectId = layers.has(belowId) ? belowId : layers.lowermostId;
     selection.selectOnly(newSelectId);
     if (newSelectId) {
         selection.setScrollRule({

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -21,9 +21,8 @@ const selection = useSelectionStore();
 const selectedAreaPixelCount = computed(() => {
     const pixelSet = new Set();
     for (const id of selection.asArray) {
-        const layer = layers.getLayer(id);
-        if (!layer) continue;
-        layer.forEachPixel((x, y) => pixelSet.add(coordsToKey(x, y)));
+        if (!layers.has(id)) continue;
+        layers.getLayer(id).forEachPixel((x, y) => pixelSet.add(coordsToKey(x, y)));
     }
     return pixelSet.size;
 });

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -12,6 +12,7 @@ export const useLayerStore = defineStore('layers', {
         exists: (state) => state._order.length > 0,
         order: (state) => readonly(state._order),
         layersById: (state) => shallowReadonly(state._layersById),
+        has: (state) => (id) => state._layersById[id] != null,
         count: (state) => state._order.length,
         indexOfLayer: (state) => (id) => state._order.indexOf(id),
         idsBottomToTop: (state) => state._order.slice(),


### PR DESCRIPTION
## Summary
- add `has` helper to layer store for checking layer existence
- use new `has` helper where layer existence checks were needed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a18b1e00832cb54e975d00c9d360