### PR TITLE
refactor layer locking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,15 +35,15 @@ import { onMounted, ref, computed, onUnmounted } from 'vue';
 import { useStore } from './stores';
 import { useService } from './services';
 
-import StageToolbar from './components/StageToolbar.vue';
 import Stage from './components/Stage.vue';
 import StageInfo from './components/StageInfo.vue';
 import LayersToolbar from './components/LayersToolbar.vue';
 import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 
+import StageToolbar from './components/StageToolbar.vue';
 const { input, stage: stageStore, layers, output } = useStore();
-const { stage: stageService, layerPanel, layers: layerSvc, query } = useService();
+const { stage: stageService, layerPanel, query } = useService();
 const stageToolbar = ref(null);
 
 // Width control between display and layers
@@ -101,7 +101,9 @@ function onKeydown(event) {
       if (!layers.selectionExists) return;
       output.setRollbackPoint();
       const belowId = query.below(query.lowermost(layers.selectedIds));
-      layerSvc.deleteSelected();
+      const ids = layers.selectedIds;
+      layers.deleteLayers(ids);
+      layers.removeFromSelection(ids);
       const newSelect = layers.has(belowId) ? belowId : query.lowermost();
       layerPanel.setRange(newSelect, newSelect);
       layerPanel.setScrollRule({ type: "follow", target: newSelect });

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -46,12 +46,13 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { useStore } from '../stores';
-import { useService } from '../services';
 import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32, clamp } from '../utils';
 import blockIcons from '../image/layer_block';
 
+import { useService } from '../services';
+
 const { stage: stageStore, layers, output } = useStore();
-const { stage: stageService, layerPanel, layers: layerSvc, query } = useService();
+const { stage: stageService, layerPanel, query } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);
@@ -161,9 +162,14 @@ function onColorDown() {
 }
 
 function onColorInput(id, event) {
-    if (layers.getProperty(id, 'locked')) return;
     const colorU32 = hexToRgbaU32(event.target.value);
-    layers.isSelected(id) ? layerSvc.setColorForSelectedU32(colorU32) : layers.updateProperties(id, { color: colorU32 });
+    if (layers.isSelected(id)) {
+        for (const sid of layers.selectedIds) {
+            layers.updateProperties(sid, { color: colorU32 });
+        }
+    } else {
+        layers.updateProperties(id, { color: colorU32 });
+    }
 }
 
 function onColorChange() {
@@ -172,15 +178,27 @@ function onColorChange() {
 
 function toggleVisibility(id) {
     output.setRollbackPoint();
-    if (layers.isSelected(id)) layerSvc.setVisibilityForSelected(!layers.getProperty(id, 'visible'));
-    else layers.toggleVisibility(id);
+    if (layers.isSelected(id)) {
+        const value = !layers.getProperty(id, 'visible');
+        for (const sid of layers.selectedIds) {
+            layers.updateProperties(sid, { visible: value });
+        }
+    } else {
+        layers.toggleVisibility(id);
+    }
     output.commit();
 }
 
 function toggleLock(id) {
     output.setRollbackPoint();
-    if (layers.isSelected(id)) layerSvc.setLockedForSelected(!layers.getProperty(id, 'locked'));
-    else layers.toggleLock(id);
+    if (layers.isSelected(id)) {
+        const value = !layers.getProperty(id, 'locked');
+        for (const sid of layers.selectedIds) {
+            layers.updateProperties(sid, { locked: value });
+        }
+    } else {
+        layers.toggleLock(id);
+    }
     output.commit();
 }
 
@@ -342,3 +360,5 @@ onUnmounted(() => {
     });
 });
 </script>
+const { stage: stageStore, layers, output } = useStore();
+const { stage: stageService, layerPanel, query } = useService();

