### PR TITLE
feat: centralize stage events

### DIFF
--- a/src/stores/stageEvent.js
+++ b/src/stores/stageEvent.js
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia';
+
+export const useStageEventStore = defineStore('stageEvent', {
+  state: () => ({
+    pointer: {
+      down: null,
+      move: null,
+      up: [],
+    },
+    wheel: null,
+  }),
+  actions: {
+    pointerDown(event) {
+      this.pointer.down = event;
+    },
+    pointerMove(event) {
+      this.pointer.move = event;
+    },
+    pointerUp(event) {
+      this.pointer.up = [event];
+    },
+    wheelEvent(event) {
+      this.wheel = event;
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add stageEvent store to hold pointer and wheel events
- refactor Stage component to reactively consume stageEvent store

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab445f2f8c832c85c350011b5a86fc