### PR TITLE
feat: track preview and affected pixels for tools

### DIFF
--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -2,110 +2,40 @@ import { defineStore } from 'pinia';
 import { useOverlayService } from './overlay';
 import { useStore } from '../stores';
 import { useStageToolService } from './stageTool';
-import { useViewportService } from './viewport';
 import { coordToKey } from '../utils';
 
 export const usePixelService = defineStore('pixelService', () => {
     const overlay = useOverlayService();
-    const { layers, viewportEvent: viewportEvents, viewport: viewportStore } = useStore();
-    const viewport = useViewportService();
+    const { layers } = useStore();
     let cutLayerId = null;
 
-    function startDraw() {
-        const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            addPixelsToSelection(pixels);
-        }
-    }
-
-    function moveDraw() {
-        const tool = useStageToolService();
-        if (tool.pointer.status !== 'draw' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        addPixelsToSelection([coord]);
-    }
-
+    function startDraw() {}
+    function moveDraw() {}
     function finishDraw() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'draw') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) addPixelsToSelection(pixels);
-        }
+        const pixels = tool.affectedPixels;
+        if (pixels.length > 0) addPixelsToSelection(pixels);
     }
 
-    function startErase() {
-        const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            removePixelsFromSelection(pixels);
-        }
-    }
-
-    function moveErase() {
-        const tool = useStageToolService();
-        if (tool.pointer.status !== 'erase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        removePixelsFromSelection([coord]);
-    }
-
+    function startErase() {}
+    function moveErase() {}
     function finishErase() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'erase') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) removePixelsFromSelection(pixels);
-        }
+        const pixels = tool.affectedPixels;
+        if (pixels.length > 0) removePixelsFromSelection(pixels);
     }
 
-    function startGlobalErase() {
-        const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            if (layers.selectionExists) removePixelsFromSelected(pixels);
-            else removePixelsFromAll(pixels);
-        }
-    }
-
-    function moveGlobalErase() {
-        const tool = useStageToolService();
-        if (tool.pointer.status !== 'globalErase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        if (layers.selectionExists) removePixelsFromSelected([coord]);
-        else removePixelsFromAll([coord]);
-    }
-
+    function startGlobalErase() {}
+    function moveGlobalErase() {}
     function finishGlobalErase() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'globalErase') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) {
-                if (layers.selectionExists) removePixelsFromSelected(pixels);
-                else removePixelsFromAll(pixels);
-            }
+        const pixels = tool.affectedPixels;
+        if (pixels.length > 0) {
+            if (layers.selectionExists) removePixelsFromSelected(pixels);
+            else removePixelsFromAll(pixels);
         }
     }
 
@@ -122,34 +52,13 @@ export const usePixelService = defineStore('pixelService', () => {
         overlay.helper.clear();
         overlay.helper.add(cutLayerId);
         overlay.helper.mode = 'add';
-
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            cutPixelsFromSelection(pixels);
-        }
     }
-
-    function moveCut() {
-        const tool = useStageToolService();
-        if (tool.pointer.status !== 'cut' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        cutPixelsFromSelection([coord]);
-    }
-
+    function moveCut() {}
     function finishCut() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'cut') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) cutPixelsFromSelection(pixels);
-        }
+        const pixels = tool.affectedPixels;
+        if (pixels.length > 0) cutPixelsFromSelection(pixels);
         if (cutLayerId != null) {
             if (layers.getProperty(cutLayerId, 'pixels').length)
                 layers.replaceSelection([cutLayerId]);
@@ -159,9 +68,7 @@ export const usePixelService = defineStore('pixelService', () => {
         cutLayerId = null;
     }
 
-    function cancel() {
-        cutLayerId = null;
-    }
+    function cancel() { cutLayerId = null; }
 
     function addPixelsToSelection(pixels) {
         if (layers.selectionCount !== 1) return;
@@ -242,3 +149,4 @@ export const usePixelService = defineStore('pixelService', () => {
         removePixelsFromAll
     };
 });
+

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -1,64 +1,15 @@
 import { defineStore } from 'pinia';
-import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
 import { useStore } from '../stores';
 import { useStageToolService } from './stageTool';
-import { useViewportService } from './viewport';
 
 export const useSelectService = defineStore('selectService', () => {
-    const overlay = useOverlayService();
     const layerPanel = useLayerPanelService();
     const { layers, viewportEvent: viewportEvents, viewport: viewportStore } = useStore();
-    const viewport = useViewportService();
 
-    const addByMode = (id) => {
-        const tool = useStageToolService();
-        const mode = tool.pointer.status;
-        if (mode === 'remove') {
-            if (layers.isSelected(id)) overlay.helper.add(id);
-        } else if (mode === 'add') {
-            if (!layers.isSelected(id)) overlay.helper.add(id);
-        } else {
-            overlay.helper.add(id);
-        }
-    };
+    function start(coord, startId) {}
 
-    function start(coord, startId) {
-        const tool = useStageToolService();
-        overlay.helper.clear();
-        if (tool.shape === 'rect') {
-            // rectangle interactions tracked directly in components
-        } else {
-            if (startId !== null) addByMode(startId);
-        }
-    }
-
-    function move() {
-        const tool = useStageToolService();
-        if (tool.pointer.status === 'idle') return;
-        if (!viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-
-        if (tool.shape === 'rect') {
-            const pixels = tool.getPixelsFromInteraction('move');
-            const intersectedIds = new Set();
-            for (const coord of pixels) {
-                const id = layers.topVisibleIdAt(coord);
-                if (id !== null) intersectedIds.add(id);
-            }
-            overlay.helper.clear();
-            intersectedIds.forEach(addByMode);
-        } else {
-            const coord = viewportStore.clientToCoord(event);
-            if (!coord) {
-                return;
-            }
-            const id = layers.topVisibleIdAt(coord);
-            if (id !== null) {
-                addByMode(id);
-            }
-        }
-    }
+    function move() {}
 
     function finish() {
         const tool = useStageToolService();
@@ -69,9 +20,9 @@ export const useSelectService = defineStore('selectService', () => {
         if (!event) return;
 
         const coord = viewportStore.clientToCoord(event);
-            const startEvent = viewportEvents.get('pointerdown', tool.pointer.id);
-            const dx = startEvent ? Math.abs(event.clientX - startEvent.clientX) : 0;
-            const dy = startEvent ? Math.abs(event.clientY - startEvent.clientY) : 0;
+        const startEvent = viewportEvents.get('pointerdown', tool.pointer.id);
+        const dx = startEvent ? Math.abs(event.clientX - startEvent.clientX) : 0;
+        const dy = startEvent ? Math.abs(event.clientY - startEvent.clientY) : 0;
         const isClick = dx <= 4 && dy <= 4;
         if (isClick && coord) {
             const id = layers.topVisibleIdAt(coord);
@@ -84,7 +35,7 @@ export const useSelectService = defineStore('selectService', () => {
                 layerPanel.setScrollRule({ type: 'follow', target: id });
             }
         } else {
-            const pixels = tool.getPixelsFromInteraction('up');
+            const pixels = tool.affectedPixels;
             if (pixels.length > 0) {
                 const intersectedIds = new Set();
                 for (const coord of pixels) {


### PR DESCRIPTION
## Summary
- add preview and affected pixel sets to stage tool service and keep helper overlay in sync
- update pixel tools to apply changes from affected pixel sets
- simplify selection tool to operate on affected pixels

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad8335b1ac832c9f6ee602548a19ab