### PR TITLE
Clamp zoom to container size

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -178,11 +178,12 @@ const onWheel = (e) => {
   const py = e.clientY - rect.top;
   const oldScale = stageStore.canvas.scale;
   const factor = e.deltaY < 0 ? 1.1 : 0.9;
-  const newScale = Math.max(1, Math.round(oldScale * factor));
-  const ratio = newScale / oldScale;
+  const newScale = Math.round(oldScale * factor);
+  const clamped = Math.max(stageStore.canvas.minScale, newScale);
+  const ratio = clamped / oldScale;
   offset.x = px - ratio * (px - offset.x);
   offset.y = py - ratio * (py - offset.y);
-  stageStore.setScale(newScale);
+  stageStore.setScale(clamped);
   updateCanvasPosition();
 };
 
@@ -197,11 +198,12 @@ const handlePinch = () => {
     return;
   }
   const oldScale = stageStore.canvas.scale;
-  const newScale = Math.max(1, Math.round(oldScale * (dist / lastTouchDistance)));
-  const ratio = newScale / oldScale;
+  const newScale = Math.round(oldScale * (dist / lastTouchDistance));
+  const clamped = Math.max(stageStore.canvas.minScale, newScale);
+  const ratio = clamped / oldScale;
   offset.x = cx - ratio * (cx - offset.x);
   offset.y = cy - ratio * (cy - offset.y);
-  stageStore.setScale(newScale);
+  stageStore.setScale(clamped);
   lastTouchDistance = dist;
   updateCanvasPosition();
 };

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -27,8 +27,13 @@ export const useStageService = defineStore('stageService', () => {
         const padding = 20;
         const maxW = (wrapperElement.clientWidth || 0) - padding;
         const maxH = (wrapperElement.clientHeight || 0) - padding - 60;
-        const newScale = Math.floor(Math.min(maxW / Math.max(1, stageStore.canvas.width), maxH / Math.max(1, stageStore.canvas.height))) || 16;
-        stageStore.setScale(Math.max(1, newScale));
+        const newScale = Math.floor(
+            Math.min(
+                maxW / Math.max(1, stageStore.canvas.width),
+                maxH / Math.max(1, stageStore.canvas.height)
+            )
+        ) || 16;
+        stageStore.setMinScale(newScale);
     }
     
     const patternId = ref('chk');

--- a/src/stores/stage.js
+++ b/src/stores/stage.js
@@ -8,6 +8,7 @@ export const useStageStore = defineStore('stage', {
             width: 16,
             height: 16,
             scale: 16,
+            minScale: 1,
         },
         display: 'result', // 'result' | 'original'
         imageSrc: '',
@@ -34,7 +35,13 @@ export const useStageStore = defineStore('stage', {
             this.imageSrc = src || '';
         },
         setScale(newScale) {
-            this.canvas.scale = Math.max(1, newScale | 0);
+            this.canvas.scale = Math.max(this.canvas.minScale, newScale | 0);
+        },
+        setMinScale(newMin) {
+            this.canvas.minScale = Math.max(1, newMin | 0);
+            if (this.canvas.scale < this.canvas.minScale) {
+                this.canvas.scale = this.canvas.minScale;
+            }
         },
         toggleView() {
             this.display = (this.display === 'original') ? 'result' : 'original';


### PR DESCRIPTION
## Summary
- Prevent zooming out beyond container-fit scale
- Track minimum allowed canvas scale and clamp wheel/pinch zoom
- Recalculate container-fit scale on resize

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96312cffc832cba95fd15087c76a4