### PR TITLE
Expose aggregate Pinia hooks for stores and services

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,14 +32,8 @@
 
 <script setup>
 import { onMounted, ref, computed, onUnmounted } from 'vue';
-import { useInputStore } from './stores/input';
-import { useStageStore } from './stores/stage';
-import { useStageService } from './services/stage';
-import { useLayerStore } from './stores/layers';
-import { useLayerPanelService } from './services/layerPanel';
-import { useLayerService } from './services/layers';
-import { useOutputStore } from './stores/output';
-import { useQueryService } from './services/query';
+import { useStore } from './stores';
+import { useService } from './services';
 
 import StageToolbar from './components/StageToolbar.vue';
 import Stage from './components/Stage.vue';
@@ -48,15 +42,9 @@ import LayersToolbar from './components/LayersToolbar.vue';
 import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 
-const input = useInputStore();
-const stageStore = useStageStore();
-const stageService = useStageService();
-const layers = useLayerStore();
-const layerPanel = useLayerPanelService();
-const layerSvc = useLayerService();
-const output = useOutputStore();
+const { input, stage: stageStore, layers, output } = useStore();
+const { stage: stageService, layerPanel, layers: layerSvc, query } = useService();
 const stageToolbar = ref(null);
-const query = useQueryService();
 
 // Width control between display and layers
 const container = ref(null);

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -24,16 +24,12 @@
 
 <script setup>
 import { ref, computed, onMounted, nextTick } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useStageService } from '../services/stage';
-import { useLayerStore } from '../stores/layers';
-import { useOutputStore } from '../stores/output';
+import { useStore } from '../stores';
+import { useService } from '../services';
 import { rgbaCssU32 } from '../utils';
 
-const stageStore = useStageStore();
-const stageService = useStageService();
-const layers = useLayerStore();
-const output = useOutputStore();
+const { stage: stageStore, layers, output } = useStore();
+const { stage: stageService } = useService();
 const text = ref('');
 const textareaElement = ref(null);
 

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -45,23 +45,13 @@
 
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useStageService } from '../services/stage';
-import { useLayerStore } from '../stores/layers';
-import { useLayerPanelService } from '../services/layerPanel';
-import { useLayerService } from '../services/layers';
-import { useOutputStore } from '../stores/output';
-import { useQueryService } from '../services/query';
+import { useStore } from '../stores';
+import { useService } from '../services';
 import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, coordsToKey, clamp } from '../utils';
 import blockIcons from '../image/layer_block';
 
-const stageStore = useStageStore();
-const stageService = useStageService();
-const layers = useLayerStore();
-const layerPanel = useLayerPanelService();
-const layerSvc = useLayerService();
-const output = useOutputStore();
-const query = useQueryService();
+const { stage: stageStore, layers, output } = useStore();
+const { stage: stageService, layerPanel, layers: layerSvc, query } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -19,19 +19,13 @@
 </template>
 
 <script setup>
-import { useLayerStore } from '../stores/layers';
-import { useLayerService } from '../services/layers';
-import { useOutputStore } from '../stores/output';
-import { useLayerPanelService } from '../services/layerPanel';
+import { useStore } from '../stores';
+import { useService } from '../services';
 import { computed } from 'vue';
-import { useQueryService } from '../services/query';
 import toolbarIcons from '../image/layer_toolbar';
 
-const layers = useLayerStore();
-const layerSvc = useLayerService();
-const output = useOutputStore();
-const layerPanel = useLayerPanelService();
-const query = useQueryService();
+const { layers, output } = useStore();
+const { layers: layerSvc, layerPanel, query } = useService();
 
 const hasEmptyLayers = computed(() => layers.order.some(id => (layers.getProperty(id, 'pixels')?.size ?? 0) === 0));
 const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnectedCountOf(id) > 1));

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -73,31 +73,13 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted, onUnmounted, watch } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useToolStore } from '../stores/tool';
-import { useStageService } from '../services/stage';
-import { useOverlayService } from '../services/overlay';
-import { useLayerStore } from '../stores/layers';
-import { useLayerService } from '../services/layers';
-import { useInputStore } from '../stores/input';
-import { useSelectService } from '../services/select';
-import { usePixelService } from '../services/pixel';
-import { useStageEventStore } from '../stores/stageEvent';
-import { useViewportService } from '../services/viewport';
+import { useStore } from '../stores';
+import { useService } from '../services';
 import { rgbaCssU32, rgbaCssObj, calcMarquee } from '../utils';
 import { OVERLAY_CONFIG, GRID_STROKE_COLOR } from '@/constants';
 
