### PR TITLE
Fix stage overflow to keep scrollbars functional

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,6 +1,7 @@
 <template>
   <div ref="containerEl" class="relative flex-1 min-h-0 p-2 overflow-auto touch-none"
        @wheel.prevent="onWheel"
+       @scroll="onScroll"
        @pointerdown="onContainerPointerDown"
        @pointermove="onContainerPointerMove"
        @pointerup="onContainerPointerUp"
@@ -191,15 +192,20 @@ const onPointerLeave = (e) => {
     stageStore.updatePixelInfo('-');
 };
 
+const onScroll = () => {
+  updateCanvasPosition();
+};
+
 const onWheel = (e) => {
   if (!e.ctrlKey) {
     offset.x -= e.deltaX;
     offset.y -= e.deltaY;
   } else {
     if (e.deltaY === 0) return;
-    const rect = containerEl.value.getBoundingClientRect();
-    const px = e.clientX - rect.left;
-    const py = e.clientY - rect.top;
+    const el = containerEl.value;
+    const rect = el.getBoundingClientRect();
+    const px = e.clientX - rect.left + el.scrollLeft;
+    const py = e.clientY - rect.top + el.scrollTop;
     const oldScale = stageStore.canvas.scale;
     const factor = e.deltaY < 0 ? 1.1 : 0.9;
     const newScale = oldScale * factor;
@@ -214,10 +220,11 @@ const onWheel = (e) => {
 };
 
 const handlePinch = () => {
-  const rect = containerEl.value.getBoundingClientRect();
+  const el = containerEl.value;
+  const rect = el.getBoundingClientRect();
   const [t1, t2] = Array.from(touches.values());
-  const cx = (t1.x + t2.x) / 2 - rect.left;
-  const cy = (t1.y + t2.y) / 2 - rect.top;
+  const cx = (t1.x + t2.x) / 2 - rect.left + el.scrollLeft;
+  const cy = (t1.y + t2.y) / 2 - rect.top + el.scrollTop;
   const dist = Math.hypot(t2.x - t1.x, t2.y - t1.y);
   if (!lastTouchDistance) {
     lastTouchDistance = dist;
@@ -281,12 +288,34 @@ const positionStage = (center = false) => {
     offset.y += (targetY - offset.y) * strength;
   }
 };
+const normalizeOffset = () => {
+  const el = containerEl.value;
+  const maxScrollX = el.scrollWidth - el.clientWidth;
+  if (maxScrollX > 0) {
+    el.scrollLeft = clamp(el.scrollLeft - offset.x, 0, maxScrollX);
+    offset.x = 0;
+  } else {
+    const maxOffsetX = -maxScrollX;
+    offset.x = clamp(offset.x, 0, maxOffsetX);
+    el.scrollLeft = 0;
+  }
+  const maxScrollY = el.scrollHeight - el.clientHeight;
+  if (maxScrollY > 0) {
+    el.scrollTop = clamp(el.scrollTop - offset.y, 0, maxScrollY);
+    offset.y = 0;
+  } else {
+    const maxOffsetY = -maxScrollY;
+    offset.y = clamp(offset.y, 0, maxOffsetY);
+    el.scrollTop = 0;
+  }
+};
 const updateCanvasPosition = () => {
     const el = containerEl.value;
+    normalizeOffset();
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
-    const left = rect.left + parseFloat(style.paddingLeft);
-    const top = rect.top + parseFloat(style.paddingTop);
+    const left = rect.left + parseFloat(style.paddingLeft) - el.scrollLeft;
+    const top = rect.top + parseFloat(style.paddingTop) - el.scrollTop;
     stageStore.setCanvasPosition(left + offset.x, top + offset.y);
 };
 


### PR DESCRIPTION
## Summary
- Prevent negative overflow by syncing offset with scroll position
- Add scroll event handling and adjust zoom/pinch logic for scrolled containers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaa5c2557c832cbc45916d7846dd19