### PR TITLE
refactor: centralize primitive constants

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -32,7 +32,7 @@
       </svg>
       <!-- 그리드 -->
       <svg class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
-        <g :stroke="'rgba(0,0,0,.18)'" :stroke-width="1/Math.max(1,stageStore.canvas.scale)">
+        <g :stroke="GRID_STROKE_COLOR" :stroke-width="1/Math.max(1,stageStore.canvas.scale)">
           <path v-for="x in (stageStore.canvas.width+1)" :key="'gx'+x" :d="'M '+(x-1)+' 0 V '+stageStore.canvas.height"></path>
           <path v-for="y in (stageStore.canvas.height+1)" :key="'gy'+y" :d="'M 0 '+(y-1)+' H '+stageStore.canvas.width"></path>
         </g>
@@ -85,7 +85,7 @@ import { usePixelService } from '../services/pixel';
 import { useStageEventStore } from '../stores/stageEvent';
 import { useViewportService } from '../services/viewport';
 import { rgbaCssU32, rgbaCssObj, calcMarquee } from '../utils';
-import { OVERLAY_CONFIG } from '../constants';
+import { OVERLAY_CONFIG, GRID_STROKE_COLOR } from '@/constants';
 
 const stageStore = useStageStore();
 const toolStore = useToolStore();

--- a/src/constants/cursor.js
+++ b/src/constants/cursor.js
@@ -1,27 +1,4 @@
-import cursorIcons from './image/stage_cursor';
-
-export const OVERLAY_CONFIG = {
-    SELECTED: {
-        FILL_COLOR: 'rgba(56, 189, 248, 0.1)',
-        STROKE_COLOR: 'rgba(56, 189, 248, 1.0)',
-        STROKE_WIDTH_SCALE: 3,
-    },
-    MARQUEE: {
-        FILL_COLOR: 'rgba(248, 229, 56, 0.0)',
-        STROKE_COLOR: 'rgba(248, 229, 56, 1.0)',
-        STROKE_WIDTH_SCALE: 1,
-    },
-    ADD: {
-        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
-        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
-        STROKE_WIDTH_SCALE: 2,
-    },
-    REMOVE: {
-        FILL_COLOR: 'rgba(248, 113, 113, 0.25)',
-        STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
-        STROKE_WIDTH_SCALE: 2,
-    }
-};
+import cursorIcons from '../image/stage_cursor';
 
 export const CURSOR_CONFIG = {
     DRAW_STROKE: `url("${cursorIcons.drawStroke}") 0 0, crosshair`,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,7 @@
+export * from './overlay';
+export * from './cursor';
+export * from './interaction';
+export * from './svg';
+export * from './stage';
+export * from './viewport';
+export * from './toolbar';

--- a/src/constants/interaction.js
+++ b/src/constants/interaction.js
@@ -1,0 +1,1 @@
+export const CTRL_TAP_THRESHOLD_MS = 200;

--- a/src/constants/overlay.js
+++ b/src/constants/overlay.js
@@ -1,0 +1,22 @@
+export const OVERLAY_CONFIG = {
+    SELECTED: {
+        FILL_COLOR: 'rgba(56, 189, 248, 0.1)',
+        STROKE_COLOR: 'rgba(56, 189, 248, 1.0)',
+        STROKE_WIDTH_SCALE: 3,
+    },
+    MARQUEE: {
+        FILL_COLOR: 'rgba(248, 229, 56, 0.0)',
+        STROKE_COLOR: 'rgba(248, 229, 56, 1.0)',
+        STROKE_WIDTH_SCALE: 1,
+    },
+    ADD: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+    },
+    REMOVE: {
+        FILL_COLOR: 'rgba(248, 113, 113, 0.25)',
+        STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+    }
+};

--- a/src/constants/stage.js
+++ b/src/constants/stage.js
@@ -1,0 +1,10 @@
+export const GRID_STROKE_COLOR = 'rgba(0,0,0,.18)';
+
+export const MIN_SCALE_RATIO = 0.5;
+
+export const CHECKERBOARD_CONFIG = {
+    PATTERN_ID: 'chk',
+    COLOR_A: '#0a1f33',
+    COLOR_B: '#0c2742',
+    REPEAT: 1,
+};

--- a/src/constants/svg.js
+++ b/src/constants/svg.js
@@ -1,0 +1,1 @@
+export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';

