### PR TITLE
feat: add stage event store

### DIFF
--- a/src/stores/stageEvent.js
+++ b/src/stores/stageEvent.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia';
+
+export const useStageEventStore = defineStore('stageEvent', {
+    state: () => ({
+        pointer: {
+            down: [],
+            move: null,
+            up: null,
+        },
+        wheel: null,
+    }),
+    getters: {
+        lastPointerDown: (state) => state.pointer.down[state.pointer.down.length - 1],
+    },
+    actions: {
+        addPointerDown(event) {
+            this.pointer.down.push(event);
+        },
+        setPointerMove(event) {
+            this.pointer.move = event;
+        },
+        setPointerUp(event) {
+            this.pointer.up = event;
+            this.pointer.down = this.pointer.down.filter(e => e.pointerId !== event.pointerId);
+        },
+        setWheel(event) {
+            this.wheel = event;
+        },
+    },
+});


### PR DESCRIPTION
## Summary
- add stage event store to track pointer and wheel events
- refactor Stage component to dispatch events to the store and react via watchers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab47b7aae4832ca56404870c1cd5b0