### PR TITLE
refactor: use reactive for complex state

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, reactive, computed, onMounted, onUnmounted } from 'vue';
 import { useStageStore } from '../stores/stage';
 import { useToolStore } from '../stores/tool';
 import { useStageService } from '../services/stage';
@@ -91,8 +91,8 @@ const selectSvc = useSelectService();
 const pixelSvc = usePixelService();
 const containerEl = ref(null);
 const stageEl = ref(null);
-const offset = ref({ x: 0, y: 0 });
-const marquee = ref({ visible: false, x: 0, y: 0, w: 0, h: 0 });
+const offset = reactive({ x: 0, y: 0 });
+const marquee = reactive({ visible: false, x: 0, y: 0, w: 0, h: 0 });
 
 const updateHover = (event) => {
     const pixel = stageService.clientToPixel(event);
@@ -117,10 +117,10 @@ const updateHover = (event) => {
 
 const updateMarquee = (e) => {
     if (toolStore.shape !== 'rect' || toolStore.pointer.status === 'idle' || !toolStore.pointer.start || !e) {
-        marquee.value = { visible: false, x: 0, y: 0, w: 0, h: 0 };
+        Object.assign(marquee, { visible: false, x: 0, y: 0, w: 0, h: 0 });
         return;
     }
-    marquee.value = calcMarquee(toolStore.pointer.start, { x: e.clientX, y: e.clientY }, stageStore.canvas);
+    Object.assign(marquee, calcMarquee(toolStore.pointer.start, { x: e.clientX, y: e.clientY }, stageStore.canvas));
 };
   
 const touches = new Map();
@@ -180,8 +180,8 @@ const onWheel = (e) => {
   const factor = e.deltaY < 0 ? 1.1 : 0.9;
   const newScale = Math.max(1, Math.round(oldScale * factor));
   const ratio = newScale / oldScale;
-  offset.value.x = px - ratio * (px - offset.value.x);
-  offset.value.y = py - ratio * (py - offset.value.y);
+  offset.x = px - ratio * (px - offset.x);
+  offset.y = py - ratio * (py - offset.y);
   stageStore.setScale(newScale);
   updateCanvasPosition();
 };
@@ -199,8 +199,8 @@ const handlePinch = () => {
   const oldScale = stageStore.canvas.scale;
   const newScale = Math.max(1, Math.round(oldScale * (dist / lastTouchDistance)));
   const ratio = newScale / oldScale;
-  offset.value.x = cx - ratio * (cx - offset.value.x);
-  offset.value.y = cy - ratio * (cy - offset.value.y);
+  offset.x = cx - ratio * (cx - offset.x);
+  offset.y = cy - ratio * (cy - offset.y);
   stageStore.setScale(newScale);
   lastTouchDistance = dist;
   updateCanvasPosition();
@@ -236,8 +236,8 @@ const patternUrl = computed(() => `url(#${stageService.ensureCheckerboardPattern
 const centerStage = () => {
   const rect = containerEl.value?.getBoundingClientRect();
   if (!rect) return;
-  offset.value.x = (rect.width - stageStore.pixelWidth) / 2;
-  offset.value.y = (rect.height - stageStore.pixelHeight) / 2;
+  offset.x = (rect.width - stageStore.pixelWidth) / 2;
+  offset.y = (rect.height - stageStore.pixelHeight) / 2;
 };
 const updateCanvasPosition = () => {
     const rect = stageEl.value?.getBoundingClientRect();

--- a/src/components/StageToolbar.vue
+++ b/src/components/StageToolbar.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { reactive, watch } from 'vue';
 import { useStageStore } from '../stores/stage';
 import { useToolStore } from '../stores/tool';
 import { useSelectionStore } from '../stores/selection';
@@ -37,12 +37,12 @@ const stageStore = useStageStore();
 const toolStore = useToolStore();
 const selection = useSelectionStore();
 
-const selectables = ref([]);
+const selectables = reactive([]);
 watch(() => selection.count, (size) => {
-  selectables.value = size === 1 ? 
-    [{ type: 'draw', name: 'Draw' }, { type: 'erase', name: 'Erase' }] :
-    [{ type: 'select', name: 'Select' }, { type: 'globalErase', name: 'Global Erase' }];
-  if (!selectables.value.includes(toolStore.static)) {
+  selectables.splice(0, selectables.length, ...(size === 1
+    ? [{ type: 'draw', name: 'Draw' }, { type: 'erase', name: 'Erase' }]
+    : [{ type: 'select', name: 'Select' }, { type: 'globalErase', name: 'Global Erase' }]));
+  if (!selectables.some(tool => tool.type === toolStore.static)) {
     toolStore.setStatic(size === 1 ? 'draw' : 'select');
   }
 }, { immediate: true });


### PR DESCRIPTION
## Summary
- replace selectables ref with reactive array and adjust watch logic
- convert offset and marquee refs to reactive objects and update pointer handling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a95fdf1b70832cb2d08d6e85f22aec