### PR TITLE
feat: start display at two thirds width

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,8 @@ const stageToolbar = ref(null);
 
 // Width control between display and layers
 const container = ref(null);
-const leftWidth = ref(50);
+// Display starts at 2/3 of the width (66.67%), leaving 1/3 for layers
+const leftWidth = ref((2 / 3) * 100);
 const isDragging = ref(false);
 
 const displayStyle = computed(() => ({ width: `${leftWidth.value}%` }));


### PR DESCRIPTION
## Summary
- default display section width to 2/3 and layers to 1/3

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaa6c4d6dc832c8e725a306af9716b