--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -1,0 +1,12 @@
+import stageIcons from '../image/stage_toolbar';
+
+export const SINGLE_SELECTION_TOOLS = [
+  { type: 'draw', name: 'Draw', icon: stageIcons.draw },
+  { type: 'erase', name: 'Erase', icon: stageIcons.erase },
+  { type: 'cut', name: 'Cut', icon: stageIcons.cut },
+];
+
+export const MULTI_SELECTION_TOOLS = [
+  { type: 'select', name: 'Select', icon: stageIcons.select },
+  { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
+];

--- a/src/constants/viewport.js
+++ b/src/constants/viewport.js
@@ -1,0 +1,3 @@
+export const WHEEL_ZOOM_IN_FACTOR = 1.1;
+export const WHEEL_ZOOM_OUT_FACTOR = 0.9;
+export const POSITION_LERP_EXPONENT = 2;

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -5,7 +5,7 @@ import { useToolStore } from '../stores/tool';
 import { useLayerStore } from '../stores/layers';
 import { useOverlayService } from './overlay';
 import { keyToCoords, getPixelUnionSet, pixelsToUnionPath, calcMarquee } from '../utils';
-import { CURSOR_CONFIG } from '../constants';
+import { CURSOR_CONFIG, SVG_NAMESPACE, CHECKERBOARD_CONFIG, MIN_SCALE_RATIO } from '@/constants';
 
 export const useStageService = defineStore('stageService', () => {
     // stores
@@ -41,55 +41,50 @@ export const useStageService = defineStore('stageService', () => {
             height / Math.max(1, stageStore.canvas.height)
         );
         stageStore.setContainScale(containScale);
-        const minScale = Math.max(1, containScale * 0.5);
+        const minScale = Math.max(1, containScale * MIN_SCALE_RATIO);
         stageStore.setMinScale(minScale);
     }
-    
-    const patternId = ref('chk');
-    const colorA = ref('#0a1f33');
-    const colorB = ref('#0c2742');
-    const checkerRepeat = ref(1);
+    const { PATTERN_ID, COLOR_A, COLOR_B, REPEAT } = CHECKERBOARD_CONFIG;
 
     function ensureCheckerboardPattern(target = document.body) {
-        const id = patternId.value;
+        const id = PATTERN_ID;
         if (document.getElementById(id)) return id;
-        const svgNamespace = 'http://www.w3.org/2000/svg';
-        const svg = document.createElementNS(svgNamespace, 'svg');
+        const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
         svg.setAttribute('width', '0');
         svg.setAttribute('height', '0');
         svg.style.position = 'absolute';
         svg.style.left = '-9999px';
-        const defs = document.createElementNS(svgNamespace, 'defs');
-        const pattern = document.createElementNS(svgNamespace, 'pattern');
+        const defs = document.createElementNS(SVG_NAMESPACE, 'defs');
+        const pattern = document.createElementNS(SVG_NAMESPACE, 'pattern');
         pattern.setAttribute('id', id);
-        const repeatSize = checkerRepeat.value
+        const repeatSize = REPEAT;
         pattern.setAttribute('width', String(repeatSize));
         pattern.setAttribute('height', String(repeatSize));
         pattern.setAttribute('patternUnits', 'userSpaceOnUse');
-        const r00 = document.createElementNS(svgNamespace, 'rect');
+        const r00 = document.createElementNS(SVG_NAMESPACE, 'rect');
         r00.setAttribute('x', '0');
         r00.setAttribute('y', '0');
         r00.setAttribute('width', String(repeatSize / 2));
         r00.setAttribute('height', String(repeatSize / 2));
-        r00.setAttribute('fill', colorA.value);
-        const r11 = document.createElementNS(svgNamespace, 'rect');
+        r00.setAttribute('fill', COLOR_A);
+        const r11 = document.createElementNS(SVG_NAMESPACE, 'rect');
         r11.setAttribute('x', String(repeatSize / 2));
         r11.setAttribute('y', String(repeatSize / 2));
         r11.setAttribute('width', String(repeatSize / 2));
         r11.setAttribute('height', String(repeatSize / 2));
-        r11.setAttribute('fill', colorA.value);
-        const r10 = document.createElementNS(svgNamespace, 'rect');
+        r11.setAttribute('fill', COLOR_A);
+        const r10 = document.createElementNS(SVG_NAMESPACE, 'rect');
         r10.setAttribute('x', String(repeatSize / 2));
         r10.setAttribute('y', '0');
         r10.setAttribute('width', String(repeatSize / 2));
         r10.setAttribute('height', String(repeatSize / 2));
-        r10.setAttribute('fill', colorB.value);
-        const r01 = document.createElementNS(svgNamespace, 'rect');
+        r10.setAttribute('fill', COLOR_B);
+        const r01 = document.createElementNS(SVG_NAMESPACE, 'rect');
         r01.setAttribute('x', '0');
         r01.setAttribute('y', String(repeatSize / 2));
         r01.setAttribute('width', String(repeatSize / 2));
         r01.setAttribute('height', String(repeatSize / 2));
-        r01.setAttribute('fill', colorB.value);
+        r01.setAttribute('fill', COLOR_B);
         pattern.appendChild(r00);
         pattern.appendChild(r11);
         pattern.appendChild(r10);

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { reactive, ref } from 'vue';
 import { useStageStore } from '../stores/stage';
 import { clamp } from '../utils';
+import { WHEEL_ZOOM_IN_FACTOR, WHEEL_ZOOM_OUT_FACTOR, POSITION_LERP_EXPONENT } from '@/constants';
 
 export const useViewportService = defineStore('viewportService', () => {
   const stageStore = useStageStore();
@@ -51,7 +52,7 @@ export const useViewportService = defineStore('viewportService', () => {
       const px = e.clientX - rect.left;
       const py = e.clientY - rect.top;
       const oldScale = stageStore.canvas.scale;
-      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      const factor = e.deltaY < 0 ? WHEEL_ZOOM_IN_FACTOR : WHEEL_ZOOM_OUT_FACTOR;
       const newScale = oldScale * factor;
       const clamped = Math.max(stageStore.canvas.minScale, newScale);
       const ratio = clamped / oldScale;
@@ -101,7 +102,7 @@ export const useViewportService = defineStore('viewportService', () => {
       offset.x = targetX;
       offset.y = targetY;
     } else {
-      const strength = (stageStore.canvas.minScale / stageStore.canvas.scale) ** 2;
+      const strength = (stageStore.canvas.minScale / stageStore.canvas.scale) ** POSITION_LERP_EXPONENT;
       offset.x += (targetX - offset.x) * strength;
       offset.y += (targetY - offset.y) * strength;
     }


### PR DESCRIPTION
## Summary
- Add `MIN_SCALE_RATIO`, zoom factors, and lerp exponent to central constants
- Destructure checkerboard config in stage service without reactive refs
- Use toolbar tool-set constants and drop reactive mutation for static options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abf3e955c8832ca097b38eb55d422e