### PR TITLE
refactor: simplify select service status

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -136,7 +136,7 @@ const hoverStyle = computed(() => {
 });
 
 const selectOverlayStyle = computed(() => (
-    toolStore.pointer.status === 'select:remove'
+    toolStore.pointer.status === 'remove'
         ? OVERLAY_CONFIG.REMOVE
         : OVERLAY_CONFIG.ADD
 ));

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -27,7 +27,7 @@ export const useSelectService = defineStore('selectService', () => {
 
         output.setRollbackPoint();
 
-        toolStore.pointer.status = `select:${mode}`;
+        toolStore.pointer.status = mode;
         toolStore.pointer.start = { x: event.clientX, y: event.clientY };
 
         try {
@@ -58,7 +58,7 @@ export const useSelectService = defineStore('selectService', () => {
     function toolMove(event) {
         if (toolStore.pointer.status === 'idle') return;
 
-        const [, mode] = toolStore.pointer.status.split(':');
+        const mode = toolStore.pointer.status;
 
         if (toolStore.shape === 'rect') {
             toolStore.pointer.current = { x: event.clientX, y: event.clientY };
@@ -113,7 +113,7 @@ export const useSelectService = defineStore('selectService', () => {
     function toolFinish(event) {
         if (toolStore.pointer.status === 'idle') return;
 
-        const [, mode] = toolStore.pointer.status.split(':');
+        const mode = toolStore.pointer.status;
 
         const pixel = stage.clientToPixel(event);
         const start = toolStore.pointer.start;

--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -22,7 +22,10 @@ export const useToolStore = defineStore('tool', {
     getters: {
         expected() {
             if (this.pointer.status !== 'idle') {
-                return this.pointer.status.split(':')[0];
+                const status = this.pointer.status;
+                return (status === 'select' || status === 'add' || status === 'remove')
+                    ? 'select'
+                    : status;
             }
             let tool = this.static;
             if (this.shiftHeld) {


### PR DESCRIPTION
## Summary
- store selection mode directly in pointer status
- adjust overlay and tool store to use new status format

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae8ffcbc832c89e24a2f76c0ade6