### PR TITLE
refactor: delegate helper overlays to tools

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -84,7 +84,7 @@ const stage = viewportStore.stage;
 const onStagePointerLeave = (e) => {
     if (e.pointerType === 'touch') return;
     overlay.helper.clear();
-    overlay.helper.mode = 'add';
+    overlay.helper.config = OVERLAY_CONFIG.ADD;
     viewportStore.updatePixelInfo('-');
 };
 
@@ -92,12 +92,11 @@ const helperOverlay = computed(() => {
     const path = overlay.helper.path;
     if (!path) return { path }; // no style when empty
 
-    const mode = stageToolService.pointer.status === 'remove'
-        ? 'remove'
+    const style = stageToolService.pointer.status === 'remove'
+        ? OVERLAY_CONFIG.REMOVE
         : stageToolService.pointer.status === 'idle'
-            ? overlay.helper.mode
-            : 'add';
-    const style = mode === 'remove' ? OVERLAY_CONFIG.REMOVE : OVERLAY_CONFIG.ADD;
+            ? overlay.helper.config
+            : OVERLAY_CONFIG.ADD;
 
     return {
         path,

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { computed, reactive, ref, watch } from 'vue';
 import { useStore } from '../stores';
 import { coordToKey, keyToCoord, pixelsToUnionPath } from '../utils';
+import { OVERLAY_CONFIG } from '@/constants';
 
 export const useOverlayService = defineStore('overlayService', () => {
     const { layers } = useStore();
@@ -26,7 +27,7 @@ export const useOverlayService = defineStore('overlayService', () => {
 
     const selection = createOverlayState();
     const helper = createOverlayState();
-    const helperMode = ref('add');
+    const helperConfig = ref(OVERLAY_CONFIG.ADD);
 
     function rebuildSelection() {
         selection.clear();
@@ -37,6 +38,6 @@ export const useOverlayService = defineStore('overlayService', () => {
 
     return {
         selection,
-        helper: { ...helper, mode: helperMode }
+        helper: { ...helper, config: helperConfig }
     };
 });

--- a/src/services/pixel.js
+++ b/src/services/pixel.js
@@ -2,111 +2,66 @@ import { defineStore } from 'pinia';
 import { useOverlayService } from './overlay';
 import { useStore } from '../stores';
 import { useStageToolService } from './stageTool';
-import { useViewportService } from './viewport';
 import { coordToKey } from '../utils';
+import { OVERLAY_CONFIG } from '@/constants';
 
 export const usePixelService = defineStore('pixelService', () => {
     const overlay = useOverlayService();
-    const { layers, viewportEvent: viewportEvents, viewport: viewportStore } = useStore();
-    const viewport = useViewportService();
+    const { layers } = useStore();
     let cutLayerId = null;
 
     function startDraw() {
         const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            addPixelsToSelection(pixels);
-        }
+        addPixelsToSelection(tool.affectedPixels);
     }
 
     function moveDraw() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'draw' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        addPixelsToSelection([coord]);
+        if (tool.pointer.status !== 'draw') return;
+        addPixelsToSelection(tool.affectedPixels);
     }
 
     function finishDraw() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'draw') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) addPixelsToSelection(pixels);
-        }
+        addPixelsToSelection(tool.affectedPixels);
     }
 
     function startErase() {
         const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            removePixelsFromSelection(pixels);
-        }
+        removePixelsFromSelection(tool.affectedPixels);
     }
 
     function moveErase() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'erase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        removePixelsFromSelection([coord]);
+        if (tool.pointer.status !== 'erase') return;
+        removePixelsFromSelection(tool.affectedPixels);
     }
 
     function finishErase() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'erase') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) removePixelsFromSelection(pixels);
-        }
+        removePixelsFromSelection(tool.affectedPixels);
     }
 
     function startGlobalErase() {
         const tool = useStageToolService();
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            if (layers.selectionExists) removePixelsFromSelected(pixels);
-            else removePixelsFromAll(pixels);
-        }
+        if (layers.selectionExists) removePixelsFromSelected(tool.affectedPixels);
+        else removePixelsFromAll(tool.affectedPixels);
     }
 
     function moveGlobalErase() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'globalErase' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        if (layers.selectionExists) removePixelsFromSelected([coord]);
-        else removePixelsFromAll([coord]);
+        if (tool.pointer.status !== 'globalErase') return;
+        if (layers.selectionExists) removePixelsFromSelected(tool.affectedPixels);
+        else removePixelsFromAll(tool.affectedPixels);
     }
 
     function finishGlobalErase() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'globalErase') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) {
-                if (layers.selectionExists) removePixelsFromSelected(pixels);
-                else removePixelsFromAll(pixels);
-            }
-        }
+        if (layers.selectionExists) removePixelsFromSelected(tool.affectedPixels);
+        else removePixelsFromAll(tool.affectedPixels);
     }
 
     function startCut() {
@@ -121,35 +76,21 @@ export const usePixelService = defineStore('pixelService', () => {
         }, sourceId);
         overlay.helper.clear();
         overlay.helper.add(cutLayerId);
-        overlay.helper.mode = 'add';
+        overlay.helper.config = OVERLAY_CONFIG.ADD;
 
-        if (tool.shape !== 'rect') {
-            if (!viewportEvents.isDragging(tool.pointer.id)) return;
-            const event = viewportEvents.get('pointerdown', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('down');
-            cutPixelsFromSelection(pixels);
-        }
+        cutPixelsFromSelection(tool.affectedPixels);
     }
 
     function moveCut() {
         const tool = useStageToolService();
-        if (tool.pointer.status !== 'cut' || tool.shape === 'rect' || !viewportEvents.isDragging(tool.pointer.id)) return;
-        const event = viewportEvents.get('pointermove', tool.pointer.id);
-        const coord = viewportStore.clientToCoord(event);
-        if (!coord) return;
-        cutPixelsFromSelection([coord]);
+        if (tool.pointer.status !== 'cut') return;
+        cutPixelsFromSelection(tool.affectedPixels);
     }
 
     function finishCut() {
         const tool = useStageToolService();
         if (tool.pointer.status !== 'cut') return;
-        if (tool.shape === 'rect') {
-            const event = viewportEvents.get('pointerup', tool.pointer.id);
-            if (!event) return;
-            const pixels = tool.getPixelsFromInteraction('up');
-            if (pixels.length > 0) cutPixelsFromSelection(pixels);
-        }
+        cutPixelsFromSelection(tool.affectedPixels);
         if (cutLayerId != null) {
             if (layers.getProperty(cutLayerId, 'pixels').length)
                 layers.replaceSelection([cutLayerId]);
@@ -157,10 +98,14 @@ export const usePixelService = defineStore('pixelService', () => {
                 layers.deleteLayers([cutLayerId]);
         }
         cutLayerId = null;
+        overlay.helper.clear();
+        overlay.helper.config = OVERLAY_CONFIG.ADD;
     }
 
     function cancel() {
         cutLayerId = null;
+        overlay.helper.clear();
+        overlay.helper.config = OVERLAY_CONFIG.ADD;
     }
 
     function addPixelsToSelection(pixels) {


### PR DESCRIPTION
## Summary
- replace helper overlay mode with configurable OVERLAY_CONFIG state
- supply desired overlay config from select and pixel tools
- derive cursor and helper overlay style from provided config

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad905e318c832c80380450e6edf63c