### PR TITLE
Remove default layer selection at startup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -173,8 +173,6 @@ onMounted(async () => {
     layers.createLayer({});
     layers.createLayer({});
   }
-  selection.selectOne(layers.idsTopToBottom[0]);
-
 
   window.addEventListener('keydown', onKeydown);
   window.addEventListener('keyup', onKeyup);


### PR DESCRIPTION
## Summary
- Avoid auto-selecting the top layer during initialization so the app starts with no layers selected.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa723aadbc832c8d6d94c9e317171c