### PR TITLE
Hide stage scrollbars when content fits

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="containerEl" class="relative flex-1 min-h-0 p-2 overflow-scroll touch-none"
+  <div ref="containerEl" class="relative flex-1 min-h-0 p-2 overflow-auto touch-none"
        @wheel.prevent="onWheel"
        @pointerdown="onContainerPointerDown"
        @pointermove="onContainerPointerMove"


### PR DESCRIPTION
## Summary
- show Stage scrollbars only when content overflows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa070cdf3c832c911b64ffe8945743