### PR TITLE
Refactor viewport event handling

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -87,7 +87,7 @@ const offset = viewport.offset;
 
 const onViewportPointerDown = (e) => {
   if (e.pointerType === 'touch') e.preventDefault();
-  viewportEvents.addPointerDown(e);
+  viewportEvents.setPointerDown(e);
 };
 
 const onViewportPointerMove = (e) => {
@@ -103,7 +103,7 @@ const onViewportPointerCancel = (e) => {
 };
 
 const onPointerDown = (e) => {
-  viewportEvents.addPointerDown(e);
+  viewportEvents.setPointerDown(e);
 };
 
 const onPointerMove = (e) => {

--- a/src/components/StageToolbar.vue
+++ b/src/components/StageToolbar.vue
@@ -62,17 +62,19 @@ const redo = () => output.redo();
 
 // Keyboard handlers
 const isCtrlDown = () => {
-  const ctrl = viewportEvents.keyboard['Control'];
-  const meta = viewportEvents.keyboard['Meta'];
-  const check = (entry) => entry && (!entry.up || entry.down?.timeStamp > entry.up.timeStamp);
-  return check(ctrl) || check(meta);
+  const check = (key) => {
+    const down = viewportEvents.getEvent('keydown', key);
+    const up = viewportEvents.getEvent('keyup', key);
+    return !!down && (!up || down.timeStamp > up.timeStamp);
+  };
+  return check('Control') || check('Meta');
 };
 function ctrlKeyDown(e) {
   viewportEvents.setKeyDown(e);
 }
 function ctrlKeyUp(e) {
   if (e) {
-    const down = viewportEvents.keyboard[e.key]?.down;
+    const down = viewportEvents.getEvent('keydown', e.key);
     if (down && !down.repeat) {
       const t = stageToolService.prepared;
       if (t === 'draw' || t === 'erase') {

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -14,7 +14,8 @@ export const usePixelService = defineStore('pixelService', () => {
     function startDraw() {
         const tool = useStageToolService();
         if (tool.shape !== 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.down;
+            if (!viewportEvents.isDragging(tool.pointer.id)) return;
+            const event = viewportEvents.getEvent('pointerdown', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('down');
             addPixelsToSelection(pixels);
@@ -23,9 +24,8 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function moveDraw() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'draw' || tool.shape === 'rect') return;
-        const event = viewportEvents.pointer[tool.pointer.id]?.move;
-        if (!event) return;
+        if (tool.pointer.status !== 'draw' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
+        const event = viewportEvents.getEvent('pointermove', tool.pointer.id);
         const coord = stage.clientToCoord(event);
         if (!coord) return;
         addPixelsToSelection([coord]);
@@ -35,7 +35,7 @@ export const usePixelService = defineStore('pixelService', () => {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'draw') return;
         if (tool.shape === 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.up;
+            const event = viewportEvents.getEvent('pointerup', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('up');
             if (pixels.length > 0) addPixelsToSelection(pixels);
@@ -45,7 +45,8 @@ export const usePixelService = defineStore('pixelService', () => {
     function startErase() {
         const tool = useStageToolService();
         if (tool.shape !== 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.down;
+            if (!viewportEvents.isDragging(tool.pointer.id)) return;
+            const event = viewportEvents.getEvent('pointerdown', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('down');
             removePixelsFromSelection(pixels);
@@ -54,9 +55,8 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function moveErase() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'erase' || tool.shape === 'rect') return;
-        const event = viewportEvents.pointer[tool.pointer.id]?.move;
-        if (!event) return;
+        if (tool.pointer.status !== 'erase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
+        const event = viewportEvents.getEvent('pointermove', tool.pointer.id);
         const coord = stage.clientToCoord(event);
         if (!coord) return;
         removePixelsFromSelection([coord]);
@@ -66,7 +66,7 @@ export const usePixelService = defineStore('pixelService', () => {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'erase') return;
         if (tool.shape === 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.up;
+            const event = viewportEvents.getEvent('pointerup', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('up');
             if (pixels.length > 0) removePixelsFromSelection(pixels);
@@ -76,7 +76,8 @@ export const usePixelService = defineStore('pixelService', () => {
     function startGlobalErase() {
         const tool = useStageToolService();
         if (tool.shape !== 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.down;
+            if (!viewportEvents.isDragging(tool.pointer.id)) return;
+            const event = viewportEvents.getEvent('pointerdown', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('down');
             if (layers.selectionExists) removePixelsFromSelected(pixels);
@@ -86,9 +87,8 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function moveGlobalErase() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'globalErase' || tool.shape === 'rect') return;
-        const event = viewportEvents.pointer[tool.pointer.id]?.move;
-        if (!event) return;
+        if (tool.pointer.status !== 'globalErase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
+        const event = viewportEvents.getEvent('pointermove', tool.pointer.id);
         const coord = stage.clientToCoord(event);
         if (!coord) return;
         if (layers.selectionExists) removePixelsFromSelected([coord]);
@@ -99,7 +99,7 @@ export const usePixelService = defineStore('pixelService', () => {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'globalErase') return;
         if (tool.shape === 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.up;
+            const event = viewportEvents.getEvent('pointerup', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('up');
             if (pixels.length > 0) {
@@ -124,7 +124,8 @@ export const usePixelService = defineStore('pixelService', () => {
         overlay.helper.mode = 'add';
 
         if (tool.shape !== 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.down;
+            if (!viewportEvents.isDragging(tool.pointer.id)) return;
+            const event = viewportEvents.getEvent('pointerdown', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('down');
             cutPixelsFromSelection(pixels);
@@ -133,9 +134,8 @@ export const usePixelService = defineStore('pixelService', () => {
 
     function moveCut() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'cut' || tool.shape === 'rect') return;
-        const event = viewportEvents.pointer[tool.pointer.id]?.move;
-        if (!event) return;
+        if (tool.pointer.status !== 'cut' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
+        const event = viewportEvents.getEvent('pointermove', tool.pointer.id);
         const coord = stage.clientToCoord(event);
         if (!coord) return;
         cutPixelsFromSelection([coord]);
@@ -145,7 +145,7 @@ export const usePixelService = defineStore('pixelService', () => {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'cut') return;
         if (tool.shape === 'rect') {
-            const event = viewportEvents.pointer[tool.pointer.id]?.up;
+            const event = viewportEvents.getEvent('pointerup', tool.pointer.id);
             if (!event) return;
             const pixels = tool.getPixelsFromInteraction('up');
             if (pixels.length > 0) cutPixelsFromSelection(pixels);

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -36,8 +36,8 @@ export const useSelectService = defineStore('selectService', () => {
     function move() {
         const tool = useStageToolService();
         if (tool.pointer.status === 'idle') return;
-        const event = viewportEvents.pointer[tool.pointer.id]?.move;
-        if (!event) return;
+        if (!viewportEvents.isDragging(tool.pointer.id)) return;
+        const event = viewportEvents.getEvent('pointermove', tool.pointer.id);
 
         if (tool.shape === 'rect') {
             const pixels = tool.getPixelsFromInteraction('move');
@@ -65,11 +65,11 @@ export const useSelectService = defineStore('selectService', () => {
         if (tool.pointer.status === 'idle') return;
 
         const mode = tool.pointer.status;
-        const event = viewportEvents.pointer[tool.pointer.id]?.up;
+        const event = viewportEvents.getEvent('pointerup', tool.pointer.id);
         if (!event) return;
 
         const coord = stage.clientToCoord(event);
-            const startEvent = viewportEvents.pointer[tool.pointer.id]?.down;
+            const startEvent = viewportEvents.getEvent('pointerdown', tool.pointer.id);
             const dx = startEvent ? Math.abs(event.clientX - startEvent.clientX) : 0;
             const dy = startEvent ? Math.abs(event.clientY - startEvent.clientY) : 0;
         const isClick = dx <= 4 && dy <= 4;

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -93,34 +93,43 @@ export const useViewportService = defineStore('viewportService', () => {
     stageStore.setCanvasPosition(left + offset.x, top + offset.y);
   }
 
-  watch(() => {
-    const id = viewportEvents.pointer.recent;
-    return id != null ? viewportEvents.pointer[id]?.down : null;
-  }, (e) => {
-    if (!e || e.pointerType !== 'touch') return;
-    touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    lastTouchDistance = 0;
-  });
+  watch(
+    () => viewportEvents.recent.pointer.down,
+    (events) => {
+      for (const e of events) {
+        if (e.pointerType !== 'touch') continue;
+        touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        lastTouchDistance = 0;
+      }
+    },
+    { deep: true }
+  );
 
-  watch(() => {
-    const id = viewportEvents.pointer.recent;
-    return id != null ? viewportEvents.pointer[id]?.move : null;
-  }, (e) => {
-    if (!e || e.pointerType !== 'touch') return;
-    touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    if (touches.size === 2) handlePinch();
-  });
+  watch(
+    () => viewportEvents.recent.pointer.move,
+    (events) => {
+      for (const e of events) {
+        if (e.pointerType !== 'touch') continue;
+        touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        if (touches.size === 2) handlePinch();
+      }
+    },
+    { deep: true }
+  );
 
-  watch(() => {
-    const id = viewportEvents.pointer.recent;
-    return id != null ? viewportEvents.pointer[id]?.up : null;
-  }, (e) => {
-    if (!e || e.pointerType !== 'touch') return;
-    touches.delete(e.pointerId);
-    lastTouchDistance = 0;
-  });
+  watch(
+    () => viewportEvents.recent.pointer.up,
+    (events) => {
+      for (const e of events) {
+        if (e.pointerType !== 'touch') continue;
+        touches.delete(e.pointerId);
+        lastTouchDistance = 0;
+      }
+    },
+    { deep: true }
+  );
 
-  watch(() => viewportEvents.wheel, (e) => {
+  watch(() => viewportEvents.getEvent('wheel'), (e) => {
     if (e) handleWheel(e);
   });
 

--- a/src/stores/viewportEvent.js
+++ b/src/stores/viewportEvent.js
@@ -1,60 +1,117 @@
 import { defineStore } from 'pinia';
+import { readonly, nextTick } from 'vue';
 import { MAX_POINTER_WINDOW } from '@/constants';
 
 export const useViewportEventStore = defineStore('viewportEvent', {
     state: () => ({
-        pointer: { recent: null },
-        keyboard: { recent: null },
-        wheel: null,
+        _pointer: {},
+        _keyboard: {},
+        _wheel: null,
+        _recent: {
+            pointer: { down: [], move: [], up: [] },
+            keyboard: { down: [], up: [] },
+        },
+        _recentTicks: {
+            pointer: { down: 0, move: 0, up: 0 },
+            keyboard: { down: 0, up: 0 },
+        },
+        _tick: 0,
+        _tickScheduled: false,
     }),
+    getters: {
+        pointer: (state) => readonly(state._pointer),
+        keyboard: (state) => readonly(state._keyboard),
+        wheel: (state) => readonly(state._wheel),
+        recent: (state) => readonly(state._recent),
+        isPressed: (state) => (key) => {
+            const entry = state._keyboard[key];
+            return !!entry && !!entry.down && (!entry.up || entry.down.timeStamp > entry.up.timeStamp);
+        },
+        isDragging: (state) => (id) => {
+            const entry = state._pointer[id];
+            return !!entry && !!entry.down && (!entry.up || entry.down.timeStamp > entry.up.timeStamp);
+        },
+    },
     actions: {
-        addPointerDown(event) {
-            if (this.pointer[event.pointerId])
-                this.pointer[event.pointerId].down = event;
+        setPointerDown(event) {
+            if (this._pointer[event.pointerId])
+                this._pointer[event.pointerId].down = event;
             else {
-                this.pointer[event.pointerId] = { down: event, move: null, up: null };
+                this._pointer[event.pointerId] = { down: event, move: null, up: null };
                 this.pruneOldPointers();
             }
-            this.pointer.recent = event.pointerId;
+            this._pushRecent('pointer', 'down', event);
         },
         setPointerMove(event) {
-            if (this.pointer[event.pointerId])
-                this.pointer[event.pointerId].move = event;
+            if (this._pointer[event.pointerId])
+                this._pointer[event.pointerId].move = event;
             else {
-                this.pointer[event.pointerId] = { down: null, move: event, up: null };
+                this._pointer[event.pointerId] = { down: null, move: event, up: null };
                 this.pruneOldPointers();
             }
-            this.pointer.recent = event.pointerId;
+            this._pushRecent('pointer', 'move', event);
         },
         setPointerUp(event) {
-            if (this.pointer[event.pointerId])
-                this.pointer[event.pointerId].up = event;
+            if (this._pointer[event.pointerId])
+                this._pointer[event.pointerId].up = event;
             else {
-                this.pointer[event.pointerId] = { down: null, move: null, up: event };
+                this._pointer[event.pointerId] = { down: null, move: null, up: event };
                 this.pruneOldPointers();
             }
-            this.pointer.recent = event.pointerId;
+            this._pushRecent('pointer', 'up', event);
         },
         setKeyDown(event) {
-            if (this.keyboard[event.key]) this.keyboard[event.key].down = event;
-            else this.keyboard[event.key] = { down: event, up: null };
-            this.keyboard.recent = event.key;
+            if (this._keyboard[event.key]) this._keyboard[event.key].down = event;
+            else this._keyboard[event.key] = { down: event, up: null };
+            this._pushRecent('keyboard', 'down', event);
         },
         setKeyUp(event) {
-            if (this.keyboard[event.key]) this.keyboard[event.key].up = event;
-            else this.keyboard[event.key] = { down: null, up: event };
-            this.keyboard.recent = event.key;
+            if (this._keyboard[event.key]) this._keyboard[event.key].up = event;
+            else this._keyboard[event.key] = { down: null, up: event };
+            this._pushRecent('keyboard', 'up', event);
         },
         setWheel(event) {
-            this.wheel = event;
+            this._wheel = event;
+        },
+        getEvent(type, idOrKey) {
+            switch (type) {
+                case 'pointerdown':
+                    return this._pointer[idOrKey]?.down;
+                case 'pointermove':
+                    return this._pointer[idOrKey]?.move;
+                case 'pointerup':
+                    return this._pointer[idOrKey]?.up;
+                case 'keydown':
+                    return this._keyboard[idOrKey]?.down;
+                case 'keyup':
+                    return this._keyboard[idOrKey]?.up;
+                case 'wheel':
+                    return this._wheel;
+                default:
+                    return null;
+            }
+        },
+        _pushRecent(category, type, event) {
+            if (this._recentTicks[category][type] !== this._tick) {
+                this._recent[category][type].length = 0;
+                this._recentTicks[category][type] = this._tick;
+            }
+            this._recent[category][type].push(event);
+            if (!this._tickScheduled) {
+                this._tickScheduled = true;
+                nextTick(() => {
+                    this._tick++;
+                    this._tickScheduled = false;
+                });
+            }
         },
         pruneOldPointers() {
-            const entries = Object.entries(this.pointer).filter(([id]) => id !== 'recent');
+            const entries = Object.entries(this._pointer);
             if (entries.length <= MAX_POINTER_WINDOW) return;
             const getLatest = (p) => Math.max(p.down?.timeStamp || 0, p.move?.timeStamp || 0, p.up?.timeStamp || 0);
             entries.sort(([, a], [, b]) => getLatest(b) - getLatest(a));
             for (let i = MAX_POINTER_WINDOW; i < entries.length; i++) {
-                delete this.pointer[entries[i][0]];
+                delete this._pointer[entries[i][0]];
             }
         },
     },


### PR DESCRIPTION
## Summary
- clarify input helpers so `isPressed` checks keys while `isDragging` covers pointer presses via timestamps only
- update pixel and stage tools to rely on `isDragging` for pointer guards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac645e5c2c832ca38b85e254c281f3