### PR TITLE
refactor: unify layer query methods

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,9 +100,9 @@ function onKeydown(event) {
       event.preventDefault();
       if (!layers.selectionExists) return;
       output.setRollbackPoint();
-      const belowId = query.belowId(query.lowermostIdOf(layers.selectedIds));
+      const belowId = query.below(query.lowermost(layers.selectedIds));
       layerSvc.deleteSelected();
-      const newSelect = layers.has(belowId) ? belowId : query.lowermostId;
+      const newSelect = layers.has(belowId) ? belowId : query.lowermost();
       layerPanel.setRange(newSelect, newSelect);
       layerPanel.setScrollRule({ type: "follow", target: newSelect });
       output.commit();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -187,9 +187,9 @@ function toggleLock(id) {
 function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = layers.isSelected(id) ? layers.selectedIds : [id];
-    const belowId = query.belowId(query.lowermostIdOf(targets));
+    const belowId = query.below(query.lowermost(targets));
     layers.deleteLayers(targets);
-    const newSelectId = layers.has(belowId) ? belowId : query.lowermostId;
+    const newSelectId = layers.has(belowId) ? belowId : query.lowermost();
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
         layerPanel.setScrollRule({

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -32,7 +32,7 @@ const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnecte
 
 const onAdd = () => {
     output.setRollbackPoint();
-    const above = layers.selectionCount ? query.uppermostIdOf(layers.selectedIds) : null;
+    const above = layers.selectionCount ? query.uppermost(layers.selectedIds) : null;
     const id = layers.createLayer({});
     if (above !== null) {
         layers.reorderLayers([id], above, false);

--- a/src/services/layerPanel.js
+++ b/src/services/layerPanel.js
@@ -83,11 +83,11 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
         if (!layers.exists || ctrl) return;
         if (shift) {
             if (!layers.selectionExists) return;
-            const newTail = query.aboveId(state.tailId) ?? query.uppermostId;
+            const newTail = query.above(state.tailId) ?? query.uppermost();
             setRange(state.anchorId, newTail);
             setScrollRule({ type: 'follow-up', target: newTail });
         } else {
-            const nextId = query.aboveId(state.anchorId) ?? state.anchorId;
+            const nextId = query.above(state.anchorId) ?? state.anchorId;
             setRange(nextId, nextId);
             setScrollRule({ type: 'follow-up', target: nextId });
         }
@@ -97,18 +97,18 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
         if (!layers.exists || ctrl) return;
         if (shift) {
             if (!layers.selectionExists) return;
-            const newTail = query.belowId(state.tailId) ?? query.lowermostId;
+            const newTail = query.below(state.tailId) ?? query.lowermost();
             setRange(state.anchorId, newTail);
             setScrollRule({ type: 'follow-down', target: newTail });
         } else {
-            const nextId = query.belowId(state.anchorId) ?? state.anchorId;
+            const nextId = query.below(state.anchorId) ?? state.anchorId;
             setRange(nextId, nextId);
             setScrollRule({ type: 'follow-down', target: nextId });
         }
     }
 
     function selectAll() {
-        setRange(query.uppermostId, query.lowermostId);
+        setRange(query.uppermost(), query.lowermost());
     }
 
     function serialize() {

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -60,7 +60,7 @@ export const useLayerService = defineStore('layerService', () => {
         const newLayerId = layers.createLayer({ name: `Merged ${anchorName}`, color: colorU32 });
         const newPixels = [...pixelUnionSet].map(keyToCoords);
         if (newPixels.length) layers.addPixels(newLayerId, newPixels);
-        layers.reorderLayers([newLayerId], query.lowermostIdOf(layers.selectedIds), true);
+        layers.reorderLayers([newLayerId], query.lowermost(layers.selectedIds), true);
         deleteSelected();
         return newLayerId;
     }

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -15,7 +15,9 @@ export const useQueryService = defineStore('queryService', () => {
         const idSet = new Set(ids);
         if (!idSet.size) return null;
         const order = layers.idsBottomToTop;
-        const index = Math.max(...order.map((id, idx) => idSet.has(id) ? idx : -1));
+        const index = Math.max(
+            ...order.map((id, idx) => (idSet.has(id) ? idx : -1))
+        );
         return index >= 0 ? order[index] : null;
     }
 
@@ -23,18 +25,28 @@ export const useQueryService = defineStore('queryService', () => {
         const idSet = new Set(ids);
         if (!idSet.size) return null;
         const order = layers.idsBottomToTop;
-        const index = Math.min(...order.map((id, idx) => idSet.has(id) ? idx : Infinity));
+        const index = Math.min(
+            ...order.map((id, idx) => (idSet.has(id) ? idx : Infinity))
+        );
         return isFinite(index) ? order[index] : null;
     }
 
-    function aboveId(id) {
+    function uppermost(ids) {
+        return ids == null ? uppermostId.value : uppermostIdOf(ids);
+    }
+
+    function lowermost(ids) {
+        return ids == null ? lowermostId.value : lowermostIdOf(ids);
+    }
+
+    function above(id) {
         if (id == null) return null;
         const order = layers.idsBottomToTop;
         const idx = order.indexOf(id);
         return order[idx + 1] ?? null;
     }
 
-    function belowId(id) {
+    function below(id) {
         if (id == null) return null;
         const order = layers.idsBottomToTop;
         const idx = order.indexOf(id);
@@ -68,12 +80,10 @@ export const useQueryService = defineStore('queryService', () => {
     }
 
     return {
-        uppermostId,
-        lowermostId,
-        uppermostIdOf,
-        lowermostIdOf,
-        aboveId,
-        belowId,
+        uppermost,
+        lowermost,
+        above,
+        below,
         empty,
         byPixelCount,
         byColor,


### PR DESCRIPTION
## Summary
- rename query service APIs to `uppermost`, `lowermost`, `above`, and `below`
- merge `uppermostId`/`uppermostIdOf` and `lowermostId`/`lowermostIdOf` into single methods with optional arguments
- update components and services to use the new query API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac11ce44d8832c8cfa2fa786e5f00a