### PR TITLE
feat: add layer group functionality

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,44 +1,49 @@
 <template>
   <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="props in layers.getProperties(layers.idsTopToBottom)" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="props.id" :data-id="props.id" :class="{ selected: layers.isSelected(props.id), anchor: layerPanel.anchorId===props.id, dragging: dragId===props.id }" draggable="true" @click="layerPanel.onLayerClick(props.id,$event)" @dragstart="onDragStart(props.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(props.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(props.id,$event)">
+    <template v-for="item in layerItems" :key="item.type + '-' + item.id">
+      <div v-if="item.type==='group'" class="layer-group px-2 py-1 text-xs font-bold text-slate-300 border border-white/15 rounded-md bg-sky-900/40 cursor-pointer" @click="toggleGroup(item.id)">
+        {{ item.name }}
+      </div>
+      <div v-else class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :data-id="item.id" :class="{ selected: layers.isSelected(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item.id,$event)">
       <!-- 썸네일 -->
-      <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
+      <div @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
         <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
           <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          <path :d="layers.pathOf(item.id)" :fill="rgbaCssU32(item.color)" :opacity="item.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
         </svg>
       </div>
       <!-- 색상 -->
       <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': props.locked }" :disabled="props.locked" :value="rgbaToHexU32(props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(props.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
+        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.locked }" :disabled="item.locked" :value="rgbaToHexU32(item.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
       </div>
       <!-- 이름/픽셀 -->
       <div class="min-w-0 flex-1">
         <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(props.id)" @keydown="onNameKey(props.id,$event)" @blur="finishRename(props.id,$event)">{{ props.name }}</span>
+          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.name }}</span>
         </div>
         <div class="text-xs text-slate-400">
-          <template v-if="layers.disconnectedCountOf(props.id) > 1">
-            <span class="cursor-pointer" @click.stop="onDisconnectedClick(props.id)">⚠️</span>
-            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
+          <template v-if="layers.disconnectedCountOf(item.id) > 1">
+            <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
+            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ layers.disconnectedCountOf(item.id) }} piece</span>
             <span class="mx-1">|</span>
           </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels.length }} px</span>
+          <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.pixels.length }} px</span>
         </div>
       </div>
       <!-- 액션 -->
       <div class="flex gap-1 justify-end">
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
+          <img :src="(item.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-          <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
+          <img :src="(item.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
         </div>
         <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(props.id)" />
+          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
         </div>
         </div>
-    </div>
+      </div>
+    </template>
       <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>
