### PR TITLE
feat: add getPixelUnionSet util

### DIFF
--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -13,16 +13,13 @@ import { computed } from 'vue';
 import { useStageStore } from '../stores/stage';
 import { useLayerStore } from '../stores/layers';
 import { useSelectionStore } from '../stores/selection';
-import { coordsToKey } from '../utils';
+import { getPixelUnionSet } from '../utils';
 
 const stageStore = useStageStore();
 const layers = useLayerStore();
 const selection = useSelectionStore();
 const selectedAreaPixelCount = computed(() => {
-    const pixelSet = new Set();
-    for (const [, layer] of layers.getLayers(selection.asArray)) {
-        layer.forEachPixel((x, y) => pixelSet.add(coordsToKey(x, y)));
-    }
+    const pixelSet = getPixelUnionSet(layers.getLayers(selection.asArray));
     return pixelSet.size;
-});
+  });
 </script>

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { useLayerStore } from '../stores/layers';
 import { useSelectionStore } from '../stores/selection';
-import { coordsToKey, keyToCoords, buildOutline, findPixelComponents } from '../utils';
+import { keyToCoords, buildOutline, findPixelComponents, getPixelUnionSet } from '../utils';
 
 export const useLayerService = defineStore('layerService', () => {
     const layers = useLayerStore();
@@ -37,8 +37,7 @@ export const useLayerService = defineStore('layerService', () => {
 
     function mergeSelected() {
         if (selection.size < 2) return;
-        const pixelUnionSet = new Set();
-        forEachSelected(L => L.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y))));
+        const pixelUnionSet = getPixelUnionSet(layers.getLayers(selection.asArray));
 
         let r = 0, g = 0, b = 0;
         if (pixelUnionSet.size) {
@@ -91,8 +90,7 @@ export const useLayerService = defineStore('layerService', () => {
 
     function selectionPath() {
         if (!selection.size) return '';
-        const pixelUnionSet = new Set();
-        forEachSelected(L => L.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y))));
+        const pixelUnionSet = getPixelUnionSet(layers.getLayers(selection.asArray));
         const groups = buildOutline(pixelUnionSet);
         const pathData = [];
         for (const group of groups)

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -4,7 +4,7 @@ import { useStageStore } from '../stores/stage';
 import { useToolStore } from '../stores/tool';
 import { useSelectionStore } from '../stores/selection';
 import { useLayerStore } from '../stores/layers';
-import { coordsToKey, keyToCoords, pixelsToUnionPath, clamp } from '../utils';
+import { keyToCoords, pixelsToUnionPath, clamp, getPixelUnionSet } from '../utils';
 import { CURSOR_CONFIG } from '../constants';
 
 export const useStageService = defineStore('stageService', () => {
@@ -17,10 +17,7 @@ export const useStageService = defineStore('stageService', () => {
     // --- Overlay Paths ---
     const selectOverlayPath = computed(() => {
         if (!toolStore.selectOverlayLayerIds.size) return '';
-        const pixelUnionSet = new Set();
-        for (const [, layer] of layers.getLayers(toolStore.selectOverlayLayerIds)) {
-            layer.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y)));
-        }
+        const pixelUnionSet = getPixelUnionSet(layers.getLayers(toolStore.selectOverlayLayerIds));
         return pixelsToUnionPath(pixelUnionSet);
     });
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,15 @@ export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 export const coordsToKey = (x, y) => x + "," + y;
 export const keyToCoords = (key) => key.split(",").map(n => +n);
 
+export function getPixelUnionSet(layerEntries) {
+    const pixelUnionSet = new Set();
+    if (!layerEntries) return pixelUnionSet;
+    for (const [, layer] of layerEntries) {
+        layer.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y)));
+    }
+    return pixelUnionSet;
+}
+
 // --- color helpers (32-bit unsigned RGBA packed as 0xRRGGBBAA) ---
 export const packRGBA = (color) => {
     const r = clamp((+color.r || 0), 0, 255),


### PR DESCRIPTION
## Summary
- add reusable `getPixelUnionSet` helper
- refactor services and components to use the new helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a8f752a4832cb11be8d5408e1721