### PR TITLE
Skip containment when zooming in

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -185,7 +185,7 @@ const onWheel = (e) => {
   offset.y = py - ratio * (py - offset.y);
   stageStore.setScale(clamped);
   updateCanvasPosition();
-  containStage();
+  if (clamped <= oldScale) containStage();
 };
 
 const handlePinch = () => {
@@ -207,7 +207,7 @@ const handlePinch = () => {
   stageStore.setScale(clamped);
   lastTouchDistance = dist;
   updateCanvasPosition();
-  containStage();
+  if (clamped <= oldScale) containStage();
 };
 
 const selectionPath = computed(() => layerSvc.selectionPath());


### PR DESCRIPTION
## Summary
- Avoid clamping stage position when zooming in so pointer location is preserved

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a991b35388832cb426bcda77225873