### PR TITLE
refactor: use coord for pixel I/O

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -47,7 +47,7 @@
 import { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
-import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, coordsToKey, clamp } from '../utils';
+import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, clamp } from '../utils';
 import blockIcons from '../image/layer_block';
 
 const { stage: stageStore, layers, output } = useStore();

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -86,21 +86,22 @@ const marquee = reactive({ visible: false, x: 0, y: 0, w: 0, h: 0 });
 const offset = viewport.offset;
 
     const updateHover = (event) => {
-        const pixel = stageService.clientToPixel(event);
-        if (!pixel) {
+        const coord = stageService.clientToCoord(event);
+        if (!coord) {
             stageStore.updatePixelInfo('-');
             overlay.clearHover();
             return;
         }
+        const [px, py] = coord;
         if (stageStore.display === 'original' && input.isLoaded) {
-            const colorObject = input.readPixel(pixel.x, pixel.y);
-            stageStore.updatePixelInfo(`[${pixel.x},${pixel.y}] ${rgbaCssObj(colorObject)}`);
+            const colorObject = input.readPixel(coord);
+            stageStore.updatePixelInfo(`[${px},${py}] ${rgbaCssObj(colorObject)}`);
         } else {
-            const colorU32 = layers.compositeColorAt(pixel.x, pixel.y);
-            stageStore.updatePixelInfo(`[${pixel.x},${pixel.y}] ${rgbaCssU32(colorU32)}`);
+            const colorU32 = layers.compositeColorAt(coord);
+            stageStore.updatePixelInfo(`[${px},${py}] ${rgbaCssU32(colorU32)}`);
         }
         if (toolStore.isSelect) {
-            overlay.setHover(layers.topVisibleIdAt(pixel.x, pixel.y));
+            overlay.setHover(layers.topVisibleIdAt(coord));
         } else {
             overlay.clearHover();
         }

--- a/src/components/StageInfo.vue
+++ b/src/components/StageInfo.vue
@@ -11,11 +11,11 @@
 <script setup>
 import { computed } from 'vue';
 import { useStore } from '../stores';
-import { getPixelUnionSet } from '../utils';
+import { getPixelUnion } from '../utils';
 
 const { stage: stageStore, layers } = useStore();
 const selectedAreaPixelCount = computed(() => {
-    const pixelSet = getPixelUnionSet(layers.getProperties(layers.selectedIds));
-    return pixelSet.size;
+    const pixels = getPixelUnion(layers.getProperties(layers.selectedIds));
+    return pixels.length;
   });
 </script>

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
 import { useStore } from '../stores';
-import { pixelsToUnionPath, getPixelUnionSet } from '../utils';
+import { pixelsToUnionPath, getPixelUnion } from '../utils';
 
 export const useOverlayService = defineStore('overlayService', () => {
     const { tool: toolStore, layers } = useStore();
@@ -11,8 +11,8 @@ export const useOverlayService = defineStore('overlayService', () => {
 
     const selectOverlayPath = computed(() => {
         if (!selectOverlayLayerIds.size) return '';
-        const pixelUnionSet = getPixelUnionSet(layers.getProperties([...selectOverlayLayerIds]));
-        return pixelsToUnionPath(pixelUnionSet);
+        const pixelUnion = getPixelUnion(layers.getProperties([...selectOverlayLayerIds]));
+        return pixelsToUnionPath(pixelUnion);
     });
 
     const hoverOverlayPath = computed(() => {

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useStageService } from './stage';
 import { useOverlayService } from './overlay';
 import { useStore } from '../stores';
-import { coordsToKey } from '../utils';
+import { coordToKey } from '../utils';
 
 export const usePixelService = defineStore('pixelService', () => {
     const stage = useStageService();
@@ -12,8 +12,8 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function toolStart(event) {
         if (event.button !== 0) return;
-        const pixel = stage.clientToPixel(event);
-        if (!pixel) return;
+        const coord = stage.clientToCoord(event);
+        if (!coord) return;
 
         output.setRollbackPoint();
 
@@ -41,7 +41,7 @@ export const usePixelService = defineStore('pixelService', () => {
             // no additional pointer state needed for rectangle interactions
         } else {
             toolStore.visited.clear();
-            toolStore.visited.add(coordsToKey(pixel.x, pixel.y));
+            toolStore.visited.add(coordToKey(coord));
             const pixels = stage.getPixelsFromInteraction(event);
 
             if (toolStore.isGlobalErase) {
@@ -61,16 +61,16 @@ export const usePixelService = defineStore('pixelService', () => {
         if (toolStore.shape === 'rect') {
             // rectangle interactions handled in stage component
         } else {
-            const pixel = stage.clientToPixel(event);
-            if (!pixel) {
+            const coord = stage.clientToCoord(event);
+            if (!coord) {
                 return;
             }
-            const k = coordsToKey(pixel.x, pixel.y);
+            const k = coordToKey(coord);
             if (toolStore.visited.has(k)) {
                 return;
             }
             toolStore.visited.add(k);
-            const delta = [[pixel.x, pixel.y]];
+            const delta = [coord];
             if (toolStore.isGlobalErase) {
                 if (layers.selectionExists) removePixelsFromSelected(delta);
                 else removePixelsFromAll(delta);
@@ -147,21 +147,21 @@ export const usePixelService = defineStore('pixelService', () => {
         if (layers.selectionCount !== 1 || cutLayerId == null) return;
         const sourceId = layers.selectedIds[0];
         const coords = layers.getProperty(sourceId, 'pixels');
-        const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
+        const set = new Set(coords.map(coordToKey));
         const pixelsToMove = [];
-        for (const [x, y] of pixels) {
-            if (set.has(coordsToKey(x, y))) pixelsToMove.push([x, y]);
+        for (const coord of pixels) {
+            if (set.has(coordToKey(coord))) pixelsToMove.push(coord);
         }
         if (!pixelsToMove.length) return;
         layers.removePixels(sourceId, pixelsToMove);
         layers.addPixels(cutLayerId, pixelsToMove);
     }
 
-    function togglePointInSelection(x, y) {
+    function togglePointInSelection(coord) {
         if (layers.selectionCount !== 1) return;
         const id = layers.selectedIds[0];
         if (layers.getProperty(id, 'locked')) return;
-        layers.togglePixel(id, x, y);
+        layers.togglePixel(id, coord);
     }
 
     function removePixelsFromSelected(pixels) {
@@ -170,10 +170,10 @@ export const usePixelService = defineStore('pixelService', () => {
             const props = layers.getProperties(id);
             if (props.locked) continue;
             const coords = props.pixels;
-            const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
+            const set = new Set(coords.map(coordToKey));
             const pixelsToRemove = [];
-            for (const [x, y] of pixels) {
-                if (set.has(coordsToKey(x, y))) pixelsToRemove.push([x, y]);
+            for (const coord of pixels) {
+                if (set.has(coordToKey(coord))) pixelsToRemove.push(coord);
             }
             if (pixelsToRemove.length) layers.removePixels(id, pixelsToRemove);
         }
@@ -185,10 +185,10 @@ export const usePixelService = defineStore('pixelService', () => {
             const props = layers.getProperties(id);
             if (props.locked) continue;
             const coords = props.pixels;
-            const set = new Set(coords.map(([x, y]) => coordsToKey(x, y)));
+            const set = new Set(coords.map(coordToKey));
             const pixelsToRemove = [];
-            for (const [x, y] of pixels) {
-                if (set.has(coordsToKey(x, y))) pixelsToRemove.push([x, y]);
+            for (const coord of pixels) {
+                if (set.has(coordToKey(coord))) pixelsToRemove.push(coord);
             }
             if (pixelsToRemove.length) layers.removePixels(id, pixelsToRemove);
         }

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -47,21 +47,22 @@ export const useInputStore = defineStore('input', {
         async loadFromQuery() {
             await this.load(new URL(location.href).searchParams.get('pixel'));
         },
-        isWithin(x, y) {
+        isWithin([x, y]) {
             return x >= 0 && y >= 0 && x < this._width && y < this._height;
         },
-        _offset(x, y) {
+        _offset([x, y]) {
             return ((y * this._width) + x) * 4;
         },
-        readPixel(x, y) {
-            if (!this.isLoaded || !this.isWithin(x, y)) return {
+        readPixel(coord) {
+            const [x, y] = coord;
+            if (!this.isLoaded || !this.isWithin(coord)) return {
                 r: 0,
                 g: 0,
                 b: 0,
                 a: 0
             };
             const data = this._buffer;
-            const i = this._offset(x, y);
+            const i = this._offset(coord);
             return {
                 r: data[i],
                 g: data[i + 1],
@@ -69,9 +70,9 @@ export const useInputStore = defineStore('input', {
                 a: data[i + 3]
             };
         },
-        writePixel(x, y, { r = 0, g = 0, b = 0, a = 255 } = {}) {
-            if (!this.isLoaded || !this.isWithin(x, y)) return;
-            const i = this._offset(x, y);
+        writePixel(coord, { r = 0, g = 0, b = 0, a = 255 } = {}) {
+            if (!this.isLoaded || !this.isWithin(coord)) return;
+            const i = this._offset(coord);
             this._buffer[i] = r;
             this._buffer[i + 1] = g;
             this._buffer[i + 2] = b;
@@ -99,7 +100,7 @@ export const useInputStore = defineStore('input', {
                 for (let x = 0; x < width; x++) {
                     const flatIndex = y * width + x;
                     if (visited[flatIndex]) continue;
-                    const pixelIndex = this._offset(x, y);
+                    const pixelIndex = this._offset([x, y]);
                     const seedColor = {
                         r: data[pixelIndex],
                         g: data[pixelIndex + 1],
@@ -114,7 +115,7 @@ export const useInputStore = defineStore('input', {
                     const colors = [];
                     while (queue.length) {
                         const [cx, cy] = queue.pop();
-                        const currentIndex = this._offset(cx, cy);
+                        const currentIndex = this._offset([cx, cy]);
                         const currentR = data[currentIndex],
                             currentG = data[currentIndex + 1],
                             currentB = data[currentIndex + 2],
@@ -130,10 +131,10 @@ export const useInputStore = defineStore('input', {
                         for (const [dx, dy] of directions) {
                             const nextX = cx + dx,
                                 nextY = cy + dy;
-                            if (!this.isWithin(nextX, nextY)) continue;
+                            if (!this.isWithin([nextX, nextY])) continue;
                             const nextFlatIndex = nextY * width + nextX;
                             if (visited[nextFlatIndex]) continue;
-                            const nextIndex = this._offset(nextX, nextY);
+                            const nextIndex = this._offset([nextX, nextY]);
                             const nextAlpha = data[nextIndex + 3];
                             if (nextAlpha > 0 && colorDistance({
                                     r: data[nextIndex],


### PR DESCRIPTION
## Summary
- standardize pixel handling around `[x, y]` coords
- expose `coordToKey`, `keyToCoord`, and `getPixelUnion`
- adjust layers, services, and components to consume coord arrays
- rename `clientToCoord` helper and update all call sites

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac16b48384832ca9866f45817047a7