--- a/src/services/layers.js
+++ b/src/services/layers.js
@@ -9,35 +9,6 @@ export const useLayerService = defineStore('layerService', () => {
     const layerPanel = useLayerPanelService();
     const query = useQueryService();
 
-    function setColorForSelectedU32(colorU32) {
-        for (const id of layers.selectedIds) {
-            if (layers.getProperty(id, 'locked')) continue;
-            layers.updateProperties(id, { color: colorU32 });
-        }
-    }
-
-    function setLockedForSelected(isLocked) {
-        for (const id of layers.selectedIds) {
-            layers.updateProperties(id, { locked: isLocked });
-        }
-    }
-
-    function setVisibilityForSelected(isVisible) {
-        for (const id of layers.selectedIds) {
-            layers.updateProperties(id, { visible: isVisible });
-        }
-    }
-
-    function deleteSelected() {
-        const ids = layers.selectedIds;
-        layers.deleteLayers(ids);
-        layers.removeFromSelection(ids);
-    }
-
-    function reorderGroup(selIds, targetId, placeBelow = true) {
-        layers.reorderLayers(selIds, targetId, placeBelow);
-    }
-
     function mergeSelected() {
         if (layers.selectionCount < 2) return;
         const pixelUnion = getPixelUnion(layers.getProperties(layers.selectedIds));
@@ -59,7 +30,9 @@ export const useLayerService = defineStore('layerService', () => {
         const newPixels = pixelUnion;
         if (newPixels.length) layers.addPixels(newLayerId, newPixels);
         layers.reorderLayers([newLayerId], query.lowermost(layers.selectedIds), true);
-        deleteSelected();
+        const ids = layers.selectedIds;
+        layers.deleteLayers(ids);
+        layers.removeFromSelection(ids);
         return newLayerId;
     }
 
@@ -126,11 +99,6 @@ export const useLayerService = defineStore('layerService', () => {
     }
 
     return {
-        setColorForSelectedU32,
-        setLockedForSelected,
-        setVisibilityForSelected,
-        deleteSelected,
-        reorderGroup,
         mergeSelected,
         copySelected,
         selectionPath,

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -135,14 +135,12 @@ export const usePixelService = defineStore('pixelService', () => {
     function addPixelsToSelection(pixels) {
         if (layers.selectionCount !== 1) return;
         const id = layers.selectedIds[0];
-        if (layers.getProperty(id, 'locked')) return;
         layers.addPixels(id, pixels);
     }
 
     function removePixelsFromSelection(pixels) {
         if (layers.selectionCount !== 1) return;
         const id = layers.selectedIds[0];
-        if (layers.getProperty(id, 'locked')) return;
         layers.removePixels(id, pixels);
     }
 
@@ -163,7 +161,6 @@ export const usePixelService = defineStore('pixelService', () => {
     function togglePointInSelection(coord) {
         if (layers.selectionCount !== 1) return;
         const id = layers.selectedIds[0];
-        if (layers.getProperty(id, 'locked')) return;
         layers.togglePixel(id, coord);
     }
 
@@ -171,7 +168,6 @@ export const usePixelService = defineStore('pixelService', () => {
         if (!pixels || !pixels.length) return;
         for (const id of layers.selectedIds) {
             const props = layers.getProperties(id);
-            if (props.locked) continue;
             const coords = props.pixels;
             const set = new Set(coords.map(coordToKey));
             const pixelsToRemove = [];
@@ -186,7 +182,6 @@ export const usePixelService = defineStore('pixelService', () => {
         if (!pixels || !pixels.length) return;
         for (const id of layers.order) {
             const props = layers.getProperties(id);
-            if (props.locked) continue;
             const coords = props.pixels;
             const set = new Set(coords.map(coordToKey));
             const pixelsToRemove = [];

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -103,6 +103,7 @@ export const useLayerStore = defineStore('layers', {
         /** Update properties of a layer */
         updateProperties(id, props) {
             if (this._name[id] == null) return;
+            if (this._locked[id] && props.locked !== false && (props.name !== undefined || props.color !== undefined || props.pixels !== undefined)) return;
             if (props.name !== undefined) this._name[id] = props.name;
             if (props.color !== undefined) this._color[id] = (props.color >>> 0);
             if (props.visible !== undefined) this._visible[id] = !!props.visible;
@@ -121,14 +122,17 @@ export const useLayerStore = defineStore('layers', {
             this._locked[id] = !this._locked[id];
         },
         addPixels(id, pixels) {
+            if (this._locked[id]) return;
             const set = this._pixels[id];
             for (const coord of pixels) set.add(coordToKey(coord));
         },
         removePixels(id, pixels) {
+            if (this._locked[id]) return;
             const set = this._pixels[id];
             for (const coord of pixels) set.delete(coordToKey(coord));
         },
         togglePixel(id, coord) {
+            if (this._locked[id]) return;
             const set = this._pixels[id];
             const key = coordToKey(coord);
             if (set.has(key)) set.delete(key);


### PR DESCRIPTION
## Summary
- centralize locked-layer update checks inside layer store
- remove set/delete helpers from layer service and update callers
- simplify pixel editing and layer panel to rely on store safeguards

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac2a58fa5c832ca1f181524d90deb0