### PR TITLE
Restrict layer panel range updates to keyboard and panel interactions

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -60,9 +60,12 @@ const onSelectEmpty = () => {
         layerPanel.clearRange();
     }
 };
-  const onSplit = () => {
-      output.setRollbackPoint();
-      layerSvc.splitLayer(layerPanel.anchorId);
-      output.commit();
-  };
+const onSplit = () => {
+    output.setRollbackPoint();
+    const ids = layerSvc.splitLayer(layerPanel.anchorId);
+    if (ids && ids.length) {
+        layerPanel.setRange(ids[0], ids[ids.length - 1]);
+    }
+    output.commit();
+};
 </script>

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -32,7 +32,6 @@ export const useLayerService = defineStore('layerService', () => {
         const ids = layers.selectedIds;
         layers.deleteLayers(ids);
         layers.removeFromSelection(ids);
-        layerPanel.clearRange();
     }
 
     function reorderGroup(selIds, targetId, placeBelow = true) {
@@ -124,7 +123,7 @@ export const useLayerService = defineStore('layerService', () => {
         layers._order = orderWithoutNew;
 
         layers.replaceSelection(newIds);
-        layerPanel.setRange(newIds[0], newIds[newIds.length - 1]);
+        return newIds;
     }
 
     return {

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -1,14 +1,12 @@
 import { defineStore } from 'pinia';
 import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
-import { useLayerPanelService } from './layerPanel';
 import { useStore } from '../stores';
 import { coordsToKey } from '../utils';
 
 export const usePixelService = defineStore('pixelService', () => {
     const stage = useStageService();
     const overlay = useOverlayService();
-    const layerPanel = useLayerPanelService();
     const { tool: toolStore, layers, output } = useStore();
     let cutLayerId = null;
 
@@ -103,7 +101,7 @@ export const usePixelService = defineStore('pixelService', () => {
 
         if (toolStore.isCut && cutLayerId != null) {
             if (layers.getProperty(cutLayerId, 'pixels').length)
-                layerPanel.setRange(cutLayerId, cutLayerId);
+                layers.replaceSelection([cutLayerId]);
             else
                 layers.deleteLayers([cutLayerId]);
         }

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -88,10 +88,9 @@ export const useSelectService = defineStore('selectService', () => {
             const id = layers.topVisibleIdAt(pixel.x, pixel.y);
             if (id !== null) {
                 if (mode === 'select' || !mode) {
-                    layerPanel.setRange(id, id);
+                    layers.replaceSelection([id]);
                 } else {
                     layers.toggleSelection(id);
-                    layerPanel.clearRange();
                 }
                 layerPanel.setScrollRule({ type: 'follow', target: id });
             }
@@ -114,12 +113,9 @@ export const useSelectService = defineStore('selectService', () => {
                     intersectedIds.forEach(id => currentSelection.add(id));
                 }
                 layers.replaceSelection([...currentSelection]);
-                if (mode === 'select' || !mode) {
-                    layerPanel.clearRange();
-                }
             } else if (mode === 'select' || !mode) {
-                    layers.clearSelection();
-                }
+                layers.clearSelection();
+            }
         }
 
         try {
@@ -145,9 +141,5 @@ export const useSelectService = defineStore('selectService', () => {
         overlay.clear();
     }
 
-    function selectRange(anchorId, tailId) {
-        layerPanel.setRange(anchorId, tailId);
-    }
-
-    return { toolStart, toolMove, toolFinish, cancel, selectRange };
+    return { toolStart, toolMove, toolFinish, cancel };
 });


### PR DESCRIPTION
## Summary
- Remove select service's `selectRange` helper and avoid layer panel range manipulation during canvas selections
- Return new layer IDs from `splitLayer` and move range updates into the layer toolbar
- Replace direct range updates in pixel cut tool with plain selection changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac11d05d98832c8d518b4aabafe370