### PR TITLE
Return layer list without IDs in layer store

### DIFF
--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -8,8 +8,9 @@ export const useLayerService = defineStore('layerService', () => {
     const selection = useSelectionStore();
 
     function forEachSelected(fn) {
-        for (const [id, layer] of layers.getLayers(selection.asArray)) {
-            fn(layer, id);
+        for (const id of selection.asArray) {
+            const layer = layers.getLayer(id);
+            if (layer) fn(layer, id);
         }
     }
 

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -146,7 +146,9 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function removePixelsFromAll(pixels) {
         if (!pixels || !pixels.length) return;
-        for (const [id, layer] of layers.getLayers(layers.order)) {
+        for (const id of layers.order) {
+            const layer = layers.getLayer(id);
+            if (!layer) continue;
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (layer.has(x, y)) pixelsToRemove.push([x, y]);

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -75,7 +75,7 @@ export const useLayerStore = defineStore('layers', {
             const result = [];
             for (const id of ids) {
                 const layer = this._layersById[id];
-                if (layer) result.push([id, layer]);
+                if (layer) result.push(layer);
             }
             return result;
         },

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,10 +2,10 @@ export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 export const coordsToKey = (x, y) => x + "," + y;
 export const keyToCoords = (key) => key.split(",").map(n => +n);
 
-export function getPixelUnionSet(layerEntries) {
+export function getPixelUnionSet(layers) {
     const pixelUnionSet = new Set();
-    if (!layerEntries) return pixelUnionSet;
-    for (const [, layer] of layerEntries) {
+    if (!layers) return pixelUnionSet;
+    for (const layer of layers) {
         layer.forEachPixel((x, y) => pixelUnionSet.add(coordsToKey(x, y)));
     }
     return pixelUnionSet;


### PR DESCRIPTION
## Summary
- Simplify `getLayers` to return only layer objects
- Adapt pixel union utility and services to operate without layer IDs
- Update pixel service to iterate over layers directly when removing pixels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8aef43bac832caf15da35b9acec08