### PR TITLE
refactor: expose layer pixels as coordinates

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -23,7 +23,7 @@
             <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
             <span class="mx-1">|</span>
           </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels?.size ?? 0 }} px</span>
+          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels.length }} px</span>
         </div>
       </div>
       <!-- 액션 -->

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -33,7 +33,7 @@ const output = useOutputStore();
 const layerPanel = useLayerPanelService();
 const query = useQueryService();
 
-const hasEmptyLayers = computed(() => layers.order.some(id => (layers.getProperty(id, 'pixels')?.size ?? 0) === 0));
+const hasEmptyLayers = computed(() => layers.order.some(id => layers.getProperty(id, 'pixels').length === 0));
 const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnectedCountOf(id) > 1));
 
 const onAdd = () => {

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -17,7 +17,7 @@ import { getPixelUnionSet } from '../utils';
 const stageStore = useStageStore();
 const layers = useLayerStore();
 const selectedAreaPixelCount = computed(() => {
-    const pixelSet = getPixelUnionSet(layers, layers.selectedIds);
+    const pixelSet = getPixelUnionSet(layers.getProperties(layers.selectedIds));
     return pixelSet.size;
   });
 </script>

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -13,7 +13,7 @@ export const useOverlayService = defineStore('overlayService', () => {
 
     const selectOverlayPath = computed(() => {
         if (!selectOverlayLayerIds.size) return '';
-        const pixelUnionSet = getPixelUnionSet(layers, selectOverlayLayerIds);
+        const pixelUnionSet = getPixelUnionSet(layers.getProperties([...selectOverlayLayerIds]));
         return pixelsToUnionPath(pixelUnionSet);
     });
 

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -106,7 +106,7 @@ export const usePixelService = defineStore('pixelService', () => {
         }
 
         if (toolStore.isCut && cutLayerId != null) {
-            if ((layers.getProperty(cutLayerId, 'pixels')?.size ?? 0))
+            if (layers.getProperty(cutLayerId, 'pixels').length)
                 layerPanel.setRange(cutLayerId, cutLayerId);
             else
                 layers.deleteLayers([cutLayerId]);
@@ -152,8 +152,8 @@ export const usePixelService = defineStore('pixelService', () => {
     function cutPixelsFromSelection(pixels) {
         if (layers.selectionCount !== 1 || cutLayerId == null) return;
         const sourceId = layers.selectedIds[0];
-        const set = layers.getProperty(sourceId, 'pixels');
-        if (!set) return;
+        const coords = layers.getProperty(sourceId, 'pixels');
+        const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
         const pixelsToMove = [];
         for (const [x, y] of pixels) {
             if (set.has(coordsToKey(x, y))) pixelsToMove.push([x, y]);
@@ -175,8 +175,8 @@ export const usePixelService = defineStore('pixelService', () => {
         for (const id of layers.selectedIds) {
             const props = layers.getProperties(id);
             if (props.locked) continue;
-            const set = props.pixels;
-            if (!set) continue;
+            const coords = props.pixels;
+            const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (set.has(coordsToKey(x, y))) pixelsToRemove.push([x, y]);
@@ -190,8 +190,8 @@ export const usePixelService = defineStore('pixelService', () => {
         for (const id of layers.order) {
             const props = layers.getProperties(id);
             if (props.locked) continue;
-            const set = props.pixels;
-            if (!set) continue;
+            const coords = props.pixels;
+            const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
             const pixelsToRemove = [];
             for (const [x, y] of pixels) {
                 if (set.has(coordsToKey(x, y))) pixelsToRemove.push([x, y]);

--- a/src/services/stage.js
+++ b/src/services/stage.js
@@ -23,7 +23,7 @@ export const useStageService = defineStore('stageService', () => {
     // --- Overlay Paths ---
     const selectOverlayPath = computed(() => {
         if (!overlay.selectOverlayLayerIds.size) return '';
-        const pixelUnionSet = getPixelUnionSet(layers, overlay.selectOverlayLayerIds);
+        const pixelUnionSet = getPixelUnionSet(layers.getProperties([...overlay.selectOverlayLayerIds]));
         return pixelsToUnionPath(pixelUnionSet);
     });
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,14 +2,12 @@ export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 export const coordsToKey = (x, y) => x + "," + y;
 export const keyToCoords = (key) => key.split(",").map(n => +n);
 
-export function getPixelUnionSet(layerStore, ids = []) {
+export function getPixelUnionSet(props = []) {
     const pixelUnionSet = new Set();
-    if (!layerStore || !ids) return pixelUnionSet;
-    for (const id of ids) {
-        const set = layerStore.pixels[id];
-        if (!set) continue;
-        for (const key of set) pixelUnionSet.add(key);
-    }
+    const layers = Array.isArray(props) ? props : [props];
+    for (const layer of layers)
+        for (const [x, y] of layer.pixels)
+            pixelUnionSet.add(coordsToKey(x, y));
     return pixelUnionSet;
 }
 


### PR DESCRIPTION
## Summary
- remove snapshotPixels action from layer store
- accept layer property objects in util.getPixelUnionSet
- expose layer pixel data as coordinate arrays
- adjust services and components for coordinate-based API
- assume layer properties exist when id present and remove defensive checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac03a46858832c91de30c77c42047b