### PR TITLE
feat: show disconnected layer counts

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -17,7 +17,14 @@
         <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
           <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(id)" @keydown="onNameKey(id,$event)" @blur="finishRename(id,$event)">{{ layers.nameOf(id) }}</span>
         </div>
-        <div class="text-xs text-slate-400 cursor-pointer" @click.stop="onPixelCountClick(id)" title="같은 크기의 모든 레이어 선택">{{ layers.pixelCountOf(id) }} px</div>
+        <div class="text-xs text-slate-400">
+          <span class="cursor-pointer" @click.stop="onPixelCountClick(id)" title="같은 크기의 모든 레이어 선택">{{ layers.pixelCountOf(id) }} px</span>
+          <template v-if="layers.disconnectedCountOf(id) > 1">
+            <span class="mx-1">/</span>
+            <span class="cursor-pointer" @click.stop="onDisconnectedClick(id)">Disconnected</span>:
+            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(id)">{{ layers.disconnectedCountOf(id) }}</span>
+          </template>
+        </div>
       </div>
       <!-- 액션 -->
       <div class="flex gap-1 justify-end">
@@ -88,6 +95,22 @@ function onThumbnailClick(id) {
 
 function onPixelCountClick(id) {
     layerSvc.selectByPixelCount(id);
+    selection.setScrollRule({
+        type: "follow",
+        target: id
+    });
+}
+
+function onDisconnectedClick(id) {
+    layerSvc.selectDisconnectedLayers(id);
+    selection.setScrollRule({
+        type: "follow",
+        target: id
+    });
+}
+
+function onDisconnectedCountClick(id) {
+    layerSvc.selectByDisconnectedCount(id);
     selection.setScrollRule({
         type: "follow",
         target: id

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -51,7 +51,7 @@ const onRemoveEmpty = () => {
 };
 const onSplit = () => {
     output.setRollbackPoint();
-    layerSvc.splitSelectedLayer();
+    layerSvc.splitLayer(selection.anchorId);
     output.commit();
 };
 const undo = () => output.undo();

--- a/src/domain/Layer.js
+++ b/src/domain/Layer.js
@@ -1,5 +1,5 @@
 import { effectScope, reactive, computed } from 'vue';
-import { coordsToKey, keyToCoords, pixelsToUnionPath, randColorU32 } from '../utils';
+import { coordsToKey, keyToCoords, pixelsToUnionPath, randColorU32, groupConnectedPixels } from '../utils';
 
 export class Layer {
     constructor({
@@ -17,6 +17,7 @@ export class Layer {
         this._scope = effectScope(true);
         this._pixels = reactive(new Set(keyedPixels)); // Set<string>
         this._pathData = this._scope.run(() => computed(() => pixelsToUnionPath(this._pixels)));
+        this._disconnected = this._scope.run(() => computed(() => groupConnectedPixels(this._pixels).length));
     }
     // Color API (u32)
     getColorU32() {
@@ -35,6 +36,9 @@ export class Layer {
     }
     get pixelCount() {
         return this._pixels.size;
+    }
+    get disconnectedCount() {
+        return this._disconnected.value;
     }
     forEachPixel(fn) {
         for (const pixelKey of this._pixels) {

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -106,9 +106,8 @@ export const useLayerService = defineStore('layerService', () => {
         if (removed.length) selection.clear();
     }
 
-    function splitSelectedLayer() {
-        if (selection.count !== 1) return;
-        const layerId = selection.ids[0];
+    function splitLayer(layerId) {
+        if (layerId == null) return;
         const layer = layers.getLayer(layerId);
         if (!layer || layer.pixelCount < 2) return;
 
@@ -138,6 +137,23 @@ export const useLayerService = defineStore('layerService', () => {
         layers._order = orderWithoutNew;
 
         selection.replace(newIds, newIds[0], newIds[0]);
+    }
+
+    function selectDisconnectedLayers(id) {
+        const idsToSelect = layers.order.filter(layerId => layers.disconnectedCountOf(layerId) > 1);
+        if (idsToSelect.length) selection.replace(idsToSelect, id, id);
+    }
+
+    function selectByDisconnectedCount(id) {
+        const targetLayer = layers.getLayer(id);
+        if (!targetLayer) return;
+        const targetCount = targetLayer.disconnectedCount;
+        if (targetCount <= 1) {
+            selection.selectOne(id);
+            return;
+        }
+        const idsToSelect = layers.order.filter(layerId => layers.disconnectedCountOf(layerId) === targetCount);
+        if (idsToSelect.length) selection.replace(idsToSelect, id, id);
     }
 
     function selectByPixelCount(id) {
@@ -170,9 +186,11 @@ export const useLayerService = defineStore('layerService', () => {
         copySelected,
         selectionPath,
         removeEmptyLayers,
-        splitSelectedLayer,
+        splitLayer,
         selectByPixelCount,
-        selectByColor
+        selectByColor,
+        selectDisconnectedLayers,
+        selectByDisconnectedCount
     };
 });
 

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -46,6 +46,7 @@ export const useLayerStore = defineStore('layers', {
         nameOf: (state) => (id) => state._layersById[id]?.name,
         visibilityOf: (state) => (id) => !!state._layersById[id]?.visible,
         pixelCountOf: (state) => (id) => state._layersById[id]?.pixelCount ?? 0,
+        disconnectedCountOf: (state) => (id) => state._layersById[id]?.disconnectedCount ?? 0,
         compositeColorAt: (state) => (x, y) => {
             for (let i = state._order.length - 1; i >= 0; i--) {
                 const layer = state._layersById[state._order[i]];


### PR DESCRIPTION
## Summary
- split divided now targets the chosen layer only
- display disconnected component count and selection helpers in the layers panel
- track disconnected pixel groups per layer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9793ad538832c9f5d44f613e5ecac