### PR TITLE
Rename layer service to layerTool service

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -25,7 +25,7 @@ import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
 const { layers, output } = useStore();
-const { layers: layerSvc, layerPanel, query } = useService();
+const { layerTool: layerSvc, layerPanel, query } = useService();
 
 const hasEmptyLayers = computed(() => layers.order.some(id => layers.getProperty(id, 'pixels').length === 0));
 const canSplit = computed(() => layers.selectedIds.some(id => layers.disconnectedCountOf(id) > 1));

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -42,7 +42,7 @@
           <!-- Selection overlay (sky blue) -->
           <path id="selectionOverlay"
                 v-if="layers.selectionExists"
-                :d="selectionPath"
+                :d="overlay.selection.path"
                 :fill="OVERLAY_CONFIG.SELECTED.FILL_COLOR"
                 :stroke="OVERLAY_CONFIG.SELECTED.STROKE_COLOR"
                 :stroke-width="OVERLAY_CONFIG.SELECTED.STROKE_WIDTH_SCALE / Math.max(1, stageStore.canvas.scale)"
@@ -117,7 +117,6 @@ const onWheel = (e) => {
   stageEvents.setWheel(e);
 };
 
-const selectionPath = computed(() => overlay.selection.path);
 const helperOverlay = computed(() => {
     const path = overlay.helper.path;
     if (!path) return { path }; // no style when empty

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,5 @@
 import { useLayerPanelService } from './layerPanel';
-import { useLayerService } from './layers';
+import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { usePixelService } from './pixel';
 import { useQueryService } from './query';
@@ -10,7 +10,7 @@ import { useViewportService } from './viewport';
 
 export {
     useLayerPanelService,
-    useLayerService,
+    useLayerToolService,
     useOverlayService,
     usePixelService,
     useQueryService,
@@ -22,7 +22,7 @@ export {
 
 export const useService = () => ({
     layerPanel: useLayerPanelService(),
-    layers: useLayerService(),
+    layerTool: useLayerToolService(),
     overlay: useOverlayService(),
     pixel: usePixelService(),
     query: useQueryService(),

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -2,9 +2,9 @@ import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 import { useLayerPanelService } from './layerPanel';
 import { useQueryService } from './query';
-import { buildOutline, findPixelComponents, getPixelUnion, averageColorU32 } from '../utils';
+import { findPixelComponents, getPixelUnion, averageColorU32 } from '../utils';
 
-export const useLayerService = defineStore('layerService', () => {
+export const useLayerToolService = defineStore('layerToolService', () => {
     const { layers } = useStore();
     const layerPanel = useLayerPanelService();
     const query = useQueryService();
@@ -53,17 +53,6 @@ export const useLayerService = defineStore('layerService', () => {
         return newLayerIds;
     }
 
-    function selectionPath() {
-        if (!layers.selectionCount) return '';
-        const pixelUnion = getPixelUnion(layers.getProperties(layers.selectedIds));
-        const groups = buildOutline(pixelUnion);
-        const pathData = [];
-        for (const group of groups)
-            for (const [[x0, y0], [x1, y1]] of group)
-                pathData.push(`M ${x0} ${y0} L ${x1} ${y1}`);
-        return pathData.join(' ');
-    }
-
     function splitLayer(layerId) {
         if (layerId == null) return;
         if (layers.getProperty(layerId, 'pixels').length < 2) return;
@@ -101,7 +90,6 @@ export const useLayerService = defineStore('layerService', () => {
     return {
         mergeSelected,
         copySelected,
-        selectionPath,
         splitLayer,
     };
 });


### PR DESCRIPTION
## Summary
- rename layer service to layerTool service
- drop obsolete selectionPath helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac3a4940ec832cb489dbe02c4ed53f