### PR TITLE
refactor: compute marquee in stage and drop pointer current

### DIFF
--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -31,9 +31,8 @@ export const usePixelService = defineStore('pixelService', () => {
         } catch {}
 
         if (toolStore.shape === 'rect') {
-            toolStore.pointer.current = { x: event.clientX, y: event.clientY };
+            // no additional pointer state needed for rectangle interactions
         } else {
-            toolStore.pointer.current = pixel;
             toolStore.visited.clear();
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
 
@@ -51,16 +50,14 @@ export const usePixelService = defineStore('pixelService', () => {
         if (toolStore.pointer.status === 'idle') return;
 
         if (toolStore.shape === 'rect') {
-            toolStore.pointer.current = { x: event.clientX, y: event.clientY };
+            // rectangle interactions handled in stage component
         } else {
             const pixel = stage.clientToPixel(event);
             if (!pixel) {
-                toolStore.pointer.current = pixel;
                 return;
             }
             const k = coordsToKey(pixel.x, pixel.y);
             if (toolStore.visited.has(k)) {
-                toolStore.pointer.current = pixel;
                 return;
             }
             toolStore.visited.add(k);
@@ -72,7 +69,6 @@ export const usePixelService = defineStore('pixelService', () => {
                 if (toolStore.isErase) removePixelsFromSelection(delta);
                 else addPixelsToSelection(delta);
             }
-            toolStore.pointer.current = pixel;
         }
     }
 
@@ -110,7 +106,6 @@ export const usePixelService = defineStore('pixelService', () => {
         toolStore.pointer.status = 'idle';
         toolStore.pointer.id = null;
         toolStore.pointer.start = null;
-        toolStore.pointer.current = null;
         toolStore.visited.clear();
         toolStore.selectOverlayLayerIds.clear();
     }

--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -1,6 +1,4 @@
 import { defineStore } from 'pinia';
-import { useStageStore } from './stage';
-import { clamp } from '../utils';
 
 export const useToolStore = defineStore('tool', {
     state: () => ({
@@ -13,7 +11,6 @@ export const useToolStore = defineStore('tool', {
             status: 'idle',
             start: null,
             id: null,
-            current: null,
         },
         hoverLayerId: null,
         selectOverlayLayerIds: new Set(),
@@ -44,32 +41,6 @@ export const useToolStore = defineStore('tool', {
         isGlobalErase() { return this.expected === 'globalErase'; },
         isStroke: (state) => state.shape === 'stroke',
         isRect: (state) => state.shape === 'rect',
-        marquee() {
-            const stage = useStageStore();
-            const s = this.pointer;
-            if (this.shape !== 'rect' || !s.start || !s.current) {
-                return { visible: false, x: 0, y: 0, w: 0, h: 0 };
-            }
-            const left = Math.min(s.start.x, s.current.x) - stage.canvas.x;
-            const top = Math.min(s.start.y, s.current.y) - stage.canvas.y;
-            const right = Math.max(s.start.x, s.current.x) - stage.canvas.x;
-            const bottom = Math.max(s.start.y, s.current.y) - stage.canvas.y;
-            const minX = Math.floor(left / stage.canvas.scale),
-                  maxX = Math.floor((right - 1) / stage.canvas.scale);
-            const minY = Math.floor(top / stage.canvas.scale),
-                  maxY = Math.floor((bottom - 1) / stage.canvas.scale);
-            const minx = clamp(minX, 0, stage.canvas.width - 1),
-                  maxx = clamp(maxX, 0, stage.canvas.width - 1);
-            const miny = clamp(minY, 0, stage.canvas.height - 1),
-                  maxy = clamp(maxY, 0, stage.canvas.height - 1);
-            return {
-                visible: true,
-                x: minx,
-                y: miny,
-                w: (maxx >= minx) ? (maxx - minx + 1) : 0,
-                h: (maxy >= miny) ? (maxy - miny + 1) : 0,
-            };
-        },
     },
     actions: {
         setStatic(newTool) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,6 +11,29 @@ export function getPixelUnionSet(layers) {
     return pixelUnionSet;
 }
 
+export function calcMarquee(start, current, canvas) {
+    if (!start || !current) return { visible: false, x: 0, y: 0, w: 0, h: 0 };
+    const left = Math.min(start.x, current.x) - canvas.x;
+    const top = Math.min(start.y, current.y) - canvas.y;
+    const right = Math.max(start.x, current.x) - canvas.x;
+    const bottom = Math.max(start.y, current.y) - canvas.y;
+    const minX = Math.floor(left / canvas.scale),
+        maxX = Math.floor((right - 1) / canvas.scale);
+    const minY = Math.floor(top / canvas.scale),
+        maxY = Math.floor((bottom - 1) / canvas.scale);
+    const minx = clamp(minX, 0, canvas.width - 1),
+        maxx = clamp(maxX, 0, canvas.width - 1);
+    const miny = clamp(minY, 0, canvas.height - 1),
+        maxy = clamp(maxY, 0, canvas.height - 1);
+    return {
+        visible: true,
+        x: minx,
+        y: miny,
+        w: (maxx >= minx) ? (maxx - minx + 1) : 0,
+        h: (maxy >= miny) ? (maxy - miny + 1) : 0,
+    };
+}
+
 // --- color helpers (32-bit unsigned RGBA packed as 0xRRGGBBAA) ---
 export const packRGBA = (color) => {
     const r = clamp((+color.r || 0), 0, 255),


### PR DESCRIPTION
## Summary
- compute marquee rectangle locally in Stage component
- remove pointer.current state and related getter from tool store
- update pixel and select services to operate without pointer.current
- add calcMarquee utility for shared marquee calculations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7a09b7c832cabec3423765c951e