### PR TITLE
Adjust layer toolbar order and toggles

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -1,19 +1,19 @@
 <template>
     <div class="flex items-center gap-2 p-2 flex-wrap">
-      <button @click="onAdd" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+      <button @click="onAdd" title="Add layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
         <img :src="'image/layer_toolbar/add.svg'" alt="Add layer" class="w-4 h-4">
       </button>
-      <button @click="onMerge" :disabled="selection.count < 2" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
-        <img :src="'image/layer_toolbar/merge.svg'" alt="Merge layers" class="w-4 h-4">
-      </button>
-      <button @click="onCopy" :disabled="!selection.exists" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+      <button @click="onCopy" :disabled="!selection.exists" title="Copy layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
         <img :src="'image/layer_toolbar/copy.svg'" alt="Copy layer" class="w-4 h-4">
       </button>
-      <button @click="onSelectEmpty" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
-        <img :src="'image/layer_toolbar/empty.svg'" alt="Select empty" class="w-4 h-4">
+      <button @click="onMerge" :disabled="selection.count < 2" title="Merge layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+        <img :src="'image/layer_toolbar/merge.svg'" alt="Merge layers" class="w-4 h-4">
       </button>
-      <button @click="onSplit" :disabled="selection.count !== 1" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
-        <img :src="'image/layer_toolbar/split.svg'" alt="Split divided" class="w-4 h-4">
+      <button @click="onSplit" :disabled="!canSplit" title="Split disconnected" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+        <img :src="'image/layer_toolbar/split.svg'" alt="Split disconnected" class="w-4 h-4">
+      </button>
+      <button @click="onSelectEmpty" :disabled="!hasEmptyLayers" title="Select empty layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+        <img :src="'image/layer_toolbar/empty.svg'" alt="Select empty layers" class="w-4 h-4">
       </button>
     </div>
 </template>
@@ -23,11 +23,15 @@ import { useLayerStore } from '../stores/layers';
 import { useLayerService } from '../services/layers';
 import { useOutputStore } from '../stores/output';
 import { useSelectionStore } from '../stores/selection';
+import { computed } from 'vue';
 
 const layers = useLayerStore();
 const layerSvc = useLayerService();
 const output = useOutputStore();
 const selection = useSelectionStore();
+
+const hasEmptyLayers = computed(() => layers.order.some(id => layers.pixelCountOf(id) === 0));
+const canSplit = computed(() => selection.ids.some(id => layers.disconnectedCountOf(id) > 1));
 
 const onAdd = () => {
     output.setRollbackPoint();


### PR DESCRIPTION
## Summary
- Reorder layer toolbar buttons to add, copy, merge, split, empty
- Disable empty button when no blank layers and enable split only for disconnected selections
- Add titles to toolbar buttons and rename split action to “Split disconnected”

## Testing
- ⚠️ `npm test` *(no test script)*
- ✅ `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9c63ceaac832caab430931619b1d8