### PR TITLE
refactor: reuse utility helpers instead of manual math

### DIFF
--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -49,14 +49,15 @@ export const usePixelService = defineStore('pixelService', () => {
         } else {
             toolStore.visited.clear();
             toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
+            const pixels = stage.getPixelsFromInteraction(event);
 
             if (toolStore.isGlobalErase) {
-                if (layers.selectionExists) removePixelsFromSelected([[pixel.x, pixel.y]]);
-                else removePixelsFromAll([[pixel.x, pixel.y]]);
+                if (layers.selectionExists) removePixelsFromSelected(pixels);
+                else removePixelsFromAll(pixels);
             } else if (toolStore.isDraw || toolStore.isErase || toolStore.isCut) {
-                if (toolStore.isErase) removePixelsFromSelection([[pixel.x, pixel.y]]);
-                else if (toolStore.isCut) cutPixelsFromSelection([[pixel.x, pixel.y]]);
-                else addPixelsToSelection([[pixel.x, pixel.y]]);
+                if (toolStore.isErase) removePixelsFromSelection(pixels);
+                else if (toolStore.isCut) cutPixelsFromSelection(pixels);
+                else addPixelsToSelection(pixels);
             }
         }
     }

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -1,17 +1,15 @@
 import { defineStore } from 'pinia';
 import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
-import { useStageStore } from '../stores/stage';
 import { useToolStore } from '../stores/tool';
 import { useLayerStore } from '../stores/layers';
 import { useOutputStore } from '../stores/output';
 import { useLayerPanelService } from './layerPanel';
-import { coordsToKey, calcMarquee } from '../utils';
+import { coordsToKey } from '../utils';
 
 export const useSelectService = defineStore('selectService', () => {
     const stage = useStageService();
     const overlay = useOverlayService();
-    const stageStore = useStageStore();
     const toolStore = useToolStore();
     const layers = useLayerStore();
     const output = useOutputStore();
@@ -56,17 +54,11 @@ export const useSelectService = defineStore('selectService', () => {
         if (toolStore.pointer.status === 'idle') return;
 
         if (toolStore.shape === 'rect') {
-            const { x, y, w, h } = calcMarquee(
-                toolStore.pointer.start,
-                { x: event.clientX, y: event.clientY },
-                stageStore.canvas
-            );
+            const pixels = stage.getPixelsFromInteraction(event);
             const intersectedIds = new Set();
-            for (let yy = y; yy < y + h; yy++) {
-                for (let xx = x; xx < x + w; xx++) {
-                    const id = layers.topVisibleIdAt(xx, yy);
-                    if (id !== null) intersectedIds.add(id);
-                }
+            for (const [xx, yy] of pixels) {
+                const id = layers.topVisibleIdAt(xx, yy);
+                if (id !== null) intersectedIds.add(id);
             }
             overlay.setFromIntersected(intersectedIds);
         } else {


### PR DESCRIPTION
## Summary
- use `averageColorU32` when computing segment colors
- replace ad hoc rectangle math with `calcMarquee`
- reuse stage's `getPixelsFromInteraction` across selection and pixel services
- lean on input store helpers for segmentation instead of hand-rolled bounds/index math

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abea20d108832c9aa296df41c6fcc3