### PR TITLE
Rename layer visible property to visibility

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -170,7 +170,7 @@ onMounted(async () => {
       layers.createLayer({
         name: `Auto ${i+1}`,
         color: segment.colorU32,
-        visible: true,
+        visibility: true,
         pixels: segment.pixels
       });
     }

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="viewportStore.display!=='result'" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
         <g>
-            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visible?'visible':'hidden'"></path>
+            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -5,7 +5,7 @@
       <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
         <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
           <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visible?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
         </svg>
       </div>
       <!-- 색상 -->
@@ -29,7 +29,7 @@
       <!-- 액션 -->
       <div class="flex gap-1 justify-end">
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(props.visible?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
+          <img :src="(props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
           <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
@@ -179,9 +179,9 @@ function onColorChange() {
 function toggleVisibility(id) {
     output.setRollbackPoint();
     if (layers.isSelected(id)) {
-        const value = !layers.getProperty(id, 'visible');
+        const value = !layers.getProperty(id, 'visibility');
         for (const sid of layers.selectedIds) {
-            layers.updateProperties(sid, { visible: value });
+            layers.updateProperties(sid, { visibility: value });
         }
     } else {
         layers.toggleVisibility(id);

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -23,7 +23,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g>
-            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visible?'visible':'hidden'"></path>
+            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -45,7 +45,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             const newLayerId = layers.createLayer({
                 name: `Copy of ${layer.name}`,
                 color: layer.color,
-                visible: layer.visible,
+                visibility: layer.visibility,
                 pixels
             }, id);
             newLayerIds.push(newLayerId);
@@ -64,14 +64,14 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         const originalLayer = layers.getProperties(layerId);
         const originalName = originalLayer.name;
         const originalColor = originalLayer.color;
-        const originalVisibility = originalLayer.visible;
+        const originalVisibility = originalLayer.visibility;
         const originalIndex = layers.indexOfLayer(layerId);
 
         const newIds = components.reverse().map((componentPixels, index) => (
             layers.createLayer({
                 name: `${originalName} #${components.length - index}`,
                 color: originalColor,
-                visible: originalVisibility,
+                visibility: originalVisibility,
                 pixels: componentPixels
             })
         ));

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -118,7 +118,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
         const newLayerId = layers.createLayer({
             name: `Cut of ${layers.getProperty(sourceId, 'name')}`,
             color: layers.getProperty(sourceId, 'color'),
-            visible: layers.getProperty(sourceId, 'visible'),
+            visibility: layers.getProperty(sourceId, 'visibility'),
             pixels: cutCoords,
         }, sourceId);
 

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -7,7 +7,7 @@ export const useLayerStore = defineStore('layers', {
         _order: [],
         _name: {},
         _color: {},
-        _visible: {},
+        _visibility: {},
         _locked: {},
         _pixels: {},
         _selection: new Set()
@@ -28,8 +28,8 @@ export const useLayerStore = defineStore('layers', {
                     return state._name[id];
                 case 'color':
                     return (state._color[id] >>> 0);
-                case 'visible':
-                    return !!state._visible[id];
+                case 'visibility':
+                    return !!state._visibility[id];
                 case 'locked':
                     return !!state._locked[id];
                 case 'pixels':
@@ -43,7 +43,7 @@ export const useLayerStore = defineStore('layers', {
                 id,
                 name: state._name[id],
                 color: (state._color[id] >>> 0),
-                visible: !!state._visible[id],
+                visibility: !!state._visibility[id],
                 locked: !!state._locked[id],
                 pixels: [...state._pixels[id]].map(keyToCoord)
             });
@@ -60,7 +60,7 @@ export const useLayerStore = defineStore('layers', {
             const key = coordToKey(coord);
             for (let i = state._order.length - 1; i >= 0; i--) {
                 const id = state._order[i];
-                if (!state._visible[id]) continue;
+                if (!state._visibility[id]) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return (state._color[id] >>> 0);
             }
@@ -70,7 +70,7 @@ export const useLayerStore = defineStore('layers', {
             const key = coordToKey(coord);
             for (let i = state._order.length - 1; i >= 0; i--) {
                 const id = state._order[i];
-                if (!state._visible[id]) continue;
+                if (!state._visibility[id]) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return id;
             }
@@ -87,7 +87,7 @@ export const useLayerStore = defineStore('layers', {
         createLayer(layerProperties = {}, above = null) {
             const id = this._allocId();
             this._name[id] = layerProperties.name || 'Layer';
-            this._visible[id] = layerProperties.visible ?? true;
+            this._visibility[id] = layerProperties.visibility ?? true;
             this._locked[id] = layerProperties.locked ?? false;
             this._color[id] = (layerProperties.color ?? randColorU32()) >>> 0;
             const keyedPixels = layerProperties.pixels ? layerProperties.pixels.map(coordToKey) : [];
@@ -104,14 +104,14 @@ export const useLayerStore = defineStore('layers', {
         updateProperties(id, props) {
             if (this._name[id] == null) return;
             if (props.name !== undefined) this._name[id] = props.name;
-            if (props.visible !== undefined) this._visible[id] = !!props.visible;
+            if (props.visibility !== undefined) this._visibility[id] = !!props.visibility;
             if (props.locked !== undefined) this._locked[id] = !!props.locked;
             if (!this._locked[id] && props.color !== undefined) this._color[id] = (props.color >>> 0);
             if (!this._locked[id] && props.pixels !== undefined) this._pixels[id] = new Set(props.pixels.map(coordToKey));
         },
         toggleVisibility(id) {
             if (this._name[id] == null) return;
-            this._visible[id] = !this._visible[id];
+            this._visibility[id] = !this._visibility[id];
         },
         toggleLock(id) {
             if (this._name[id] == null) return;
@@ -141,7 +141,7 @@ export const useLayerStore = defineStore('layers', {
             for (const id of idSet) {
                 delete this._name[id];
                 delete this._color[id];
-                delete this._visible[id];
+                delete this._visibility[id];
                 delete this._locked[id];
                 delete this._pixels[id];
             }
@@ -189,7 +189,7 @@ export const useLayerStore = defineStore('layers', {
                 order: this._order.slice(),
                 byId: Object.fromEntries(this._order.map(id => [id, {
                     name: this._name[id],
-                    visible: !!this._visible[id],
+                    visibility: !!this._visibility[id],
                     locked: !!this._locked[id],
                     color: (this._color[id] >>> 0),
                     pixels: [...this._pixels[id]].map(key => keyToCoord(key))
@@ -204,7 +204,7 @@ export const useLayerStore = defineStore('layers', {
             this._order = [];
             this._name = {};
             this._color = {};
-            this._visible = {};
+            this._visibility = {};
             this._locked = {};
             this._pixels = {};
             // rebuild
@@ -213,7 +213,7 @@ export const useLayerStore = defineStore('layers', {
                 const info = byId[idStr] || byId[id];
                 if (!info) continue;
                 this._name[id] = info.name || 'Layer';
-                this._visible[id] = !!info.visible;
+                this._visibility[id] = !!info.visibility;
                 this._locked[id] = !!info.locked;
                 this._color[id] = (info.color ?? randColorU32()) >>> 0;
                 const keyedPixels = info.pixels ? info.pixels.map(coordToKey) : [];


### PR DESCRIPTION
## Summary
- rename layer property from `visible` to `visibility` across store, services, and components
- update serialization and layer utilities to use `visibility`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae8a27e844832c95b941d623ae970a