### PR TITLE
feat: extract overlay tasks into service

### DIFF
--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -1,0 +1,71 @@
+import { defineStore } from 'pinia';
+import { computed, reactive, ref } from 'vue';
+import { useToolStore } from '../stores/tool';
+import { useLayerStore } from '../stores/layers';
+import { pixelsToUnionPath, getPixelUnionSet } from '../utils';
+
+export const useOverlayService = defineStore('overlayService', () => {
+    const toolStore = useToolStore();
+    const layers = useLayerStore();
+
+    const hoverLayerId = ref(null);
+    const selectOverlayLayerIds = reactive(new Set());
+
+    const selectOverlayPath = computed(() => {
+        if (!selectOverlayLayerIds.size) return '';
+        const pixelUnionSet = getPixelUnionSet(layers.getLayers(selectOverlayLayerIds));
+        return pixelsToUnionPath(pixelUnionSet);
+    });
+
+    const hoverOverlayPath = computed(() => {
+        return hoverLayerId.value != null ? layers.pathOf(hoverLayerId.value) : '';
+    });
+
+    function setHover(id) {
+        hoverLayerId.value = id;
+    }
+
+    function clearHover() {
+        hoverLayerId.value = null;
+    }
+
+    function add(id) {
+        if (id == null) return;
+        selectOverlayLayerIds.add(id);
+    }
+
+    function clear() {
+        selectOverlayLayerIds.clear();
+    }
+
+    function addByMode(id) {
+        if (id == null) return;
+        const mode = toolStore.pointer.status;
+        if (mode === 'remove') {
+            if (layers.isSelected(id)) add(id);
+        } else if (mode === 'add') {
+            if (!layers.isSelected(id)) add(id);
+        } else {
+            add(id);
+        }
+    }
+
+    function setFromIntersected(ids) {
+        clear();
+        for (const id of ids) {
+            addByMode(id);
+        }
+    }
+
+    return {
+        hoverLayerId,
+        hoverOverlayPath,
+        selectOverlayPath,
+        setHover,
+        clearHover,
+        add,
+        clear,
+        addByMode,
+        setFromIntersected,
+    };
+});

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { useStageService } from './stage';
+import { useOverlayService } from './overlay';
 import { useToolStore } from '../stores/tool';
 import { useLayerStore } from '../stores/layers';
 import { useLayerService } from './layers';
@@ -9,6 +10,7 @@ import { coordsToKey } from '../utils';
 
 export const usePixelService = defineStore('pixelService', () => {
     const stage = useStageService();
+    const overlay = useOverlayService();
     const toolStore = useToolStore();
     const layers = useLayerStore();
     const layerSvc = useLayerService();
@@ -33,7 +35,7 @@ export const usePixelService = defineStore('pixelService', () => {
                 colorU32: srcLayer.getColorU32(),
                 visible: srcLayer.visible,
             }, sourceId);
-            toolStore.selectOverlayLayerIds.add(cutLayerId);
+            overlay.add(cutLayerId);
         }
 
         toolStore.pointer.status = toolStore.expected;
@@ -131,7 +133,7 @@ export const usePixelService = defineStore('pixelService', () => {
         toolStore.pointer.id = null;
         toolStore.pointer.start = null;
         toolStore.visited.clear();
-        toolStore.selectOverlayLayerIds.clear();
+        overlay.clear();
         cutLayerId = null;
     }
 

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue';
 import { useStageStore } from '../stores/stage';
 import { useToolStore } from '../stores/tool';
 import { useLayerStore } from '../stores/layers';
-import { keyToCoords, pixelsToUnionPath, clamp, getPixelUnionSet } from '../utils';
+import { useOverlayService } from './overlay';
+import { keyToCoords, clamp } from '../utils';
 import { CURSOR_CONFIG } from '../constants';
 
 export const useStageService = defineStore('stageService', () => {
@@ -11,13 +12,7 @@ export const useStageService = defineStore('stageService', () => {
     const stageStore = useStageStore();
     const toolStore = useToolStore();
     const layers = useLayerStore();
-
-    // --- Overlay Paths ---
-    const selectOverlayPath = computed(() => {
-        if (!toolStore.selectOverlayLayerIds.size) return '';
-        const pixelUnionSet = getPixelUnionSet(layers.getLayers(toolStore.selectOverlayLayerIds));
-        return pixelsToUnionPath(pixelUnionSet);
-    });
+    const overlay = useOverlayService();
 
     // --- Canvas Utilities ---
     function recalcMinScale(container) {
@@ -136,7 +131,7 @@ export const useStageService = defineStore('stageService', () => {
         const shape = toolStore.shape;
 
         if (tool === 'select') {
-            const isRemoving = toolStore.shiftHeld && layers.isSelected(toolStore.hoverLayerId);
+            const isRemoving = toolStore.shiftHeld && layers.isSelected(overlay.hoverLayerId);
             if (shape === 'stroke') {
                 return isRemoving ? CURSOR_CONFIG.REMOVE_STROKE : CURSOR_CONFIG.ADD_STROKE;
             }
@@ -157,7 +152,6 @@ export const useStageService = defineStore('stageService', () => {
 
     return {
         // interaction state
-        selectOverlayPath,
         cursor,
         // methods
         recalcMinScale,

--- a/src/stores/tool.js
+++ b/src/stores/tool.js
@@ -12,8 +12,6 @@ export const useToolStore = defineStore('tool', {
             start: null,
             id: null,
         },
-        hoverLayerId: null,
-        selectOverlayLayerIds: new Set(),
         visited: new Set(),
     }),
     getters: {


### PR DESCRIPTION
## Summary
- centralize hover and selection overlay IDs inside `overlayService`
- update stage and select tools to read hover state from overlay service
- drop obsolete hover/selection overlay state from tool store

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4db56598832c92a406a74d47ced1