### PR TITLE
Add layer locking controls

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -10,7 +10,7 @@
       </div>
       <!-- 색상 -->
       <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :value="rgbaToHexU32(layers.colorOf(id))" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(id, $event)" @change.stop="onColorChange()" title="색상 변경" />
+        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed opacity-50': layers.lockedOf(id) }" :disabled="layers.lockedOf(id)" :value="rgbaToHexU32(layers.colorOf(id))" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(id, $event)" @change.stop="onColorChange()" title="색상 변경" />
       </div>
       <!-- 이름/픽셀 -->
       <div class="min-w-0 flex-1">
@@ -31,10 +31,13 @@
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
           <img :src="(layers.visibilityOf(id)?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
         </div>
+        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+          <img :src="(layers.lockedOf(id)?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(id)" />
+        </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
           <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(id)" />
         </div>
-      </div>
+        </div>
     </div>
     <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
@@ -66,6 +69,8 @@ const listElement = ref(null);
 const icons = reactive({
     show: 'image/layer_block/show.svg',
     hide: 'image/layer_block/hide.svg',
+    lock: 'image/layer_block/locked.svg',
+    unlock: 'image/layer_block/unlocked.svg',
     del: 'image/layer_block/delete.svg'
 });
 
@@ -161,6 +166,7 @@ function onColorDown() {
 }
 
 function onColorInput(id, event) {
+    if (layers.lockedOf(id)) return;
     const colorU32 = hexToRgbaU32(event.target.value);
     selection.isSelected(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.updateLayer(id, { colorU32 });
 }
@@ -173,6 +179,13 @@ function toggleVisibility(id) {
     output.setRollbackPoint();
     if (selection.isSelected(id)) layerSvc.setVisibilityForSelected(!layers.visibilityOf(id));
     else layers.toggleVisibility(id);
+    output.commit();
+}
+
+function toggleLock(id) {
+    output.setRollbackPoint();
+    if (selection.isSelected(id)) layerSvc.setLockedForSelected(!layers.lockedOf(id));
+    else layers.toggleLock(id);
     output.commit();
 }
 

--- a/src/domain/Layer.js
+++ b/src/domain/Layer.js
@@ -6,10 +6,12 @@ export class Layer {
         name,
         colorU32,
         visible,
+        locked,
         pixels
     } = {}) {
         this.name = name || 'Layer';
         this.visible = visible ?? true;
+        this.locked = locked ?? false;
         this._color = (colorU32 >>> 0) || randColorU32();
 
         const keyedPixels = pixels ? pixels.map(p => coordsToKey(p[0], p[1])) : [];
@@ -72,6 +74,7 @@ export class Layer {
         return {
             name: this.name,
             visible: this.visible,
+            locked: this.locked,
             color: this._color >>> 0,
             pixels: [...this._pixels].map(s => keyToCoords(s))
         };
@@ -81,6 +84,7 @@ export class Layer {
             name: data.name,
             colorU32: data.color >>> 0,
             visible: !!data.visible,
+            locked: !!data.locked,
             pixels: data.pixels
         });
     }

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -16,7 +16,14 @@ export const useLayerService = defineStore('layerService', () => {
 
     function setColorForSelectedU32(colorU32) {
         for (const id of selection.ids) {
+            if (layers.lockedOf(id)) continue;
             layers.updateLayer(id, { colorU32 });
+        }
+    }
+
+    function setLockedForSelected(isLocked) {
+        for (const id of selection.ids) {
+            layers.updateLayer(id, { locked: isLocked });
         }
     }
 
@@ -180,6 +187,7 @@ export const useLayerService = defineStore('layerService', () => {
     return {
         forEachSelected,
         setColorForSelectedU32,
+        setLockedForSelected,
         setVisibilityForSelected,
         deleteSelected,
         reorderGroup,

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -113,24 +113,28 @@ export const usePixelService = defineStore('pixelService', () => {
     function addPixelsToSelection(pixels) {
         if (selection.count !== 1) return;
         const id = selection.ids[0];
+        if (layers.lockedOf(id)) return;
         layers.addPixels(id, pixels);
     }
 
     function removePixelsFromSelection(pixels) {
         if (selection.count !== 1) return;
         const id = selection.ids[0];
+        if (layers.lockedOf(id)) return;
         layers.removePixels(id, pixels);
     }
 
     function togglePointInSelection(x, y) {
         if (selection.count !== 1) return;
         const id = selection.ids[0];
+        if (layers.lockedOf(id)) return;
         layers.togglePixel(id, x, y);
     }
 
     function removePixelsFromSelected(pixels) {
         if (!pixels || !pixels.length) return;
         layerSvc.forEachSelected((layer, id) => {
+            if (layer.locked) return;
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (layer.has(x, y)) pixelsToRemove.push([x, y]);
@@ -143,7 +147,7 @@ export const usePixelService = defineStore('pixelService', () => {
         if (!pixels || !pixels.length) return;
         for (const id of layers.order) {
             const layer = layers.getLayer(id);
-            if (!layer) continue;
+            if (!layer || layer.locked) continue;
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (layer.has(x, y)) pixelsToRemove.push([x, y]);


### PR DESCRIPTION
## Summary
- Add lock toggle in layer panel with new icons and disabled color picker when locked
- Prevent pixel and color edits on locked layers and skip them during canvas selection
- Extend layer model, store, and services to support lock state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aacc657d10832cadc239d466b75e3f