### PR TITLE
fix: global erase in multi-select mode

### DIFF
--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -8,8 +8,9 @@ export const useLayerService = defineStore('layerService', () => {
     const selection = useSelectionStore();
 
     function forEachSelected(fn) {
-        for (const layer of layers.getLayers(selection.ids)) {
-            fn(layer);
+        for (const id of selection.ids) {
+            const layer = layers.getLayer(id);
+            if (layer) fn(layer, id);
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `forEachSelected` to provide layer ids, enabling global erase and copy operations to target selected layers correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa8e452124832c89661ebc73b4e93b