### PR TITLE
Fix canvas pointer offset after zoom

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -184,8 +184,8 @@ const onWheel = (e) => {
   offset.x = px - ratio * (px - offset.x);
   offset.y = py - ratio * (py - offset.y);
   stageStore.setScale(clamped);
-  updateCanvasPosition();
   if (clamped <= oldScale) containStage();
+  updateCanvasPosition();
 };
 
 const handlePinch = () => {
@@ -206,8 +206,8 @@ const handlePinch = () => {
   offset.y = cy - ratio * (cy - offset.y);
   stageStore.setScale(clamped);
   lastTouchDistance = dist;
-  updateCanvasPosition();
   if (clamped <= oldScale) containStage();
+  updateCanvasPosition();
 };
 
 const selectionPath = computed(() => layerSvc.selectionPath());
@@ -250,14 +250,19 @@ const containStage = () => {
   offset.y = maxY >= 0 ? maxY / 2 : clamp(offset.y, maxY, 0);
 };
 const updateCanvasPosition = () => {
-    const rect = stageEl.value?.getBoundingClientRect();
-    if (rect) stageStore.setCanvasPosition(rect.left, rect.top);
+    const el = containerEl.value;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    const left = rect.left + parseFloat(style.paddingLeft);
+    const top = rect.top + parseFloat(style.paddingTop);
+    stageStore.setCanvasPosition(left + offset.x, top + offset.y);
 };
 
 const onResize = () => {
     stageService.recalcScale(containerEl.value);
-    updateCanvasPosition();
     containStage();
+    updateCanvasPosition();
 }
   
 const resizeObserver = new ResizeObserver(onResize);


### PR DESCRIPTION
## Summary
- keep stage canvas coordinates in sync after zoom adjustments
- compute canvas position from container bounds and translate offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9946daa6c832c9e39e9c8d0fa7baf