### PR TITLE
Refactor overlay handling into centralized service

### DIFF
--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -1,69 +1,42 @@
 import { defineStore } from 'pinia';
-import { computed, reactive, ref } from 'vue';
+import { computed, reactive, ref, watch } from 'vue';
 import { useStore } from '../stores';
-import { pixelsToUnionPath, getPixelUnion } from '../utils';
+import { coordToKey, keyToCoord, pixelsToUnionPath } from '../utils';
 
 export const useOverlayService = defineStore('overlayService', () => {
-    const { tool: toolStore, layers } = useStore();
+    const { layers } = useStore();
 
-    const hoverLayerId = ref(null);
-    const selectOverlayLayerIds = reactive(new Set());
-
-    const selectOverlayPath = computed(() => {
-        if (!selectOverlayLayerIds.size) return '';
-        const pixelUnion = getPixelUnion(layers.getProperties([...selectOverlayLayerIds]));
-        return pixelsToUnionPath(pixelUnion);
-    });
-
-    const hoverOverlayPath = computed(() => {
-        return hoverLayerId.value != null ? layers.pathOf(hoverLayerId.value) : '';
-    });
-
-    function setHover(id) {
-        hoverLayerId.value = id;
-    }
-
-    function clearHover() {
-        hoverLayerId.value = null;
-    }
-
-    function add(id) {
-        if (id == null) return;
-        selectOverlayLayerIds.add(id);
-    }
-
-    function clear() {
-        selectOverlayLayerIds.clear();
-    }
-
-    function addByMode(id) {
-        if (id == null) return;
-        const mode = toolStore.pointer.status;
-        if (mode === 'remove') {
-            if (layers.isSelected(id)) add(id);
-        } else if (mode === 'add') {
-            if (!layers.isSelected(id)) add(id);
-        } else {
-            add(id);
+    function createOverlayState() {
+        const pixelKeys = reactive(new Set());
+        const path = computed(() => {
+            if (!pixelKeys.size) return '';
+            const coords = Array.from(pixelKeys).map(keyToCoord);
+            return pixelsToUnionPath(coords);
+        });
+        function clear() {
+            pixelKeys.clear();
         }
+        function add(id) {
+            if (id == null) return;
+            const pixels = layers.getProperty(id, 'pixels') || [];
+            for (const coord of pixels) pixelKeys.add(coordToKey(coord));
+        }
+        return { pixels: pixelKeys, path, clear, add };
     }
 
-    function setFromIntersected(ids) {
-        clear();
-        for (const id of ids) {
-            addByMode(id);
-        }
+    const selection = createOverlayState();
+    const helper = createOverlayState();
+    const helperMode = ref('add');
+
+    function rebuildSelection() {
+        selection.clear();
+        layers.selectedIds.forEach(id => selection.add(id));
     }
+
+    watch(() => layers.selectedIds.slice(), rebuildSelection, { immediate: true });
 
     return {
-        hoverLayerId,
-        hoverOverlayPath,
-        selectOverlayPath,
-        setHover,
-        clearHover,
-        add,
-        clear,
-        addByMode,
-        setFromIntersected,
+        selection,
+        helper: { ...helper, mode: helperMode }
     };
 });

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -26,7 +26,9 @@ export const usePixelService = defineStore('pixelService', () => {
                 color: sourceProps.color,
                 visible: sourceProps.visible,
             }, sourceId);
-            overlay.add(cutLayerId);
+            overlay.helper.clear();
+            overlay.helper.add(cutLayerId);
+            overlay.helper.mode = 'add';
         }
 
         toolStore.pointer.status = toolStore.expected;
@@ -125,7 +127,8 @@ export const usePixelService = defineStore('pixelService', () => {
         toolStore.pointer.id = null;
         toolStore.pointer.start = null;
         toolStore.visited.clear();
-        overlay.clear();
+        overlay.helper.clear();
+        overlay.helper.mode = 'add';
         cutLayerId = null;
     }
 


### PR DESCRIPTION
## Summary
- centralize selection and helper overlays in overlay service with pixel-based state
- update Stage and related services to use unified overlay APIs
- base cursor styling on helper overlay mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac21982f78832cadd91251964787a5