@@ -61,6 +66,25 @@ const listElement = ref(null);
 const icons = reactive(blockIcons);
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
+
+const layerItems = computed(() => {
+  const items = [];
+  const seen = new Set();
+  for (const id of layers.idsTopToBottom) {
+    const gid = layers.groupOf(id);
+    if (gid && !seen.has(gid)) {
+      items.push({ type: 'group', id: gid, name: layers.groupName(gid) });
+      seen.add(gid);
+    }
+    const props = layers.getProperties(id);
+    items.push({ type: 'layer', ...props });
+  }
+  return items;
+});
+
+function toggleGroup(id) {
+  layers.toggleGroupVisibility(id);
+}
 
 
   function onThumbnailClick(id) {

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -12,6 +12,9 @@
         <button @click="onSplit" :disabled="!canSplit" title="Split disconnected" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.split" alt="Split disconnected" class="w-4 h-4">
         </button>
+        <button @click="onGroup" :disabled="layers.selectionCount < 2" title="Group layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+          <img :src="toolbarIcons.group" alt="Group layers" class="w-4 h-4">
+        </button>
         <button @click="onSelectEmpty" :disabled="!hasEmptyLayers" title="Select empty layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.empty" alt="Select empty layers" class="w-4 h-4">
         </button>
@@ -63,6 +66,14 @@ const onSelectEmpty = () => {
 const onSplit = () => {
     output.setRollbackPoint();
     layerSvc.splitLayer(layerPanel.anchorId);
+    output.commit();
+};
+const onGroup = () => {
+    if (layers.selectionCount < 2) return;
+    output.setRollbackPoint();
+    const name = `Group ${Object.keys(layers.groups).length + 1}`;
+    layers.createGroup(name, layers.selectedIds);
+    layerPanel.clearRange();
     output.commit();
 };
 </script>

--- a/src/image/layer_toolbar/group.svg
+++ b/src/image/layer_toolbar/group.svg
@@ -1,0 +1,4 @@
+<svg class="svg-icon" style="overflow:hidden;fill:currentColor" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="10" width="20" height="18" fill="#808080"/>
+  <rect x="8" y="4" width="20" height="18" fill="#f0f0f0"/>
+</svg>

--- a/src/image/layer_toolbar/index.js
+++ b/src/image/layer_toolbar/index.js
@@ -3,11 +3,13 @@ import copy from './copy.svg';
 import merge from './merge.svg';
 import split from './split.svg';
 import empty from './empty.svg';
+import group from './group.svg';
 
 export default {
   add,
   copy,
   merge,
   split,
-  empty
+  empty,
+  group
 };

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -10,7 +10,9 @@ export const useLayerStore = defineStore('layers', {
         _visibility: {},
         _locked: {},
         _pixels: {},
-        _selection: new Set()
+        _selection: new Set(),
+        _groups: {},
+        _layerGroup: {}
     }),
     getters: {
         exists: (state) => state._order.length > 0,
@@ -22,6 +24,9 @@ export const useLayerStore = defineStore('layers', {
         indexOfLayer: (state) => (id) => state._order.indexOf(id),
         pathOf: (state) => (id) => pixelsToUnionPath([...state._pixels[id]].map(keyToCoord)),
         disconnectedCountOf: (state) => (id) => groupConnectedPixels([...state._pixels[id]].map(keyToCoord)).length,
+        groupOf: (state) => (id) => state._layerGroup[id] ?? null,
+        groupName: (state) => (gid) => state._groups[gid]?.name,
+        groups: (state) => readonly(state._groups),
         getProperty: (state) => (id, prop) => {
             switch (prop) {
                 case 'name':
@@ -83,6 +88,11 @@ export const useLayerStore = defineStore('layers', {
             while (this.has(id)) id++;
             return id;
         },
+        _allocGroupId() {
+            let id = Date.now();
+            while (this.has(id) || this._groups[id]) id++;
+            return id;
+        },
         /** Create a layer and insert relative to a reference id (above = on top of it). If refId null -> push on top */
         createLayer(layerProperties = {}, above = null) {
             const id = this._allocId();
@@ -134,11 +144,59 @@ export const useLayerStore = defineStore('layers', {
             if (set.has(key)) set.delete(key);
             else set.add(key);
         },
+        /** Group management */
+        createGroup(name = 'Group', layerIds = []) {
+            const gid = this._allocGroupId();
+            this._groups[gid] = { name, layers: [] };
+            this.addLayersToGroup(gid, layerIds);
+            return gid;
+        },
+        addLayersToGroup(gid, layerIds = []) {
+            const group = this._groups[gid];
+            if (!group) return;
+            for (const id of layerIds) {
+                if (!this.has(id)) continue;
+                const prev = this._layerGroup[id];
+                if (prev && this._groups[prev]) {
+                    const arr = this._groups[prev].layers;
+                    this._groups[prev].layers = arr.filter(lid => lid !== id);
+                    if (this._groups[prev].layers.length === 0) delete this._groups[prev];
+                }
+                if (!group.layers.includes(id)) group.layers.push(id);
+                this._layerGroup[id] = gid;
+            }
+        },
+        removeLayersFromGroup(layerIds = []) {
+            for (const id of layerIds) {
+                const gid = this._layerGroup[id];
+                if (!gid) continue;
+                const group = this._groups[gid];
+                if (group) {
+                    group.layers = group.layers.filter(lid => lid !== id);
+                    if (group.layers.length === 0) delete this._groups[gid];
+                }
+                delete this._layerGroup[id];
+            }
+        },
+        removeGroup(gid) {
+            const group = this._groups[gid];
+            if (!group) return;
+            this.removeLayersFromGroup(group.layers.slice());
+        },
+        toggleGroupVisibility(gid) {
+            const group = this._groups[gid];
+            if (!group) return;
+            const visible = group.layers.some(id => this._visibility[id]);
+            for (const id of group.layers) {
+                this._visibility[id] = !visible;
+            }
+        },
         /** Remove layers by ids */
         deleteLayers(ids) {
             const idSet = new Set(ids);
             this._order = this._order.filter(id => !idSet.has(id));
             for (const id of idSet) {
+                this.removeLayersFromGroup([id]);
                 delete this._name[id];
                 delete this._color[id];
                 delete this._visibility[id];
@@ -194,6 +252,7 @@ export const useLayerStore = defineStore('layers', {
                     color: (this._color[id] >>> 0),
                     pixels: [...this._pixels[id]].map(key => keyToCoord(key))
                 }])),
+                groups: Object.fromEntries(Object.entries(this._groups).map(([gid, g]) => [gid, { name: g.name, layers: g.layers.slice() }])),
                 selection: [...this._selection]
             };
         },
@@ -207,6 +266,8 @@ export const useLayerStore = defineStore('layers', {
             this._visibility = {};
             this._locked = {};
             this._pixels = {};
+            this._groups = {};
+            this._layerGroup = {};
             // rebuild
             for (const idStr of order) {
                 const id = +idStr;
@@ -219,6 +280,15 @@ export const useLayerStore = defineStore('layers', {
                 const keyedPixels = info.pixels ? info.pixels.map(coordToKey) : [];
                 this._pixels[id] = reactive(new Set(keyedPixels));
                 this._order.push(id);
+            }
+            const groups = payload?.groups || {};
+            for (const gidStr of Object.keys(groups)) {
+                const gid = +gidStr;
+                const ginfo = groups[gidStr] || groups[gid];
+                if (!ginfo) continue;
+                const layerIds = (ginfo.layers || []).filter(id => this._name[id] != null);
+                this._groups[gid] = { name: ginfo.name || 'Group', layers: layerIds.slice() };
+                for (const lid of layerIds) this._layerGroup[lid] = gid;
             }
             this._selection = new Set(payload?.selection || []);
         }


### PR DESCRIPTION
## Summary
- support grouping of layers with creation, assignment, and visibility toggling
- show layer groups in the panel and allow toggling by clicking group headers
- add toolbar action and icon to group selected layers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aede0b0cc0832c8fa22c2545cb2953