### PR TITLE
refactor: rename client to content

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -81,9 +81,7 @@ const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = ref(null);
 const stage = viewportStore.stage;
 
-const viewportViewBox = computed(() => {
-    return `0 0 ${viewportStore.content.width} ${viewportStore.content.height}`;
-});
+const viewportViewBox = computed(() => `0 0 ${viewportStore.content.width} ${viewportStore.content.height}`);
 const marqueeRect = computed(() => {
     const marquee = toolSelectionService.marquee;
     if (!marquee.visible || !marquee.anchorEvent || !marquee.tailEvent)

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -79,11 +79,10 @@ import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 const { viewport: viewportStore, layers, viewportEvent: viewportEvents } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = ref(null);
-const stage = computed(() => viewportStore.stage);
+const stage = viewportStore.stage;
 
 const viewportViewBox = computed(() => {
-    const content = viewportStore.content;
-    return `0 0 ${content.width} ${content.height}`;
+    return `0 0 ${viewportStore.content.width} ${viewportStore.content.height}`;
 });
 const marqueeRect = computed(() => {
     const marquee = toolSelectionService.marquee;

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -79,15 +79,18 @@ import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 const { viewport: viewportStore, layers, viewportEvent: viewportEvents } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = ref(null);
-const stage = viewportStore.stage;
+const stage = computed(() => viewportStore.stage);
 
-const viewportViewBox = computed(() => `0 0 ${viewportStore.client.width} ${viewportStore.client.height}`);
+const viewportViewBox = computed(() => {
+    const content = viewportStore.content;
+    return `0 0 ${content.width} ${content.height}`;
+});
 const marqueeRect = computed(() => {
     const marquee = toolSelectionService.marquee;
     if (!marquee.visible || !marquee.anchorEvent || !marquee.tailEvent)
         return { x: 0, y: 0, w: 0, h: 0 };
-    const left = viewportStore.client.left + viewportStore.padding.left;
-    const top = viewportStore.client.top + viewportStore.padding.top;
+    const left = viewportStore.content.left;
+    const top = viewportStore.content.top;
     const ax = marquee.anchorEvent.clientX - left;
     const ay = marquee.anchorEvent.clientY - top;
     const tx = marquee.tailEvent.clientX - left;
@@ -117,15 +120,12 @@ const helperOverlay = computed(() => {
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
 
 const onElementResize = () => {
-    viewportStore.refreshElementCache();
-    viewportStore.recalcScales();
-    viewportStore.setScale(stage.containScale);
+    viewportStore.setScale(stage.value.containScale);
     viewport.interpolatePosition(false);
 };
 
 const onImageLoad = () => {
-    viewportStore.recalcScales();
-    viewportStore.setScale(stage.containScale);
+    viewportStore.setScale(stage.value.containScale);
     viewport.interpolatePosition(false);
 };
 

--- a/src/services/toolSelection.js
+++ b/src/services/toolSelection.js
@@ -40,8 +40,8 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
         if (!startCoord) return [];
         let currentCoord = viewportStore.clientToCoord(marquee.tailEvent);
         if (!currentCoord) {
-            const left = viewportStore.client.left + viewportStore.padding.left + viewportStore.stage.offset.x;
-            const top = viewportStore.client.top + viewportStore.padding.top + viewportStore.stage.offset.y;
+            const left = viewportStore.content.left + viewportStore.stage.offset.x;
+            const top = viewportStore.content.top + viewportStore.stage.offset.y;
             let x = Math.floor((marquee.tailEvent.clientX - left) / viewportStore.stage.scale);
             let y = Math.floor((marquee.tailEvent.clientY - top) / viewportStore.stage.scale);
             x = Math.min(Math.max(x, 0), viewportStore.stage.width - 1);

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -22,8 +22,8 @@ export const useViewportService = defineStore('viewportService', () => {
       viewportStore.stage.offset.y -= e.deltaY;
     } else {
       if (e.deltaY === 0) return;
-      const px = e.clientX - viewportStore.client.left;
-      const py = e.clientY - viewportStore.client.top;
+      const px = e.clientX - viewportStore.content.left;
+      const py = e.clientY - viewportStore.content.top;
       const oldScale = viewportStore.stage.scale;
       const factor = e.deltaY < 0 ? WHEEL_ZOOM_IN_FACTOR : WHEEL_ZOOM_OUT_FACTOR;
       const newScale = oldScale * factor;
@@ -41,8 +41,8 @@ export const useViewportService = defineStore('viewportService', () => {
     const [id1, id2] = viewportEvents.pinchIds;
     const e1 = viewportEvents.get('pointermove', id1) || viewportEvents.get('pointerdown', id1);
     const e2 = viewportEvents.get('pointermove', id2) || viewportEvents.get('pointerdown', id2);
-    const cx = (e1.clientX + e2.clientX) / 2 - viewportStore.client.left;
-    const cy = (e1.clientY + e2.clientY) / 2 - viewportStore.client.top;
+    const cx = (e1.clientX + e2.clientX) / 2 - viewportStore.content.left;
+    const cy = (e1.clientY + e2.clientY) / 2 - viewportStore.content.top;
     const dist = Math.hypot(e2.clientX - e1.clientX, e2.clientY - e1.clientY);
     if (lastTouchDistance) {
       const oldScale = viewportStore.stage.scale;
@@ -60,8 +60,8 @@ export const useViewportService = defineStore('viewportService', () => {
   function interpolatePosition(soft = true) {
     const viewportEl = viewportStore.element;
     if (!viewportEl) return;
-    const width = viewportStore.client.width;
-    const height = viewportStore.client.height;
+    const width = viewportStore.content.width;
+    const height = viewportStore.content.height;
     const scaledWidth = viewportStore.stage.width * viewportStore.stage.scale;
     const scaledHeight = viewportStore.stage.height * viewportStore.stage.scale;
     const maxX = width - scaledWidth;


### PR DESCRIPTION
## Summary
- rename viewport store's `client` bounds to `content` and include width/height
- drop `padding` getter and compute content from element styles
- update viewport service, selection tool, and component to consume new `content` bounds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa22758c832c961f85555998bc2b