### PR TITLE
Theme scrollbars and ignore resize from scrollbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -207,4 +207,24 @@ onMounted(async () => {
 
 /* 드래그/이름편집 UX */
 .layers.dragging,.layers .layer.dragging{cursor:grabbing!important}
+
+/* Scrollbar styling */
+*{
+  scrollbar-width:thin;
+  scrollbar-color:rgba(71,85,105,.8) rgba(30,41,59,.5);
+}
+*::-webkit-scrollbar{
+  width:8px;
+  height:8px;
+}
+*::-webkit-scrollbar-track{
+  background:rgba(30,41,59,.5);
+}
+*::-webkit-scrollbar-thumb{
+  background-color:rgba(71,85,105,.8);
+  border-radius:4px;
+}
+*::-webkit-scrollbar-thumb:hover{
+  background-color:rgba(100,116,139,.8);
+}
 </style>

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -291,8 +291,22 @@ const updateCanvasPosition = () => {
     stageStore.setCanvasPosition(left + offset.x, top + offset.y);
 };
 
+let prevOffsetWidth = 0;
+let prevOffsetHeight = 0;
+let prevClientWidth = 0;
+let prevClientHeight = 0;
+
 const onDomResize = () => {
-    stageService.recalcMinScale(containerEl.value);
+    const el = containerEl.value;
+    const { offsetWidth, offsetHeight, clientWidth, clientHeight } = el;
+    const sizeChanged = offsetWidth !== prevOffsetWidth || offsetHeight !== prevOffsetHeight;
+    const scrollChanged = !sizeChanged && (clientWidth !== prevClientWidth || clientHeight !== prevClientHeight);
+    prevOffsetWidth = offsetWidth;
+    prevOffsetHeight = offsetHeight;
+    prevClientWidth = clientWidth;
+    prevClientHeight = clientHeight;
+    if (scrollChanged) return;
+    stageService.recalcMinScale(el);
     stageStore.setScale(stageStore.canvas.containScale);
     positionStage(true);
     updateCanvasPosition();


### PR DESCRIPTION
## Summary
- style global scrollbars to fit dark theme
- skip stage resize when only scrollbars change to prevent stutter

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa0911a784832c8f3e93b1251ef665