### PR TITLE
Encapsulate layer properties and unify layer getters

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -180,7 +180,7 @@ onMounted(async () => {
       const segment = autoSegments[i];
       layers.createLayer({
         name: `Auto ${i+1}`,
-        colorU32: segment.colorU32,
+        color: segment.colorU32,
         visible: true,
         pixels: segment.pixels
       });

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="stageStore.display!=='result'" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="stageStore.canvas.width" :height="stageStore.canvas.height" :fill="patternUrl"/>
         <g>
-            <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
+            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visible?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,41 +1,41 @@
 <template>
   <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="id in layers.idsTopToBottom" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="id" :data-id="id" :class="{ selected: layers.isSelected(id), anchor: layerPanel.anchorId===id, dragging: dragId===id }" draggable="true" @click="layerPanel.onLayerClick(id,$event)" @dragstart="onDragStart(id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(id,$event)">
+    <div v-for="props in layers.getProperties(layers.idsTopToBottom)" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="props.id" :data-id="props.id" :class="{ selected: layers.isSelected(props.id), anchor: layerPanel.anchorId===props.id, dragging: dragId===props.id }" draggable="true" @click="layerPanel.onLayerClick(props.id,$event)" @dragstart="onDragStart(props.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(props.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(props.id,$event)">
       <!-- 썸네일 -->
-      <div @click.stop="onThumbnailClick(id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
+      <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
         <svg :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
           <rect x="0" y="0" :width="stageStore.canvas.width" :height="stageStore.canvas.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(id)" :fill="rgbaCssU32(layers.colorOf(id))" :opacity="layers.visibilityOf(id)?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visible?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
         </svg>
       </div>
       <!-- 색상 -->
       <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': layers.lockedOf(id) }" :disabled="layers.lockedOf(id)" :value="rgbaToHexU32(layers.colorOf(id))" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(id, $event)" @change.stop="onColorChange()" title="색상 변경" />
+        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': props.locked }" :disabled="props.locked" :value="rgbaToHexU32(props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(props.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
       </div>
       <!-- 이름/픽셀 -->
       <div class="min-w-0 flex-1">
         <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(id)" @keydown="onNameKey(id,$event)" @blur="finishRename(id,$event)">{{ layers.nameOf(id) }}</span>
+          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(props.id)" @keydown="onNameKey(props.id,$event)" @blur="finishRename(props.id,$event)">{{ props.name }}</span>
         </div>
         <div class="text-xs text-slate-400">
-          <template v-if="layers.disconnectedCountOf(id) > 1">
-            <span class="cursor-pointer" @click.stop="onDisconnectedClick(id)">⚠️</span>
-            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(id)">{{ layers.disconnectedCountOf(id) }} piece</span>
+          <template v-if="layers.disconnectedCountOf(props.id) > 1">
+            <span class="cursor-pointer" @click.stop="onDisconnectedClick(props.id)">⚠️</span>
+            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
             <span class="mx-1">|</span>
           </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(id)" title="같은 크기의 모든 레이어 선택">{{ layers.pixelCountOf(id) }} px</span>
+          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels?.size ?? 0 }} px</span>
         </div>
       </div>
       <!-- 액션 -->
       <div class="flex gap-1 justify-end">
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(layers.visibilityOf(id)?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(id)" />
+          <img :src="(props.visible?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-          <img :src="(layers.lockedOf(id)?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(id)" />
+          <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(id)" />
+          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(props.id)" />
         </div>
         </div>
     </div>
@@ -147,9 +147,9 @@ function onColorDown() {
 }
 
 function onColorInput(id, event) {
-    if (layers.lockedOf(id)) return;
+    if (layers.getProperty(id, 'locked')) return;
     const colorU32 = hexToRgbaU32(event.target.value);
-    layers.isSelected(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.updateLayer(id, { colorU32 });
+    layers.isSelected(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.updateProperties(id, { color: colorU32 });
 }
 
 function onColorChange() {
@@ -158,14 +158,14 @@ function onColorChange() {
 
 function toggleVisibility(id) {
     output.setRollbackPoint();
-    if (layers.isSelected(id)) layerSvc.setVisibilityForSelected(!layers.visibilityOf(id));
+    if (layers.isSelected(id)) layerSvc.setVisibilityForSelected(!layers.getProperty(id, 'visible'));
     else layers.toggleVisibility(id);
     output.commit();
 }
 
 function toggleLock(id) {
     output.setRollbackPoint();
-    if (layers.isSelected(id)) layerSvc.setLockedForSelected(!layers.lockedOf(id));
+    if (layers.isSelected(id)) layerSvc.setLockedForSelected(!layers.getProperty(id, 'locked'));
     else layers.toggleLock(id);
     output.commit();
 }
@@ -278,11 +278,11 @@ function startRename(id) {
 function finishRename(id, event) {
     const element = document.querySelector(`.layer[data-id="${id}"] .nameText`);
     element.contentEditable = false;
-    const oldName = layers.nameOf(id);
+    const oldName = layers.getProperty(id, 'name');
     const text = event.target.innerText.trim();
     editingId.value = null;
     if (text && text !== oldName) {
-        layers.updateLayer(id, { name: text });
+        layers.updateProperties(id, { name: text });
         output.commit();
     } else {
         event.target.innerText = oldName;
@@ -295,7 +295,7 @@ function finishRename(id, event) {
 }
 
 function onNameKey(id, event) {
-    const name = layers.nameOf(id);
+    const name = layers.getProperty(id, 'name');
     if (event.key === 'Enter') {
         event.preventDefault();
         event.target.blur();

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -33,7 +33,7 @@ const output = useOutputStore();
 const layerPanel = useLayerPanelService();
 const query = useQueryService();
 
-const hasEmptyLayers = computed(() => layers.order.some(id => layers.pixelCountOf(id) === 0));
+const hasEmptyLayers = computed(() => layers.order.some(id => (layers.getProperty(id, 'pixels')?.size ?? 0) === 0));
 const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnectedCountOf(id) > 1));
 
 const onAdd = () => {

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -27,7 +27,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="stageStore.display==='result'" class="absolute top-0 left-0 pointer-events-none block rounded-lg" :viewBox="stageStore.viewBox" preserveAspectRatio="xMidYMid meet" :style="{ width: stageStore.pixelWidth+'px', height: stageStore.pixelHeight+'px' }" style="image-rendering:pixelated">
         <g>
-            <path v-for="id in layers.idsBottomToTop" :key="'pix-'+id" :d="layers.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(layers.colorOf(id))" :visibility="layers.visibilityOf(id)?'visible':'hidden'"></path>
+            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visible?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->


### PR DESCRIPTION
## Summary
- Introduce `getProperty` getter in layer store for direct single-property access
- Refactor panels, toolbars, and services to use `getProperty` when only one layer field is needed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abfa85fffc832c97ece562a38f40e0