### PR TITLE
feat: add preview and affected pixel states to viewport tools

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -56,7 +56,7 @@
                 shape-rendering="crispEdges" />
 
         <!-- Helper overlay -->
-        <path v-if="stageToolService.isSelect || stageToolService.pointer.status === 'cut'"
+        <path v-if="helperOverlay.path"
               :d="helperOverlay.path"
               :fill="helperOverlay.FILL_COLOR"
               :stroke="helperOverlay.STROKE_COLOR"
@@ -83,8 +83,11 @@ const stage = viewportStore.stage;
 
 const onStagePointerLeave = (e) => {
     if (e.pointerType === 'touch') return;
+    if (stageToolService.pointer.status !== 'idle') return;
     overlay.helper.clear();
     overlay.helper.mode = 'add';
+    stageToolService.previewPixels = [];
+    stageToolService.affectedPixels = [];
     viewportStore.updatePixelInfo('-');
 };
 
@@ -92,7 +95,8 @@ const helperOverlay = computed(() => {
     const path = overlay.helper.path;
     if (!path) return { path }; // no style when empty
 
-    const mode = stageToolService.pointer.status === 'remove'
+    const removingStatuses = ['remove', 'erase', 'globalErase'];
+    const mode = removingStatuses.includes(stageToolService.pointer.status)
         ? 'remove'
         : stageToolService.pointer.status === 'idle'
             ? overlay.helper.mode

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -21,7 +21,12 @@ export const useOverlayService = defineStore('overlayService', () => {
             const pixels = layers.getProperty(id, 'pixels') || [];
             for (const coord of pixels) pixelKeys.add(coordToKey(coord));
         }
-        return { pixels: pixelKeys, path, clear, add };
+        function setPixels(coords) {
+            pixelKeys.clear();
+            if (!coords || !coords.length) return;
+            for (const coord of coords) pixelKeys.add(coordToKey(coord));
+        }
+        return { pixels: pixelKeys, path, clear, add, setPixels };
     }
 
     const selection = createOverlayState();

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -1,64 +1,17 @@
 import { defineStore } from 'pinia';
-import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
 import { useStore } from '../stores';
 import { useStageToolService } from './stageTool';
 import { useViewportService } from './viewport';
 
 export const useSelectService = defineStore('selectService', () => {
-    const overlay = useOverlayService();
     const layerPanel = useLayerPanelService();
     const { layers, viewportEvent: viewportEvents, viewport: viewportStore } = useStore();
     const viewport = useViewportService();
 
-    const addByMode = (id) => {
-        const tool = useStageToolService();
-        const mode = tool.pointer.status;
-        if (mode === 'remove') {
-            if (layers.isSelected(id)) overlay.helper.add(id);
-        } else if (mode === 'add') {
-            if (!layers.isSelected(id)) overlay.helper.add(id);
-        } else {
-            overlay.helper.add(id);
-        }
-    };
+    function start(coord, startId) {}
 
-    function start(coord, startId) {
-        const tool = useStageToolService();
-        overlay.helper.clear();
-        if (tool.shape === 'rect') {
-            // rectangle interactions tracked directly in components
-        } else {
-            if (startId !== null) addByMode(startId);
-        }
-    }
-
-    function move() {
-        const tool = useStageToolService();
-        if (tool.pointer.status === 'idle') return;
-        if (!viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-
-        if (tool.shape === 'rect') {
-            const pixels = tool.getPixelsFromInteraction('move');
-            const intersectedIds = new Set();
-            for (const coord of pixels) {
-                const id = layers.topVisibleIdAt(coord);
-                if (id !== null) intersectedIds.add(id);
-            }
-            overlay.helper.clear();
-            intersectedIds.forEach(addByMode);
-        } else {
-            const coord = viewportStore.clientToCoord(event);
-            if (!coord) {
-                return;
-            }
-            const id = layers.topVisibleIdAt(coord);
-            if (id !== null) {
-                addByMode(id);
-            }
-        }
-    }
+    function move() {}
 
     function finish() {
         const tool = useStageToolService();
@@ -69,9 +22,9 @@ export const useSelectService = defineStore('selectService', () => {
         if (!event) return;
 
         const coord = viewportStore.clientToCoord(event);
-            const startEvent = viewportEvents.get('pointerdown', tool.pointer.id);
-            const dx = startEvent ? Math.abs(event.clientX - startEvent.clientX) : 0;
-            const dy = startEvent ? Math.abs(event.clientY - startEvent.clientY) : 0;
+        const startEvent = viewportEvents.get('pointerdown', tool.pointer.id);
+        const dx = startEvent ? Math.abs(event.clientX - startEvent.clientX) : 0;
+        const dy = startEvent ? Math.abs(event.clientY - startEvent.clientY) : 0;
         const isClick = dx <= 4 && dy <= 4;
         if (isClick && coord) {
             const id = layers.topVisibleIdAt(coord);
@@ -84,7 +37,7 @@ export const useSelectService = defineStore('selectService', () => {
                 layerPanel.setScrollRule({ type: 'follow', target: id });
             }
         } else {
-            const pixels = tool.getPixelsFromInteraction('up');
+            const pixels = tool.affectedPixels;
             if (pixels.length > 0) {
                 const intersectedIds = new Set();
                 for (const coord of pixels) {

--- a/src/services/stageTool.js
+++ b/src/services/stageTool.js
@@ -5,7 +5,7 @@ import { useOverlayService } from './overlay';
 import { useSelectService } from './select';
 import { usePixelService } from './pixel';
 import { useViewportService } from './viewport';
-import { calcMarquee, rgbaCssU32, rgbaCssObj } from '../utils';
+import { calcMarquee, rgbaCssU32, rgbaCssObj, coordToKey } from '../utils';
 import { CURSOR_CONFIG } from '@/constants';
 
 export const useStageToolService = defineStore('stageToolService', () => {
@@ -19,6 +19,8 @@ export const useStageToolService = defineStore('stageToolService', () => {
     const shape = ref('stroke');
     const pointer = reactive({ status: 'idle', id: null });
     const marquee = reactive({ visible: false, x: 0, y: 0, w: 0, h: 0 });
+    const previewPixels = ref([]);
+    const affectedPixels = ref([]);
 
     const active = computed(() => {
         if (pointer.status !== 'idle') {
@@ -49,6 +51,37 @@ export const useStageToolService = defineStore('stageToolService', () => {
 
     function setPrepared(t) { prepared.value = t; }
     function setShape(s) { shape.value = s === 'rect' ? 'rect' : 'stroke'; }
+
+    function resetPreview() {
+        previewPixels.value = [];
+    }
+
+    function setPreview(pixels) {
+        if (!pixels || !pixels.length) {
+            overlay.helper.setPixels([]);
+            previewPixels.value = [];
+            return;
+        }
+        if (shape.value === 'stroke') {
+            const set = new Set(previewPixels.value.map(coordToKey));
+            for (const coord of pixels) {
+                const key = coordToKey(coord);
+                if (!set.has(key)) {
+                    set.add(key);
+                    previewPixels.value.push(coord);
+                }
+            }
+        } else {
+            previewPixels.value = pixels.slice();
+        }
+        overlay.helper.setPixels(previewPixels.value);
+    }
+
+    function finalizePreview() {
+        affectedPixels.value = previewPixels.value.slice();
+        overlay.helper.setPixels(affectedPixels.value);
+        resetPreview();
+    }
 
     const updateHover = (event) => {
         const coord = viewportStore.clientToCoord(event);
@@ -148,7 +181,6 @@ export const useStageToolService = defineStore('stageToolService', () => {
                 e.target.setPointerCapture?.(e.pointerId);
                 pointer.id = e.pointerId;
             } catch {}
-
             if (isSelect.value) {
                 const startId = layers.topVisibleIdAt(coord);
                 const mode = !viewportEvents.isPressed('Shift')
@@ -157,13 +189,20 @@ export const useStageToolService = defineStore('stageToolService', () => {
                         ? 'remove'
                         : 'add';
                 pointer.status = mode;
-                overlay.helper.mode = mode === 'remove' ? 'remove' : 'add';
-                selectSvc.tools.select.start(coord, startId);
             } else {
                 pointer.status = active.value;
+            }
+            overlay.helper.mode = (pointer.status === 'erase' || pointer.status === 'globalErase' || pointer.status === 'remove') ? 'remove' : 'add';
+            resetPreview();
+            affectedPixels.value = [];
+            setPreview(getPixelsFromInteraction('down'));
+            updateMarquee(e);
+            if (isSelect.value) {
+                const startId = layers.topVisibleIdAt(coord);
+                selectSvc.tools.select.start(coord, startId);
+            } else {
                 pixelSvc.tools[active.value].start();
             }
-            updateMarquee(e);
         }
     });
 
@@ -172,6 +211,7 @@ export const useStageToolService = defineStore('stageToolService', () => {
         if (!e || !viewportEvents.isDragging(pointer.id) || viewportEvents.pinchIds) return;
         updateHover(e);
         updateMarquee(e);
+        setPreview(getPixelsFromInteraction('move'));
         if (isSelect.value) selectSvc.tools.select.move();
         else pixelSvc.tools[active.value].move();
     });
@@ -181,10 +221,16 @@ export const useStageToolService = defineStore('stageToolService', () => {
         if (!e || viewportEvents.isDragging(pointer.id) || viewportEvents.pinchIds) return;
         updateMarquee(e);
         if (e.type === 'pointercancel') {
+            resetPreview();
+            affectedPixels.value = [];
+            overlay.helper.clear();
+            overlay.helper.mode = 'add';
             if (isSelect.value) selectSvc.cancel();
             else pixelSvc.cancel();
             output.rollbackPending();
         } else {
+            setPreview(getPixelsFromInteraction('up'));
+            finalizePreview();
             if (isSelect.value) selectSvc.tools.select.finish();
             else pixelSvc.tools[active.value].finish();
             output.commit();
@@ -192,13 +238,15 @@ export const useStageToolService = defineStore('stageToolService', () => {
         try { e.target?.releasePointerCapture?.(pointer.id); } catch {}
         pointer.status = 'idle';
         pointer.id = null;
-        overlay.helper.clear();
-        overlay.helper.mode = 'add';
     });
 
     watch(() => viewportEvents.pinchIds, (ids) => {
         if (!ids || pointer.status === 'idle') return;
         updateMarquee(null);
+        resetPreview();
+        affectedPixels.value = [];
+        overlay.helper.clear();
+        overlay.helper.mode = 'add';
         if (isSelect.value) selectSvc.cancel();
         else pixelSvc.cancel();
         output.rollbackPending();
@@ -206,8 +254,6 @@ export const useStageToolService = defineStore('stageToolService', () => {
         try { startEvent?.target?.releasePointerCapture?.(pointer.id); } catch {}
         pointer.status = 'idle';
         pointer.id = null;
-        overlay.helper.clear();
-        overlay.helper.mode = 'add';
     });
 
     return {
@@ -227,5 +273,9 @@ export const useStageToolService = defineStore('stageToolService', () => {
         setShape,
         cursor,
         getPixelsFromInteraction,
+        previewPixels,
+        affectedPixels,
+        setPreview,
+        finalizePreview,
     };
 });


### PR DESCRIPTION
## Summary
- track previewPixels and affectedPixels in stage tool service
- update tools to use affectedPixels and show helper overlay independent of shape
- allow overlay service to set pixel lists directly
- keep helper overlay and pixel state when leaving the stage during drag

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad8335b1ac832c9f6ee602548a19ab