### PR TITLE
Remove default layer selection at startup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -173,8 +173,6 @@ onMounted(async () => {
     layers.createLayer({});
     layers.createLayer({});
   }
-  selection.selectOne(layers.idsTopToBottom[0]);
-
 
   window.addEventListener('keydown', onKeydown);
   window.addEventListener('keyup', onKeyup);

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-memo="[output.commitVersion, selection.ids]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
+  <div v-memo="[output.commitVersion, selection.ids, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
     <div v-for="id in layers.idsTopToBottom" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="id" :data-id="id" :class="{ selected: selection.isSelected(id), anchor: selection.anchorId===id, dragging: dragId===id }" draggable="true" @click="onLayerClick(id,$event)" @dragstart="onDragStart(id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(id,$event)">
       <!-- 썸네일 -->
       <div @click.stop="onThumbnailClick(id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">


### PR DESCRIPTION
## Summary
- Avoid auto-selecting the top layer during initialization so the app starts with no layers selected.
- Ensure LayersPanel re-renders when layer count changes so layers show even without an initial selection.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa723aadbc832c8d6d94c9e317171c