### PR TITLE
refactor: remove forEachSelected from layer service

### DIFF
--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -9,12 +9,6 @@ export const useLayerService = defineStore('layerService', () => {
     const layerPanel = useLayerPanelService();
     const query = useQueryService();
 
-    function forEachSelected(fn) {
-        for (const id of layers.selectedIds) {
-            fn(id);
-        }
-    }
-
     function setColorForSelectedU32(colorU32) {
         for (const id of layers.selectedIds) {
             if (layers.lockedOf(id)) continue;
@@ -56,9 +50,9 @@ export const useLayerService = defineStore('layerService', () => {
                 colors.push(layers.compositeColorAt(x, y));
             }
         } else {
-            forEachSelected(id => {
+            for (const id of layers.selectedIds) {
                 colors.push(layers.colorOf(id));
-            });
+            }
         }
         const colorU32 = averageColorU32(colors);
 
@@ -74,7 +68,7 @@ export const useLayerService = defineStore('layerService', () => {
     function copySelected() {
         if (!layers.selectionCount) return [];
         const newLayerIds = [];
-        forEachSelected((id) => {
+        for (const id of layers.selectedIds) {
             const newLayerId = layers.createLayer({
                 name: `Copy of ${layers.nameOf(id)}`,
                 colorU32: layers.colorOf(id),
@@ -82,7 +76,7 @@ export const useLayerService = defineStore('layerService', () => {
                 pixels: layers.snapshotPixels(id)
             }, id);
             newLayerIds.push(newLayerId);
-        });
+        }
         return newLayerIds;
     }
 
@@ -185,7 +179,6 @@ export const useLayerService = defineStore('layerService', () => {
     }
 
     return {
-        forEachSelected,
         setColorForSelectedU32,
         setLockedForSelected,
         setVisibilityForSelected,

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -3,7 +3,6 @@ import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
 import { useToolStore } from '../stores/tool';
 import { useLayerStore } from '../stores/layers';
-import { useLayerService } from './layers';
 import { useLayerPanelService } from './layerPanel';
 import { useOutputStore } from '../stores/output';
 import { coordsToKey } from '../utils';
@@ -13,7 +12,6 @@ export const usePixelService = defineStore('pixelService', () => {
     const overlay = useOverlayService();
     const toolStore = useToolStore();
     const layers = useLayerStore();
-    const layerSvc = useLayerService();
     const layerPanel = useLayerPanelService();
     const output = useOutputStore();
     let cutLayerId = null;
@@ -173,16 +171,16 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function removePixelsFromSelected(pixels) {
         if (!pixels || !pixels.length) return;
-        layerSvc.forEachSelected((id) => {
-            if (layers.lockedOf(id)) return;
+        for (const id of layers.selectedIds) {
+            if (layers.lockedOf(id)) continue;
             const set = layers.pixels[id];
-            if (!set) return;
+            if (!set) continue;
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (set.has(coordsToKey(x, y))) pixelsToRemove.push([x, y]);
             }
             if (pixelsToRemove.length) layers.removePixels(id, pixelsToRemove);
-        });
+        }
     }
 
     function removePixelsFromAll(pixels) {


### PR DESCRIPTION
## Summary
- refactor layer service by removing `forEachSelected`
- iterate directly over `selectedIds` in merge and copy helpers
- inline iteration for pixel removal and drop unused layer service import

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abf10fad30832caccec53b8363f870