### PR TITLE
feat: pan stage with scroll and zoom with ctrl-scroll

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="containerEl" class="relative flex-1 min-h-0 p-2 overflow-hidden touch-none"
+  <div ref="containerEl" class="relative flex-1 min-h-0 p-2 touch-none"
        @wheel.prevent="onWheel"
        @pointerdown="onContainerPointerDown"
        @pointermove="onContainerPointerMove"
@@ -185,19 +185,32 @@ const onPointerCancel = (e) => {
 };
 
 const onWheel = (e) => {
-  if (e.deltaY == 0) return;
-  const rect = containerEl.value.getBoundingClientRect();
-  const px = e.clientX - rect.left;
-  const py = e.clientY - rect.top;
-  const oldScale = stageStore.canvas.scale;
-  const factor = e.deltaY < 0 ? 1.1 : 0.9;
-  const newScale = oldScale * factor;
-  const clamped = Math.max(stageStore.canvas.minScale, newScale);
-  const ratio = clamped / oldScale;
-  offset.x = px - ratio * (px - offset.x);
-  offset.y = py - ratio * (py - offset.y);
-  stageStore.setScale(clamped);
-  if (newScale < oldScale) positionStage();
+  if (e.ctrlKey) {
+    if (e.deltaY === 0) return;
+    const rect = containerEl.value.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const oldScale = stageStore.canvas.scale;
+    const factor = e.deltaY < 0 ? 1.1 : 0.9;
+    const newScale = oldScale * factor;
+    const clamped = Math.max(stageStore.canvas.minScale, newScale);
+    const ratio = clamped / oldScale;
+    offset.x = px - ratio * (px - offset.x);
+    offset.y = py - ratio * (py - offset.y);
+    stageStore.setScale(clamped);
+    if (newScale < oldScale) positionStage();
+  } else {
+    offset.x -= e.deltaX;
+    offset.y -= e.deltaY;
+    const el = containerEl.value;
+    const style = getComputedStyle(el);
+    const width = el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+    const height = el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
+    const maxX = width - stageStore.pixelWidth;
+    const maxY = height - stageStore.pixelHeight;
+    offset.x = maxX >= 0 ? maxX / 2 : clamp(offset.x, maxX, 0);
+    offset.y = maxY >= 0 ? maxY / 2 : clamp(offset.y, maxY, 0);
+  }
   updateCanvasPosition();
 };
 


### PR DESCRIPTION
## Summary
- allow vertical and horizontal scrolling to pan the stage
- support ctrl+scroll to zoom
- drop overflow-hidden on stage container

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa047d92ec832c863928b8c620ae1e