### PR TITLE
Inline layer boundary helpers in query service

### DIFF
--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,42 +1,33 @@
 import { defineStore } from 'pinia';
-import { computed } from 'vue';
 import { useStore } from '../stores';
 
 export const useQueryService = defineStore('queryService', () => {
     const { layers } = useStore();
 
-    const uppermostId = computed(() => {
+    function uppermost(ids) {
         const order = layers.idsBottomToTop;
-        return order[order.length - 1] ?? null;
-    });
-    const lowermostId = computed(() => layers.idsBottomToTop[0] ?? null);
-
-    function uppermostIdOf(ids) {
+        if (ids == null) {
+            return order[order.length - 1] ?? null;
+        }
         const idSet = new Set(ids);
         if (!idSet.size) return null;
-        const order = layers.idsBottomToTop;
         const index = Math.max(
             ...order.map((id, idx) => (idSet.has(id) ? idx : -1))
         );
         return index >= 0 ? order[index] : null;
     }
 
-    function lowermostIdOf(ids) {
+    function lowermost(ids) {
+        const order = layers.idsBottomToTop;
+        if (ids == null) {
+            return order[0] ?? null;
+        }
         const idSet = new Set(ids);
         if (!idSet.size) return null;
-        const order = layers.idsBottomToTop;
         const index = Math.min(
             ...order.map((id, idx) => (idSet.has(id) ? idx : Infinity))
         );
         return isFinite(index) ? order[index] : null;
-    }
-
-    function uppermost(ids) {
-        return ids == null ? uppermostId.value : uppermostIdOf(ids);
-    }
-
-    function lowermost(ids) {
-        return ids == null ? lowermostId.value : lowermostIdOf(ids);
     }
 
     function above(id) {

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -76,9 +76,9 @@ export const useQueryService = defineStore('queryService', () => {
         above,
         below,
         empty,
-        byPixelCount,
-        byColor,
         disconnected,
+        byColor,
+        byPixelCount,
         byDisconnectedCount,
     };
 });


### PR DESCRIPTION
## Summary
- Inline top/bottom layer lookups inside `uppermost` and `lowermost`
- Remove unused computed helpers for layer ids

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad42f2fc3c832cbffa0bf3c95987cc