### PR TITLE
refactor: move pixelated and layer styles to scoped CSS

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -199,25 +199,6 @@ onUnmounted(() => {
 /* Global styles from pixel.html */
 [v-cloak]{display:none}
 
-/* 레이어 재정렬 표시 */
-.insert-before{box-shadow:inset 0 3px 0 0 rgba(56,189,248,.7)}
-.insert-after{box-shadow:inset 0 -3px 0 0 rgba(56,189,248,.7)}
-
-/* 선택 강조 */
-.layer.selected{
-  outline:2px solid rgba(56,189,248,.70);
-  background:linear-gradient(180deg,rgba(56,189,248,.12),rgba(56,189,248,.05));
-  border-color:rgba(56,189,248,.35)
-}
-.layer.selected.anchor{
-  outline:3px solid rgba(56,189,248,.95);
-  background:linear-gradient(180deg,rgba(56,189,248,.18),rgba(56,189,248,.07));
-  border-color:rgba(56,189,248,.6)
-}
-
-/* 드래그/이름편집 UX */
-.layers.dragging,.layers .layer.dragging{cursor:grabbing!important}
-
 /* Scrollbar styling */
 *{
   scrollbar-width:thin;

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -9,7 +9,7 @@
         </g>
       </svg>
       <!-- 원본 -->
-        <img v-show="viewportStore.display!=='original'" class="w-44 h-44 object-contain rounded-md border border-white/15" :src="viewportStore.imageSrc" alt="source image" style="image-rendering:pixelated"/>
+        <img v-show="viewportStore.display!=='original'" class="w-44 h-44 object-contain rounded-md border border-white/15" :src="viewportStore.imageSrc" alt="source image"/>
     </div>
     <div class="flex-1 min-w-0 flex flex-col gap-2">
       <div class="flex gap-2 items-center">
@@ -50,3 +50,9 @@ function selectAll() {
 }
 onMounted(() => generate());
 </script>
+
+<style scoped>
+img {
+  image-rendering: pixelated;
+}
+</style>

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -360,3 +360,24 @@ onUnmounted(() => {
     });
 });
 </script>
+
+<style scoped>
+/* 레이어 재정렬 표시 */
+.insert-before{box-shadow:inset 0 3px 0 0 rgba(56,189,248,.7)}
+.insert-after{box-shadow:inset 0 -3px 0 0 rgba(56,189,248,.7)}
+
+/* 선택 강조 */
+.layer.selected{
+  outline:2px solid rgba(56,189,248,.70);
+  background:linear-gradient(180deg,rgba(56,189,248,.12),rgba(56,189,248,.05));
+  border-color:rgba(56,189,248,.35)
+}
+.layer.selected.anchor{
+  outline:3px solid rgba(56,189,248,.95);
+  background:linear-gradient(180deg,rgba(56,189,248,.18),rgba(56,189,248,.07));
+  border-color:rgba(56,189,248,.6)
+}
+
+/* 드래그/이름편집 UX */
+.layers.dragging,.layers .layer.dragging{cursor:grabbing!important}
+</style>

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -16,26 +16,26 @@
          @pointerleave="onStagePointerLeave"
          @contextmenu.prevent>
       <!-- 체커보드 -->
-      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" style="image-rendering:pixelated">
+      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <rect x="0" y="0" :width="stage.width" :height="stage.height" :fill="patternUrl"/>
       </svg>
       <!-- 원본 -->
-      <img v-show="viewportStore.display==='original'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :src="viewportStore.imageSrc" alt="source image" style="image-rendering:pixelated" @load="onImageLoad" />
+      <img v-show="viewportStore.display==='original'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :src="viewportStore.imageSrc" alt="source image" @load="onImageLoad" />
       <!-- 결과 레이어 -->
-      <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" style="image-rendering:pixelated">
+      <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g>
             <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visible?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->
-      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" style="image-rendering:pixelated">
+      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g :stroke="GRID_STROKE_COLOR" :stroke-width="1/Math.max(1,stage.scale)">
           <path v-for="x in (stage.width+1)" :key="'gx'+x" :d="'M '+(x-1)+' 0 V '+stage.height"></path>
           <path v-for="y in (stage.height+1)" :key="'gy'+y" :d="'M 0 '+(y-1)+' H '+stage.width"></path>
         </g>
       </svg>
       <!-- 오버레이 (선택, 추가, 제거, 마퀴) -->
-      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" style="image-rendering:pixelated">
+      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
           <!-- Selection overlay (sky blue) -->
           <path id="selectionOverlay"
                 v-if="layers.selectionExists"
@@ -143,3 +143,10 @@ onMounted(() => {
 });
 onUnmounted(resizeObserver.disconnect);
 </script>
+
+<style scoped>
+#stage img,
+#stage svg {
+  image-rendering: pixelated;
+}
+</style>


### PR DESCRIPTION
## Summary
- remove repeated `image-rendering: pixelated` inline styles from image and svg tags
- define scoped CSS rules to apply pixelated rendering in ExportPanel and Viewport components
- move layer-specific styling from App.vue into LayersPanel's scoped CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad7e9416a0832cbf00a847adcea153