### PR TITLE
feat: add layer lock state management

### DIFF
--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -45,6 +45,7 @@ export const useLayerStore = defineStore('layers', {
         colorOf: (state) => (id) => state._layersById[id]?.getColorU32() ?? 0,
         nameOf: (state) => (id) => state._layersById[id]?.name,
         visibilityOf: (state) => (id) => !!state._layersById[id]?.visible,
+        lockedOf: (state) => (id) => !!state._layersById[id]?.locked,
         pixelCountOf: (state) => (id) => state._layersById[id]?.pixelCount ?? 0,
         disconnectedCountOf: (state) => (id) => state._layersById[id]?.disconnectedCount ?? 0,
         compositeColorAt: (state) => (x, y) => {
@@ -100,10 +101,15 @@ export const useLayerStore = defineStore('layers', {
             if (props.name !== undefined) layer.name = props.name;
             if (props.colorU32 !== undefined) layer.setColorU32(props.colorU32);
             if (props.visible !== undefined) layer.visible = !!props.visible;
+            if (props.locked !== undefined) layer.locked = !!props.locked;
         },
         toggleVisibility(id) {
             const layer = this._layersById[id];
             if (layer) layer.visible = !layer.visible;
+        },
+        toggleLock(id) {
+            const layer = this._layersById[id];
+            if (layer) layer.locked = !layer.locked;
         },
         addPixels(id, pixels) {
             const layer = this._layersById[id];


### PR DESCRIPTION
## Summary
- expose `lockedOf` getter in layer store
- handle `locked` updates and add `toggleLock` action

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f8fa6e0832cb12201b2ae250e06