### PR TITLE
feat: use contain scale for initial zoom and adjust min scale

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -274,14 +274,14 @@ const updateCanvasPosition = () => {
 
 const onDomResize = () => {
     stageService.recalcMinScale(containerEl.value);
-    stageStore.setScale(stageStore.canvas.minScale);
+    stageStore.setScale(stageStore.canvas.containScale);
     containStage();
     updateCanvasPosition();
 };
 
 const onImageLoad = () => {
     stageService.recalcMinScale(containerEl.value);
-    stageStore.setScale(stageStore.canvas.minScale);
+    stageStore.setScale(stageStore.canvas.containScale);
     containStage();
     updateCanvasPosition();
 };

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -34,7 +34,8 @@ export const useStageService = defineStore('stageService', () => {
             width / Math.max(1, stageStore.canvas.width),
             height / Math.max(1, stageStore.canvas.height)
         );
-        const minScale = Math.max(1, containScale * 0.9);
+        stageStore.setContainScale(containScale);
+        const minScale = Math.max(1, containScale * 0.5);
         stageStore.setMinScale(minScale);
     }
     

--- a/src/stores/stage.js
+++ b/src/stores/stage.js
@@ -9,6 +9,7 @@ export const useStageStore = defineStore('stage', {
             height: 16,
             scale: 16,
             minScale: 1,
+            containScale: 1,
         },
         display: 'result', // 'result' | 'original'
         imageSrc: '',
@@ -36,6 +37,9 @@ export const useStageStore = defineStore('stage', {
         },
         setScale(newScale) {
             this.canvas.scale = Math.max(this.canvas.minScale, newScale);
+        },
+        setContainScale(newContain) {
+            this.canvas.containScale = Math.max(1, newContain);
         },
         setMinScale(newMin) {
             this.canvas.minScale = Math.max(1, newMin);


### PR DESCRIPTION
## Summary
- track containScale in stage store to record scale that fits canvas
- compute minScale at half of containScale and reset zoom to containScale on image load or DOM resize

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe204770832c82157a1cc2730051