-const stageStore = useStageStore();
-const toolStore = useToolStore();
-const stageService = useStageService();
-const overlay = useOverlayService();
-const stageEvents = useStageEventStore();
-const layers = useLayerStore();
-const layerSvc = useLayerService();
-const input = useInputStore();
-const selectSvc = useSelectService();
-const pixelSvc = usePixelService();
-const viewport = useViewportService();
+const { stage: stageStore, tool: toolStore, layers, input, stageEvent: stageEvents } = useStore();
+const { stage: stageService, overlay, layers: layerSvc, select: selectSvc, pixel: pixelSvc, viewport } = useService();
 const viewportEl = ref(null);
 const stageEl = ref(null);
 const marquee = reactive({ visible: false, x: 0, y: 0, w: 0, h: 0 });

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -10,12 +10,10 @@
 
 <script setup>
 import { computed } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 import { getPixelUnionSet } from '../utils';
 
-const stageStore = useStageStore();
-const layers = useLayerStore();
+const { stage: stageStore, layers } = useStore();
 const selectedAreaPixelCount = computed(() => {
     const pixelSet = getPixelUnionSet(layers, layers.selectedIds);
     return pixelSet.size;

--- a/src/components/StageToolbar.vue
+++ b/src/components/StageToolbar.vue
@@ -41,17 +41,11 @@
 
 <script setup>
 import { ref, watch } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useToolStore } from '../stores/tool';
-import { useLayerStore } from '../stores/layers';
-import { useOutputStore } from '../stores/output';
+import { useStore } from '../stores';
 import { CTRL_TAP_THRESHOLD_MS, SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
 
-const stageStore = useStageStore();
-const toolStore = useToolStore();
-const layers = useLayerStore();
-const output = useOutputStore();
+const { stage: stageStore, tool: toolStore, layers, output } = useStore();
 
 const selectables = ref(SINGLE_SELECTION_TOOLS);
 watch(() => layers.selectionCount, (size) => {

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,30 @@
+import { useLayerPanelService } from './layerPanel';
+import { useLayerService } from './layers';
+import { useOverlayService } from './overlay';
+import { usePixelService } from './pixel';
+import { useQueryService } from './query';
+import { useSelectService } from './select';
+import { useStageService } from './stage';
+import { useViewportService } from './viewport';
+
+export {
+    useLayerPanelService,
+    useLayerService,
+    useOverlayService,
+    usePixelService,
+    useQueryService,
+    useSelectService,
+    useStageService,
+    useViewportService
+};
+
+export const useService = () => ({
+    layerPanel: useLayerPanelService(),
+    layers: useLayerService(),
+    overlay: useOverlayService(),
+    pixel: usePixelService(),
+    query: useQueryService(),
+    select: useSelectService(),
+    stage: useStageService(),
+    viewport: useViewportService()
+});

--- a/src/services/layerPanel.js
+++ b/src/services/layerPanel.js
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import { reactive, toRefs, watch, computed } from 'vue';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 import { useQueryService } from './query';
 
 export const useLayerPanelService = defineStore('layerPanelService', () => {
-    const layers = useLayerStore();
+    const { layers } = useStore();
     const query = useQueryService();
 
     const state = reactive({

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 import { useLayerPanelService } from './layerPanel';
 import { useQueryService } from './query';
 import { keyToCoords, buildOutline, findPixelComponents, getPixelUnionSet, averageColorU32 } from '../utils';
 
 export const useLayerService = defineStore('layerService', () => {
-    const layers = useLayerStore();
+    const { layers } = useStore();
     const layerPanel = useLayerPanelService();
     const query = useQueryService();
 

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -1,12 +1,10 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
-import { useToolStore } from '../stores/tool';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 import { pixelsToUnionPath, getPixelUnionSet } from '../utils';
 
 export const useOverlayService = defineStore('overlayService', () => {
-    const toolStore = useToolStore();
-    const layers = useLayerStore();
+    const { tool: toolStore, layers } = useStore();
 
     const hoverLayerId = ref(null);
     const selectOverlayLayerIds = reactive(new Set());

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -1,19 +1,15 @@
 import { defineStore } from 'pinia';
 import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
-import { useToolStore } from '../stores/tool';
-import { useLayerStore } from '../stores/layers';
 import { useLayerPanelService } from './layerPanel';
-import { useOutputStore } from '../stores/output';
+import { useStore } from '../stores';
 import { coordsToKey } from '../utils';
 
 export const usePixelService = defineStore('pixelService', () => {
     const stage = useStageService();
     const overlay = useOverlayService();
-    const toolStore = useToolStore();
-    const layers = useLayerStore();
     const layerPanel = useLayerPanelService();
-    const output = useOutputStore();
+    const { tool: toolStore, layers, output } = useStore();
     let cutLayerId = null;
 
     function toolStart(event) {

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia';
 import { computed } from 'vue';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 
 export const useQueryService = defineStore('queryService', () => {
-    const layers = useLayerStore();
+    const { layers } = useStore();
 
     const uppermostId = computed(() => {
         const order = layers.idsBottomToTop;

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -1,19 +1,15 @@
 import { defineStore } from 'pinia';
 import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
-import { useToolStore } from '../stores/tool';
-import { useLayerStore } from '../stores/layers';
-import { useOutputStore } from '../stores/output';
 import { useLayerPanelService } from './layerPanel';
+import { useStore } from '../stores';
 import { coordsToKey } from '../utils';
 
 export const useSelectService = defineStore('selectService', () => {
     const stage = useStageService();
     const overlay = useOverlayService();
-    const toolStore = useToolStore();
-    const layers = useLayerStore();
-    const output = useOutputStore();
     const layerPanel = useLayerPanelService();
+    const { tool: toolStore, layers, output } = useStore();
 
     function toolStart(event) {
         if (event.button !== 0) return;

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -1,17 +1,13 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
-import { useStageStore } from '../stores/stage';
-import { useToolStore } from '../stores/tool';
-import { useLayerStore } from '../stores/layers';
+import { useStore } from '../stores';
 import { useOverlayService } from './overlay';
 import { keyToCoords, getPixelUnionSet, pixelsToUnionPath, calcMarquee } from '../utils';
 import { CURSOR_CONFIG, SVG_NAMESPACE, CHECKERBOARD_CONFIG, MIN_SCALE_RATIO } from '@/constants';
 
 export const useStageService = defineStore('stageService', () => {
     // stores
-    const stageStore = useStageStore();
-    const toolStore = useToolStore();
-    const layers = useLayerStore();
+    const { stage: stageStore, tool: toolStore, layers } = useStore();
     const overlay = useOverlayService();
     // stage element reference
     const element = ref(null);

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia';
 import { reactive, ref } from 'vue';
-import { useStageStore } from '../stores/stage';
+import { useStore } from '../stores';
 import { clamp } from '../utils';
 import { WHEEL_ZOOM_IN_FACTOR, WHEEL_ZOOM_OUT_FACTOR, POSITION_LERP_EXPONENT } from '@/constants';
 
 export const useViewportService = defineStore('viewportService', () => {
-  const stageStore = useStageStore();
+  const { stage: stageStore } = useStore();
   const offset = reactive({ x: 0, y: 0 });
   const touches = new Map();
   const element = ref(null);

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,24 @@
+import { useInputStore } from './input';
+import { useLayerStore } from './layers';
+import { useOutputStore } from './output';
+import { useStageStore } from './stage';
+import { useStageEventStore } from './stageEvent';
+import { useToolStore } from './tool';
+
+export {
+    useInputStore,
+    useLayerStore,
+    useOutputStore,
+    useStageStore,
+    useStageEventStore,
+    useToolStore
+};
+
+export const useStore = () => ({
+    input: useInputStore(),
+    layers: useLayerStore(),
+    output: useOutputStore(),
+    stage: useStageStore(),
+    stageEvent: useStageEventStore(),
+    tool: useToolStore()
+});

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
-import { useLayerStore } from './layers';
+import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
-import { useInputStore } from './input';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -17,7 +16,7 @@ export const useOutputStore = defineStore('output', {
     },
     actions: {
         _apply(snapshot) {
-            const layers = useLayerStore();
+            const { layers } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
             layers.applySerialized(parsed.layersState);
@@ -47,7 +46,7 @@ export const useOutputStore = defineStore('output', {
             })
         },
         currentSnap() {
-            const layers = useLayerStore();
+            const { layers } = useStore();
             const layerPanel = useLayerPanelService();
             return JSON.stringify({
                 layersState: layers.serialize(),
@@ -82,7 +81,7 @@ export const useOutputStore = defineStore('output', {
             this._pendingRollback = null;
         },
         exportToJSON() {
-            const input = useInputStore();
+            const { input } = useStore();
             return `{
         "input": { "src": "${input.src || ''}", "size": { "w": ${input.width || 0}, "h": ${input.height || 0} } },
         "state": ${this.currentSnap()}


### PR DESCRIPTION
## Summary
- Refactor components to use centralized `useStore` and `useService` helpers
- Update services and stores to rely on new aggregate accessors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac01fe8410832c996ab0f8aa8be823