### PR TITLE
refactor: extract layer query service

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,7 @@ import { useLayerPanelStore } from './stores/layerPanel';
 import { useLayerService } from './services/layers';
 import { useSelectService } from './services/select';
 import { useOutputStore } from './stores/output';
+import { useQueryService } from './services/query';
 
 import StageToolbar from './components/StageToolbar.vue';
 import Stage from './components/Stage.vue';
@@ -57,6 +58,7 @@ const layerSvc = useLayerService();
 const selectSvc = useSelectService();
 const output = useOutputStore();
 const stageToolbar = ref(null);
+const query = useQueryService();
 
 // Width control between display and layers
 const container = ref(null);
@@ -104,11 +106,11 @@ function onKeydown(event) {
       if (!layers.exists) return;
       if (shift && !ctrl) {
         if (!layers.selectionExists) return;
-        const newTail = layers.aboveId(layerPanel.tailId) ?? layers.uppermostId;
+        const newTail = query.aboveId(layerPanel.tailId) ?? query.uppermostId;
         selectSvc.selectRange(layerPanel.anchorId, newTail);
         layerPanel.setScrollRule({ type: 'follow-up', target: newTail });
       } else if (!ctrl) {
-        const nextId = layers.aboveId(layerPanel.anchorId) ?? layerPanel.anchorId;
+        const nextId = query.aboveId(layerPanel.anchorId) ?? layerPanel.anchorId;
         layerPanel.setRange(nextId, nextId);
         layerPanel.setScrollRule({ type: 'follow-up', target: nextId });
       }
@@ -118,11 +120,11 @@ function onKeydown(event) {
       if (!layers.exists) return;
       if (shift && !ctrl) {
         if (!layers.selectionExists) return;
-        const newTail = layers.belowId(layerPanel.tailId) ?? layers.lowermostId;
+        const newTail = query.belowId(layerPanel.tailId) ?? query.lowermostId;
         selectSvc.selectRange(layerPanel.anchorId, newTail);
         layerPanel.setScrollRule({ type: 'follow-down', target: newTail });
       } else if (!ctrl) {
-        const nextId = layers.belowId(layerPanel.anchorId) ?? layerPanel.anchorId;
+        const nextId = query.belowId(layerPanel.anchorId) ?? layerPanel.anchorId;
         layerPanel.setRange(nextId, nextId);
         layerPanel.setScrollRule({ type: 'follow-down', target: nextId });
       }
@@ -132,9 +134,9 @@ function onKeydown(event) {
       event.preventDefault();
       if (!layers.selectionExists) return;
       output.setRollbackPoint();
-      const belowId = layers.belowId(layers.lowermostIdOf(layers.selectedIds));
+      const belowId = query.belowId(query.lowermostIdOf(layers.selectedIds));
       layerSvc.deleteSelected();
-      const newSelect = layers.has(belowId) ? belowId : layers.lowermostId;
+      const newSelect = layers.has(belowId) ? belowId : query.lowermostId;
       layerPanel.setRange(newSelect, newSelect);
       layerPanel.setScrollRule({ type: "follow", target: newSelect });
       output.commit();
@@ -163,9 +165,9 @@ function onKeydown(event) {
   if (ctrl) {
     if (key === 'a') {
       event.preventDefault();
-      const anchor = layers.uppermostId, tail = layers.lowermostId;
-      layers.replaceSelection(layers.order);
-      layerPanel.setRange(anchor, tail);
+        const anchor = query.uppermostId, tail = query.lowermostId;
+        layers.replaceSelection(layers.order);
+        layerPanel.setRange(anchor, tail);
     } else if (key === 'z' && !shift) {
       event.preventDefault();
       output.undo();

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="stageStore.display!=='result'" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="stageStore.canvas.width" :height="stageStore.canvas.height" :fill="patternUrl"/>
         <g>
-          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
+            <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -39,7 +39,7 @@
         </div>
         </div>
     </div>
-    <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
+      <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>
 
@@ -52,6 +52,7 @@ import { useLayerPanelStore } from '../stores/layerPanel';
 import { useLayerService } from '../services/layers';
 import { useSelectService } from '../services/select';
 import { useOutputStore } from '../stores/output';
+import { useQueryService } from '../services/query';
 import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, coordsToKey, clamp } from '../utils';
 
 const stageStore = useStageStore();
@@ -61,6 +62,7 @@ const layerPanel = useLayerPanelStore();
 const layerSvc = useLayerService();
 const selectSvc = useSelectService();
 const output = useOutputStore();
+const query = useQueryService();
 
 const dragging = ref(false);
 const dragId = ref(null);
@@ -193,9 +195,9 @@ function toggleLock(id) {
 function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = layers.isSelected(id) ? layers.selectedIds : [id];
-    const belowId = layers.belowId(layers.lowermostIdOf(targets));
+    const belowId = query.belowId(query.lowermostIdOf(targets));
     layers.deleteLayers(targets);
-    const newSelectId = layers.has(belowId) ? belowId : layers.lowermostId;
+    const newSelectId = layers.has(belowId) ? belowId : query.lowermostId;
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
         layerPanel.setScrollRule({

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -24,18 +24,20 @@ import { useLayerService } from '../services/layers';
 import { useOutputStore } from '../stores/output';
 import { useLayerPanelStore } from '../stores/layerPanel';
 import { computed } from 'vue';
+import { useQueryService } from '../services/query';
 
 const layers = useLayerStore();
 const layerSvc = useLayerService();
 const output = useOutputStore();
 const layerPanel = useLayerPanelStore();
+const query = useQueryService();
 
 const hasEmptyLayers = computed(() => layers.order.some(id => layers.pixelCountOf(id) === 0));
 const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnectedCountOf(id) > 1));
 
 const onAdd = () => {
     output.setRollbackPoint();
-    const above = layers.selectionCount ? layers.uppermostIdOf(layers.selectedIds) : null;
+    const above = layers.selectionCount ? query.uppermostIdOf(layers.selectedIds) : null;
     const id = layers.createLayer({});
     if (above !== null) {
         layers.reorderLayers([id], above, false);

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -27,7 +27,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="stageStore.display==='result'" class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
         <g>
-          <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
+            <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -1,11 +1,13 @@
 import { defineStore } from 'pinia';
 import { useLayerStore } from '../stores/layers';
 import { useLayerPanelStore } from '../stores/layerPanel';
+import { useQueryService } from './query';
 import { keyToCoords, buildOutline, findPixelComponents, getPixelUnionSet } from '../utils';
 
 export const useLayerService = defineStore('layerService', () => {
     const layers = useLayerStore();
     const layerPanel = useLayerPanelStore();
+    const query = useQueryService();
 
     function forEachSelected(fn) {
         for (const id of layers.selectedIds) {
@@ -77,7 +79,7 @@ export const useLayerService = defineStore('layerService', () => {
         const newLayerId = layers.createLayer({ name: `Merged ${anchorName}`, colorU32 });
         const layer = layers.getLayer(newLayerId);
         for (const k of pixelUnionSet) layer.addPixels([keyToCoords(k)]);
-        layers.reorderLayers([newLayerId], layers.lowermostIdOf(layers.selectedIds), true);
+        layers.reorderLayers([newLayerId], query.lowermostIdOf(layers.selectedIds), true);
         deleteSelected();
         return newLayerId;
     }

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia';
+import { computed } from 'vue';
+import { useLayerStore } from '../stores/layers';
+
+export const useQueryService = defineStore('queryService', () => {
+    const layers = useLayerStore();
+
+    const uppermostId = computed(() => {
+        const order = layers.idsBottomToTop;
+        return order[order.length - 1] ?? null;
+    });
+    const lowermostId = computed(() => layers.idsBottomToTop[0] ?? null);
+
+    function uppermostIdOf(ids) {
+        const idSet = new Set(ids);
+        if (!idSet.size) return null;
+        const order = layers.idsBottomToTop;
+        const index = Math.max(...order.map((id, idx) => idSet.has(id) ? idx : -1));
+        return index >= 0 ? order[index] : null;
+    }
+
+    function lowermostIdOf(ids) {
+        const idSet = new Set(ids);
+        if (!idSet.size) return null;
+        const order = layers.idsBottomToTop;
+        const index = Math.min(...order.map((id, idx) => idSet.has(id) ? idx : Infinity));
+        return isFinite(index) ? order[index] : null;
+    }
+
+    function aboveId(id) {
+        if (id == null) return null;
+        const order = layers.idsBottomToTop;
+        const idx = order.indexOf(id);
+        return order[idx + 1] ?? null;
+    }
+
+    function belowId(id) {
+        if (id == null) return null;
+        const order = layers.idsBottomToTop;
+        const idx = order.indexOf(id);
+        return order[idx - 1] ?? null;
+    }
+
+    return {
+        uppermostId,
+        lowermostId,
+        uppermostIdOf,
+        lowermostIdOf,
+        aboveId,
+        belowId,
+    };
+});
+

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -15,33 +15,9 @@ export const useLayerStore = defineStore('layers', {
         layersById: (state) => shallowReadonly(state._layersById),
         has: (state) => (id) => state._layersById[id] != null,
         count: (state) => state._order.length,
+        idsBottomToTop: (state) => readonly(state._order.slice()),
+        idsTopToBottom: (state, getters) => readonly(getters.idsBottomToTop.slice().reverse()),
         indexOfLayer: (state) => (id) => state._order.indexOf(id),
-        idsBottomToTop: (state) => state._order.slice(),
-        idsTopToBottom: (state) => state._order.slice().reverse(),
-        uppermostId: (state) => state._order[state._order.length - 1] ?? null,
-        lowermostId: (state) => state._order[0] ?? null,
-        uppermostIdOf: (state) => (ids) => {
-            const idSet = new Set(ids);
-            if (!idSet.size) return null;
-            const index = Math.max(...state._order.map((id, idx) => idSet.has(id) ? idx : -1));
-            return index >= 0 ? state._order[index] : null;
-        },
-        lowermostIdOf: (state) => (ids) => {
-            const idSet = new Set(ids);
-            if (!idSet.size) return null;
-            const index = Math.min(...state._order.map((id, idx) => idSet.has(id) ? idx : Infinity));
-            return isFinite(index) ? state._order[index] : null;
-        },
-        aboveId: (state) => (id) => {
-            if (id == null) return null;
-            const idx = state._order.indexOf(id);
-            return state._order[idx + 1] ?? null;
-        },
-        belowId: (state) => (id) => {
-            if (id == null) return null;
-            const idx = state._order.indexOf(id);
-            return state._order[idx - 1] ?? null;
-        },
         pathOf: (state) => (id) => state._layersById[id]?.d,
         colorOf: (state) => (id) => state._layersById[id]?.getColorU32() ?? 0,
         nameOf: (state) => (id) => state._layersById[id]?.name,


### PR DESCRIPTION
## Summary
- move layer order queries from layer store to dedicated query service
- update components and services to consume query service
- keep id order getters (`idsBottomToTop`, `idsTopToBottom`) within the layer store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abccbf8060832c9d4704ae75d7177d