### PR TITLE
Enable scrolling when canvas underflows container

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -213,10 +213,14 @@ const onWheel = (e) => {
     const style = getComputedStyle(el);
     const width = el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
     const height = el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
-    const maxX = width - stageStore.pixelWidth;
-    const maxY = height - stageStore.pixelHeight;
-    offset.x = clamp(offset.x, maxX, 0);
-    offset.y = clamp(offset.y, maxY, 0);
+    const diffX = width - stageStore.pixelWidth;
+    const diffY = height - stageStore.pixelHeight;
+    const minX = Math.min(0, diffX);
+    const maxX = Math.max(0, diffX);
+    const minY = Math.min(0, diffY);
+    const maxY = Math.max(0, diffY);
+    offset.x = clamp(offset.x, minX, maxX);
+    offset.y = clamp(offset.y, minY, maxY);
   }
   updateCanvasPosition();
 };
@@ -276,10 +280,14 @@ const positionStage = (center = false) => {
   const style = getComputedStyle(el);
   const width = el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
   const height = el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
-  const maxX = width - stageStore.pixelWidth;
-  const maxY = height - stageStore.pixelHeight;
-  const targetX = maxX >= 0 ? maxX / 2 : clamp(offset.x, maxX, 0);
-  const targetY = maxY >= 0 ? maxY / 2 : clamp(offset.y, maxY, 0);
+  const diffX = width - stageStore.pixelWidth;
+  const diffY = height - stageStore.pixelHeight;
+  const minX = Math.min(0, diffX);
+  const maxX = Math.max(0, diffX);
+  const minY = Math.min(0, diffY);
+  const maxY = Math.max(0, diffY);
+  const targetX = center ? (minX + maxX) / 2 : clamp(offset.x, minX, maxX);
+  const targetY = center ? (minY + maxY) / 2 : clamp(offset.y, minY, maxY);
   if (center) {
     offset.x = targetX;
     offset.y = targetY;


### PR DESCRIPTION
## Summary
- Allow stage to scroll even when it is smaller than its container by clamping offsets for both positive and negative overflow
- Adjust positioning logic to support new clamping behavior and proper centering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa99648a68832c851532d0543d0f84