### PR TITLE
Use helper overlay for cut tool

### DIFF
--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -187,6 +187,8 @@ export const usePixelService = defineStore('pixelService', () => {
         if (!pixelsToMove.length) return;
         layers.removePixels(sourceId, pixelsToMove);
         layers.addPixels(cutLayerId, pixelsToMove);
+        overlay.helper.clear();
+        overlay.helper.add(cutLayerId);
     }
 
     function togglePointInSelection(coord) {


### PR DESCRIPTION
## Summary
- ensure cut tool updates helper overlay after moving pixels

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac57f36df4832c9f2597444d2b6b6f