### PR TITLE
Add cut tool getter to stores

### DIFF
--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -39,6 +39,7 @@ export const useToolStore = defineStore('tool', {
         isErase() { return this.expected === 'erase'; },
         isSelect() { return this.expected === 'select'; },
         isGlobalErase() { return this.expected === 'globalErase'; },
+        isCut() { return this.expected === 'cut'; },
         isStroke: (state) => state.shape === 'stroke',
         isRect: (state) => state.shape === 'rect',
     },


### PR DESCRIPTION
## Summary
- Add `isCut` getter to tool store so cut tool functionality works

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab4c119e50832cad6c5d16c8e02f0f