### PR TITLE
cache viewport metrics

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -87,10 +87,8 @@ const viewportViewBox = computed(() => `0 0 ${viewportSize.width} ${viewportSize
 const marqueeRect = computed(() => {
     if (!marquee.visible || !marquee.anchorEvent || !marquee.tailEvent)
         return { x: 0, y: 0, w: 0, h: 0 };
-    const rect = viewportStore.element.getBoundingClientRect();
-    const style = getComputedStyle(viewportStore.element);
-    const left = rect.left + (parseFloat(style.paddingLeft) || 0);
-    const top = rect.top + (parseFloat(style.paddingTop) || 0);
+    const left = viewportStore.client.left + viewportStore.padding.left;
+    const top = viewportStore.client.top + viewportStore.padding.top;
     const ax = marquee.anchorEvent.clientX - left;
     const ay = marquee.anchorEvent.clientY - top;
     const tx = marquee.tailEvent.clientX - left;
@@ -133,13 +131,9 @@ const onElementResize = () => {
     prevClientWidth = clientWidth;
     prevClientHeight = clientHeight;
     if (scrollChanged) return;
-    const style = getComputedStyle(el);
-    const paddingLeft = parseFloat(style.paddingLeft) || 0;
-    const paddingRight = parseFloat(style.paddingRight) || 0;
-    const paddingTop = parseFloat(style.paddingTop) || 0;
-    const paddingBottom = parseFloat(style.paddingBottom) || 0;
-    viewportSize.width = (clientWidth || 0) - paddingLeft - paddingRight;
-    viewportSize.height = (clientHeight || 0) - paddingTop - paddingBottom;
+    viewportStore.refreshElementCache();
+    viewportSize.width = viewportStore.client.width;
+    viewportSize.height = viewportStore.client.height;
     viewportStore.recalcScales();
     viewportStore.setScale(stage.containScale);
     viewport.interpolatePosition(false);

--- a/src/services/toolSelection.js
+++ b/src/services/toolSelection.js
@@ -40,10 +40,8 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
         if (!startCoord) return [];
         let currentCoord = viewportStore.clientToCoord(marquee.tailEvent);
         if (!currentCoord) {
-            const rect = viewportStore.element.getBoundingClientRect();
-            const style = getComputedStyle(viewportStore.element);
-            const left = rect.left + parseFloat(style.paddingLeft) + viewportStore.stage.offset.x;
-            const top = rect.top + parseFloat(style.paddingTop) + viewportStore.stage.offset.y;
+            const left = viewportStore.client.left + viewportStore.padding.left + viewportStore.stage.offset.x;
+            const top = viewportStore.client.top + viewportStore.padding.top + viewportStore.stage.offset.y;
             let x = Math.floor((marquee.tailEvent.clientX - left) / viewportStore.stage.scale);
             let y = Math.floor((marquee.tailEvent.clientY - top) / viewportStore.stage.scale);
             x = Math.min(Math.max(x, 0), viewportStore.stage.width - 1);

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -17,14 +17,13 @@ export const useViewportService = defineStore('viewportService', () => {
   function handleWheel(e) {
     const viewportEl = viewportStore.element;
     if (!viewportEl) return;
-    if (!e.ctrlKey) {
+      if (!e.ctrlKey) {
       viewportStore.stage.offset.x -= e.deltaX;
       viewportStore.stage.offset.y -= e.deltaY;
     } else {
       if (e.deltaY === 0) return;
-      const rect = viewportEl.getBoundingClientRect();
-      const px = e.clientX - rect.left;
-      const py = e.clientY - rect.top;
+      const px = e.clientX - viewportStore.client.left;
+      const py = e.clientY - viewportStore.client.top;
       const oldScale = viewportStore.stage.scale;
       const factor = e.deltaY < 0 ? WHEEL_ZOOM_IN_FACTOR : WHEEL_ZOOM_OUT_FACTOR;
       const newScale = oldScale * factor;
@@ -39,12 +38,11 @@ export const useViewportService = defineStore('viewportService', () => {
 
   function handlePinch() {
     const viewportEl = viewportStore.element;
-    const rect = viewportEl.getBoundingClientRect();
     const [id1, id2] = viewportEvents.pinchIds;
     const e1 = viewportEvents.get('pointermove', id1) || viewportEvents.get('pointerdown', id1);
     const e2 = viewportEvents.get('pointermove', id2) || viewportEvents.get('pointerdown', id2);
-    const cx = (e1.clientX + e2.clientX) / 2 - rect.left;
-    const cy = (e1.clientY + e2.clientY) / 2 - rect.top;
+    const cx = (e1.clientX + e2.clientX) / 2 - viewportStore.client.left;
+    const cy = (e1.clientY + e2.clientY) / 2 - viewportStore.client.top;
     const dist = Math.hypot(e2.clientX - e1.clientX, e2.clientY - e1.clientY);
     if (lastTouchDistance) {
       const oldScale = viewportStore.stage.scale;
@@ -62,9 +60,8 @@ export const useViewportService = defineStore('viewportService', () => {
   function interpolatePosition(soft = true) {
     const viewportEl = viewportStore.element;
     if (!viewportEl) return;
-    const style = getComputedStyle(viewportEl);
-    const width = viewportEl.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
-    const height = viewportEl.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
+    const width = viewportStore.client.width;
+    const height = viewportStore.client.height;
     const scaledWidth = viewportStore.stage.width * viewportStore.stage.scale;
     const scaledHeight = viewportStore.stage.height * viewportStore.stage.scale;
     const maxX = width - scaledWidth;


### PR DESCRIPTION
## Summary
- add client and padding cache to viewport store
- use cached metrics in selection logic and viewport component
- refresh cache on resize and reuse in viewport service

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aea3fe0908832caa71b499ed9e2a33