### PR TITLE
Remove selectionBeforeDrag and rely on selection.has during drag

### DIFF
--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -113,7 +113,6 @@ export const usePixelService = defineStore('pixelService', () => {
         toolStore.pointer.current = null;
         toolStore.visited.clear();
         toolStore.selectOverlayLayerIds.clear();
-        toolStore.selectionBeforeDrag.clear();
     }
 
     function addPixelsToSelection(pixels) {

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -17,13 +17,11 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function toolStart(event) {
         if (event.button !== 0) return;
-        const pixel = stage.clientToPixel(event);
-        if (!pixel) return;
-
+        toolStore.pointer.start = { x: event.clientX, y: event.clientY };
+        
         output.setRollbackPoint();
 
         toolStore.pointer.status = toolStore.expected;
-        toolStore.pointer.start = { x: event.clientX, y: event.clientY };
 
         try {
             event.target.setPointerCapture?.(event.pointerId);
@@ -33,7 +31,8 @@ export const usePixelService = defineStore('pixelService', () => {
         if (toolStore.shape === 'rect') {
             toolStore.pointer.current = { x: event.clientX, y: event.clientY };
         } else {
-            toolStore.pointer.current = pixel;
+            const pixel = stage.clientToPixel(event);
+            
             toolStore.visited.clear();
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
 

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -38,7 +38,6 @@ export const useSelectService = defineStore('selectService', () => {
         if (toolStore.shape === 'rect') {
             toolStore.pointer.current = { x: event.clientX, y: event.clientY };
         } else {
-            toolStore.pointer.current = pixel;
             toolStore.visited.clear();
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
 
@@ -57,11 +56,11 @@ export const useSelectService = defineStore('selectService', () => {
 
     function toolMove(event) {
         if (toolStore.pointer.status === 'idle') return;
+        toolStore.pointer.current = { x: event.clientX, y: event.clientY };
 
         const [, mode] = toolStore.pointer.status.split(':');
 
         if (toolStore.shape === 'rect') {
-            toolStore.pointer.current = { x: event.clientX, y: event.clientY };
             const { x, y, w, h } = toolStore.marquee;
             const intersectedIds = new Set();
             for (let yy = y; yy < y + h; yy++) {
@@ -86,13 +85,8 @@ export const useSelectService = defineStore('selectService', () => {
             }
         } else {
             const pixel = stage.clientToPixel(event);
-            if (!pixel) {
-                toolStore.pointer.current = pixel;
-                return;
-            }
             const k = coordsToKey(pixel.x, pixel.y);
             if (toolStore.visited.has(k)) {
-                toolStore.pointer.current = pixel;
                 return;
             }
             toolStore.visited.add(k);
@@ -106,7 +100,6 @@ export const useSelectService = defineStore('selectService', () => {
                     toolStore.selectOverlayLayerIds.add(id);
                 }
             }
-            toolStore.pointer.current = pixel;
         }
     }
 

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -19,7 +19,6 @@ export const useSelectService = defineStore('selectService', () => {
         if (!pixel) return;
 
         const startId = layers.topVisibleIdAt(pixel.x, pixel.y);
-        toolStore.selectionBeforeDrag = new Set(selection.asArray);
         const mode = !event.shiftKey
             ? 'select'
             : selection.has(startId)
@@ -46,9 +45,9 @@ export const useSelectService = defineStore('selectService', () => {
             const id = layers.topVisibleIdAt(pixel.x, pixel.y);
             if (id !== null) {
                 if (mode === 'remove') {
-                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else if (mode === 'add') {
-                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (!selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else {
                     toolStore.selectOverlayLayerIds.add(id);
                 }
@@ -74,11 +73,11 @@ export const useSelectService = defineStore('selectService', () => {
             toolStore.selectOverlayLayerIds.clear();
             if (mode === 'add') {
                 for (const id of intersectedIds) {
-                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (!selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             } else if (mode === 'remove') {
                 for (const id of intersectedIds) {
-                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 }
             } else {
                 for (const id of intersectedIds) {
@@ -100,9 +99,9 @@ export const useSelectService = defineStore('selectService', () => {
             const id = layers.topVisibleIdAt(pixel.x, pixel.y);
             if (id !== null) {
                 if (mode === 'remove') {
-                    if (toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else if (mode === 'add') {
-                    if (!toolStore.selectionBeforeDrag.has(id)) toolStore.selectOverlayLayerIds.add(id);
+                    if (!selection.has(id)) toolStore.selectOverlayLayerIds.add(id);
                 } else {
                     toolStore.selectOverlayLayerIds.add(id);
                 }
@@ -181,7 +180,6 @@ export const useSelectService = defineStore('selectService', () => {
         toolStore.visited.clear();
         toolStore.hoverLayerId = null;
         toolStore.selectOverlayLayerIds.clear();
-        toolStore.selectionBeforeDrag.clear();
     }
 
     function selectRange(anchorId, tailId) {

--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -16,7 +16,6 @@ export const useToolStore = defineStore('tool', {
             current: null,
         },
         hoverLayerId: null,
-        selectionBeforeDrag: new Set(),
         selectOverlayLayerIds: new Set(),
         visited: new Set(),
     }),


### PR DESCRIPTION
## Summary
- drop redundant `selectionBeforeDrag` state and use `selection.has` to track drag selection
- simplify select and pixel services accordingly
- clean up tool store state

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7c371e8832c97b11f3754f82653