### PR TITLE
Reset hover layer when pointer exits stage

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -14,6 +14,7 @@
          }"
          @pointerdown="onPointerDown"
          @pointermove="onPointerMove"
+         @pointerleave="onPointerLeave"
          @pointerup="onPointerUp"
          @pointercancel="onPointerCancel"
          @contextmenu.prevent>
@@ -182,6 +183,12 @@ const onPointerCancel = (e) => {
     updateMarquee(e);
     if (toolStore.isSelect) selectSvc.cancel(e);
     else pixelSvc.cancel(e);
+};
+
+const onPointerLeave = (e) => {
+    if (e.pointerType === 'touch') return;
+    toolStore.hoverLayerId = null;
+    stageStore.updatePixelInfo('-');
 };
 
 const onWheel = (e) => {


### PR DESCRIPTION
## Summary
- Clear `hoverLayerId` when the pointer leaves the stage element
- Update pixel info to reset while not hovering over the stage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa94cf9d3c832c9c9bf794ba284320