### PR TITLE
refactor: handle stage pointer styles within Stage.vue

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="containerEl" class="relative flex-1 min-h-0 p-2 flex items-center justify-center">
-    <div id="stage" ref="stageEl" class="relative rounded-lg shadow-inner ring-1 ring-white/10" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px', cursor: stageService.cursor }"
+    <div id="stage" ref="stageEl" class="relative rounded-lg shadow-inner ring-1 ring-white/10 select-none touch-none" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px', cursor: stageService.cursor }"
          @pointerdown="onPointerDown" @pointermove="onPointerMove" @pointerup="onPointerUp" @pointercancel="onPointerCancel" @contextmenu.prevent>
       <!-- 체커보드 -->
       <svg class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
@@ -137,7 +137,6 @@ const resizeObserver = new ResizeObserver(() => {
     updateCanvasPosition();
 });
 onMounted(() => {
-    stageService.ensureStagePointerStyles();
     stageService.recalcScale(containerEl.value);
     updateCanvasPosition();
     resizeObserver.observe(containerEl.value);

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -91,17 +91,6 @@ export const useStageService = defineStore('stageService', () => {
         return id;
     }
 
-    function ensureStagePointerStyles() {
-        if (document.getElementById('stage-style-fix')) return;
-        const style = document.createElement('style');
-        style.id = 'stage-style-fix';
-        style.textContent = `#stage{touch-action:none;-webkit-user-select:none;user-select:none;}
-      #stage .svg-layer{pointer-events:none;}
-      #stage .display-img{image-rendering:pixelated;}
-    `;
-        document.head.appendChild(style);
-    }
-
     function clientToPixel(event) {
         const x = Math.floor((event.clientX - stageStore.canvas.x) / stageStore.canvas.scale);
         const y = Math.floor((event.clientY - stageStore.canvas.y) / stageStore.canvas.scale);
@@ -194,6 +183,5 @@ export const useStageService = defineStore('stageService', () => {
         getPixelsFromInteraction,
         // utils for components
         ensureCheckerboardPattern,
-        ensureStagePointerStyles,
     };
 });


### PR DESCRIPTION
## Summary
- inline stage pointer interaction styles in `Stage.vue`
- remove unused `ensureStagePointerStyles` utility from stage service

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a35778cc832c8958a44b8bbf5d22