### PR TITLE
feat: add layer locking

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -26,15 +26,18 @@
           </template>
         </div>
       </div>
-      <!-- 액션 -->
-      <div class="flex gap-1 justify-end">
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(layers.visibilityOf(id)?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
+        <!-- 액션 -->
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/잠금해제">
+            <img :src="(layers.lockedOf(id)?icons.locked:icons.unlocked)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.locked=icons.unlocked=''" @click.stop="toggleLock(id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(layers.visibilityOf(id)?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(id)" />
+          </div>
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(id)" />
-        </div>
-      </div>
     </div>
     <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
@@ -66,7 +69,9 @@ const listElement = ref(null);
 const icons = reactive({
     show: 'image/layer_block/show.svg',
     hide: 'image/layer_block/hide.svg',
-    del: 'image/layer_block/delete.svg'
+    del: 'image/layer_block/delete.svg',
+    locked: 'image/layer_block/locked.svg',
+    unlocked: 'image/layer_block/unlocked.svg'
 });
 
 const patternUrl = computed(() => `url(#${stageService.ensureCheckerboardPattern(document.body)})`);
@@ -173,6 +178,13 @@ function toggleVisibility(id) {
     output.setRollbackPoint();
     if (selection.isSelected(id)) layerSvc.setVisibilityForSelected(!layers.visibilityOf(id));
     else layers.toggleVisibility(id);
+    output.commit();
+}
+
+function toggleLock(id) {
+    output.setRollbackPoint();
+    if (selection.isSelected(id)) layerSvc.setLockForSelected(!layers.lockedOf(id));
+    else layers.toggleLock(id);
     output.commit();
 }
 

--- a/src/domain/Layer.js
+++ b/src/domain/Layer.js
@@ -6,11 +6,13 @@ export class Layer {
         name,
         colorU32,
         visible,
+        locked,
         pixels
     } = {}) {
         this.name = name || 'Layer';
         this.visible = visible ?? true;
         this._color = (colorU32 >>> 0) || randColorU32();
+        this.locked = !!locked;
 
         const keyedPixels = pixels ? pixels.map(p => coordsToKey(p[0], p[1])) : [];
         // reactive pixels + scoped computed cache
@@ -72,6 +74,7 @@ export class Layer {
         return {
             name: this.name,
             visible: this.visible,
+            locked: this.locked,
             color: this._color >>> 0,
             pixels: [...this._pixels].map(s => keyToCoords(s))
         };
@@ -81,6 +84,7 @@ export class Layer {
             name: data.name,
             colorU32: data.color >>> 0,
             visible: !!data.visible,
+            locked: !!data.locked,
             pixels: data.pixels
         });
     }

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -26,6 +26,12 @@ export const useLayerService = defineStore('layerService', () => {
         }
     }
 
+    function setLockForSelected(isLocked) {
+        for (const id of selection.ids) {
+            layers.updateLayer(id, { locked: isLocked });
+        }
+    }
+
     function deleteSelected() {
         const ids = selection.ids;
         layers.deleteLayers(ids);
@@ -181,6 +187,7 @@ export const useLayerService = defineStore('layerService', () => {
         forEachSelected,
         setColorForSelectedU32,
         setVisibilityForSelected,
+        setLockForSelected,
         deleteSelected,
         reorderGroup,
         mergeSelected,

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -45,6 +45,7 @@ export const useLayerStore = defineStore('layers', {
         colorOf: (state) => (id) => state._layersById[id]?.getColorU32() ?? 0,
         nameOf: (state) => (id) => state._layersById[id]?.name,
         visibilityOf: (state) => (id) => !!state._layersById[id]?.visible,
+        lockedOf: (state) => (id) => !!state._layersById[id]?.locked,
         pixelCountOf: (state) => (id) => state._layersById[id]?.pixelCount ?? 0,
         disconnectedCountOf: (state) => (id) => state._layersById[id]?.disconnectedCount ?? 0,
         compositeColorAt: (state) => (x, y) => {
@@ -100,22 +101,27 @@ export const useLayerStore = defineStore('layers', {
             if (props.name !== undefined) layer.name = props.name;
             if (props.colorU32 !== undefined) layer.setColorU32(props.colorU32);
             if (props.visible !== undefined) layer.visible = !!props.visible;
+            if (props.locked !== undefined) layer.locked = !!props.locked;
         },
         toggleVisibility(id) {
             const layer = this._layersById[id];
             if (layer) layer.visible = !layer.visible;
         },
+        toggleLock(id) {
+            const layer = this._layersById[id];
+            if (layer) layer.locked = !layer.locked;
+        },
         addPixels(id, pixels) {
             const layer = this._layersById[id];
-            if (layer) layer.addPixels(pixels);
+            if (layer && !layer.locked) layer.addPixels(pixels);
         },
         removePixels(id, pixels) {
             const layer = this._layersById[id];
-            if (layer) layer.removePixels(pixels);
+            if (layer && !layer.locked) layer.removePixels(pixels);
         },
         togglePixel(id, x, y) {
             const layer = this._layersById[id];
-            if (layer) layer.togglePixel(x, y);
+            if (layer && !layer.locked) layer.togglePixel(x, y);
         },
         /** Remove layers by ids */
         deleteLayers(ids) {


### PR DESCRIPTION
## Summary
- add locked state to layers with serialization
- expose lock toggling in layers panel using new icons
- prevent pixel edits on locked layers and allow bulk lock updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9f8a6a9c832c8bf419b48a949034