### PR TITLE
feat: decouple tool selection service from specific tools

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -56,7 +56,7 @@
                 shape-rendering="crispEdges" />
 
         <!-- Helper overlay -->
-        <path v-if="toolSelectionService.isSelect || toolSelectionService.pointer.status === 'cut'"
+        <path v-if="toolSelectionService.active === 'select' || toolSelectionService.pointer.status === 'cut'"
               :d="helperOverlay.path"
               :fill="helperOverlay.FILL_COLOR"
               :stroke="helperOverlay.STROKE_COLOR"

--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -43,11 +43,13 @@
 import { ref, watch } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
-import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS } from '@/constants';
+import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, TOOL_MODIFIERS } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
 
 const { viewport: viewportStore, layers, output, viewportEvent: viewportEvents } = useStore();
 const { toolSelection: toolSelectionService } = useService();
+
+const ctrlToggleMap = TOOL_MODIFIERS.find(m => m.key === 'Control')?.map || {};
 
 const selectables = ref(SINGLE_SELECTION_TOOLS);
 watch(() => layers.selectionCount, (size) => {
@@ -77,11 +79,8 @@ function ctrlKeyUp(e) {
     const down = viewportEvents.get('keydown', e.key);
     if (down && !down.repeat) {
       const t = toolSelectionService.prepared;
-      if (t === 'draw' || t === 'erase') {
-        toolSelectionService.setPrepared(t === 'draw' ? 'erase' : 'draw');
-      } else if (t === 'select' || t === 'globalErase') {
-        toolSelectionService.setPrepared(t === 'select' ? 'globalErase' : 'select');
-      }
+      const toggle = ctrlToggleMap[t];
+      if (toggle) toolSelectionService.setPrepared(toggle);
     }
     viewportEvents.setKeyUp(e);
   } else {

--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -10,3 +10,25 @@ export const MULTI_SELECTION_TOOLS = [
   { type: 'select', name: 'Select', icon: stageIcons.select },
   { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
 ];
+
+// Mapping of keyboard modifiers to alternative tools. Each entry is
+// evaluated in order and only applied when the modifier key is pressed.
+//
+// - `map` is a dictionary where the current tool maps to the alternate
+//   tool when the modifier is active.
+// - `default` can be used to specify a tool to use when there is no
+//   mapping for the current tool.
+//
+// This allows the tool selection service to work without hard‑coding
+// knowledge of all tools.
+export const TOOL_MODIFIERS = [
+  { key: 'Shift', map: { default: 'select' } },
+  {
+    key: 'Control',
+    map: { draw: 'erase', erase: 'draw', select: 'globalErase', globalErase: 'select' }
+  },
+  {
+    key: 'Meta',
+    map: { draw: 'erase', erase: 'draw', select: 'globalErase', globalErase: 'select' }
+  }
+];

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -274,7 +274,7 @@ export const useSelectService = defineStore('selectService', () => {
     });
 
     const updateHoverOverlay = () => {
-        if (!tool.isSelect) {
+        if (tool.active !== 'select') {
             overlay.helper.clear();
             overlay.helper.config = OVERLAY_CONFIG.ADD;
             return;
@@ -295,7 +295,7 @@ export const useSelectService = defineStore('selectService', () => {
 
     watch(() => tool.previewPixels.slice(), updateHoverOverlay);
     watch(() => tool.pointer.status, updateHoverOverlay);
-    watch(() => tool.isSelect, updateHoverOverlay);
+    watch(() => tool.active, updateHoverOverlay);
 
     return { cancel };
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,36 +13,6 @@ export function getPixelUnion(props = []) {
     return [...set].map(keyToCoord);
 }
 
-export function calcMarquee(startEvent, currentEvent, viewportStore, viewportEl) {
-    if (!startEvent || !currentEvent || !viewportEl) return { visible: false, x: 0, y: 0, w: 0, h: 0 };
-    const rect = viewportEl.getBoundingClientRect();
-    const style = getComputedStyle(viewportEl);
-    const leftBase = rect.left + parseFloat(style.paddingLeft) + viewportStore.stage.offset.x;
-    const topBase = rect.top + parseFloat(style.paddingTop) + viewportStore.stage.offset.y;
-    const scale = viewportStore.stage.scale;
-    const width = viewportStore.stage.width;
-    const height = viewportStore.stage.height;
-    const left = Math.min(startEvent.clientX, currentEvent.clientX) - leftBase;
-    const top = Math.min(startEvent.clientY, currentEvent.clientY) - topBase;
-    const right = Math.max(startEvent.clientX, currentEvent.clientX) - leftBase;
-    const bottom = Math.max(startEvent.clientY, currentEvent.clientY) - topBase;
-    const minX = Math.floor(left / scale),
-        maxX = Math.floor((right - 1) / scale);
-    const minY = Math.floor(top / scale),
-        maxY = Math.floor((bottom - 1) / scale);
-    const minx = clamp(minX, 0, width - 1),
-        maxx = clamp(maxX, 0, width - 1);
-    const miny = clamp(minY, 0, height - 1),
-        maxy = clamp(maxY, 0, height - 1);
-    return {
-        visible: true,
-        x: minx,
-        y: miny,
-        w: (maxx >= minx) ? (maxx - minx + 1) : 0,
-        h: (maxy >= miny) ? (maxy - miny + 1) : 0,
-    };
-}
-
 export function ensureCheckerboardPattern(target = document.body) {
     const { PATTERN_ID, COLOR_A, COLOR_B, REPEAT } = CHECKERBOARD_CONFIG;
     const id = PATTERN_ID;


### PR DESCRIPTION
## Summary
- externalize modifier-to-tool mapping
- compute active tool based on dynamic mapping
- toggle prepared tool using mapping in toolbar
- inline marquee calculation into tool selection service and drop tool-specific flags

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adad70eb8c832cb0244e6f36c8884c