### PR TITLE
feat: add layer groups

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,45 +1,65 @@
 <template>
   <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="props in layers.getProperties(layers.idsTopToBottom)" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="props.id" :data-id="props.id" :class="{ selected: layers.isSelected(props.id), anchor: layerPanel.anchorId===props.id, dragging: dragId===props.id }" draggable="true" @click="layerPanel.onLayerClick(props.id,$event)" @dragstart="onDragStart(props.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(props.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(props.id,$event)">
-      <!-- 썸네일 -->
-      <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
-        <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
-          <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
-        </svg>
-      </div>
-      <!-- 색상 -->
-      <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': props.locked }" :disabled="props.locked" :value="rgbaToHexU32(props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(props.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
-      </div>
-      <!-- 이름/픽셀 -->
-      <div class="min-w-0 flex-1">
-        <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(props.id)" @keydown="onNameKey(props.id,$event)" @blur="finishRename(props.id,$event)">{{ props.name }}</span>
+    <div v-for="item in displayItems" :key="item.type + '-' + item.id">
+      <div v-if="item.type==='group'" class="layer-group flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-indigo-950/30 select-none cursor-pointer" :data-id="item.id" @click="onGroupClick(item.id,$event)">
+        <div class="min-w-0 flex-1">
+          <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
+            <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRenameGroup(item.id)" @keydown="onGroupNameKey(item.id,$event)" @blur="finishRenameGroup(item.id,$event)">{{ item.name }}</span>
+          </div>
         </div>
-        <div class="text-xs text-slate-400">
-          <template v-if="layers.disconnectedCountOf(props.id) > 1">
-            <span class="cursor-pointer" @click.stop="onDisconnectedClick(props.id)">⚠️</span>
-            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
-            <span class="mx-1">|</span>
-          </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels.length }} px</span>
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(item.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleGroupVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(item.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleGroupLock(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteGroup(item.id)" />
+          </div>
         </div>
       </div>
-      <!-- 액션 -->
-      <div class="flex gap-1 justify-end">
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
+      <div v-else class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :data-id="item.id" :class="{ selected: layers.isSelected(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item.id,$event)">
+        <!-- 썸네일 -->
+        <div @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
+          <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
+            <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
+            <path :d="layers.pathOf(item.id)" :fill="rgbaCssU32(item.color)" :opacity="item.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          </svg>
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-          <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
+        <!-- 색상 -->
+        <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
+          <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.locked }" :disabled="item.locked" :value="rgbaToHexU32(item.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(props.id)" />
+        <!-- 이름/픽셀 -->
+        <div class="min-w-0 flex-1">
+          <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
+            <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.name }}</span>
+          </div>
+          <div class="text-xs text-slate-400">
+            <template v-if="layers.disconnectedCountOf(item.id) > 1">
+              <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
+              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ layers.disconnectedCountOf(item.id) }} piece</span>
+              <span class="mx-1">|</span>
+            </template>
+            <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.pixels.length }} px</span>
+          </div>
         </div>
+        <!-- 액션 -->
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(item.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(item.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+          </div>
         </div>
+      </div>
     </div>
-      <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
+    <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>
 
@@ -51,7 +71,7 @@ import blockIcons from '../image/layer_block';
 
 import { useService } from '../services';
 
-const { viewport: viewportStore, layers, output } = useStore();
+const { viewport: viewportStore, layers, layerGroups, output } = useStore();
 const { layerPanel, query, viewport } = useService();
 
 const dragging = ref(false);
@@ -61,6 +81,27 @@ const listElement = ref(null);
 const icons = reactive(blockIcons);
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
+
+const displayItems = computed(() => {
+    const order = layers.idsTopToBottom;
+    const items = [];
+    const seen = new Set();
+    for (const id of order) {
+        const gid = layerGroups.groupOfLayer(id);
+        if (gid && !seen.has(gid)) {
+            const gprops = layerGroups.getProperties(gid);
+            items.push({ type: 'group', ...gprops });
+            const childIds = [...layerGroups.layersOf(gid)];
+            const lpropsArr = layers.getProperties(childIds);
+            for (const lp of lpropsArr) items.push({ type: 'layer', ...lp });
+            seen.add(gid);
+        } else if (!gid) {
+            const lp = layers.getProperties(id);
+            items.push({ type: 'layer', ...lp });
+        }
+    }
+    return items;
+});
 
 
   function onThumbnailClick(id) {
@@ -216,6 +257,73 @@ function deleteLayer(id) {
         });
     }
     output.commit();
+}
+
+function toggleGroupVisibility(id) {
+    output.setRollbackPoint();
+    layerGroups.toggleVisibility(id);
+    output.commit();
+}
+
+function toggleGroupLock(id) {
+    output.setRollbackPoint();
+    layerGroups.toggleLock(id);
+    output.commit();
+}
+
+function deleteGroup(id) {
+    output.setRollbackPoint();
+    layerGroups.deleteGroup(id);
+    output.commit();
+}
+
+function onGroupClick(id, event) {
+    const ids = [...layerGroups.layersOf(id)];
+    if (ids.length) {
+        layers.replaceSelection(ids);
+        layerPanel.clearRange();
+        layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
+    }
+}
+
+function startRenameGroup(id) {
+    output.setRollbackPoint();
+    const element = document.querySelector(`.layer-group[data-id="${id}"] .nameText`);
+    if (!element) return;
+    element.contentEditable = true;
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    element.focus();
+}
+
+function finishRenameGroup(id, event) {
+    const element = document.querySelector(`.layer-group[data-id="${id}"] .nameText`);
+    if (element) element.contentEditable = false;
+    const oldName = layerGroups.getProperties(id).name;
+    const text = event.target.innerText.trim();
+    if (text && text !== oldName) {
+        layerGroups.updateProperties(id, { name: text });
+        output.commit();
+    } else {
+        event.target.innerText = oldName;
+        output.clearRollbackPoint();
+    }
+}
+
+function onGroupNameKey(id, event) {
+    const name = layerGroups.getProperties(id).name;
+    if (event.key === 'Enter') {
+        event.preventDefault();
+        event.target.blur();
+    }
+    if (event.key === 'Escape') {
+        event.preventDefault();
+        event.target.innerText = name;
+        event.target.blur();
+    }
 }
 
 function ensureBlockVisibility({

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -3,6 +3,9 @@
         <button @click="onAdd" title="Add layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img :src="toolbarIcons.add" alt="Add layer" class="w-4 h-4">
         </button>
+        <button @click="onGroup" :disabled="!layers.selectionExists" title="Group layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+          <img :src="toolbarIcons.group" alt="Group layers" class="w-4 h-4">
+        </button>
         <button @click="onCopy" :disabled="!layers.selectionExists" title="Copy layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.copy" alt="Copy layer" class="w-4 h-4">
         </button>
@@ -24,7 +27,7 @@ import { useService } from '../services';
 import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
-const { layers, output } = useStore();
+const { layers, layerGroups, output } = useStore();
 const { layerTool: layerSvc, layerPanel, query } = useService();
 
 const hasEmptyLayers = computed(() => layers.order.some(id => layers.getProperty(id, 'pixels').length === 0));
@@ -63,6 +66,13 @@ const onSelectEmpty = () => {
 const onSplit = () => {
     output.setRollbackPoint();
     layerSvc.splitLayer(layerPanel.anchorId);
+    output.commit();
+};
+const onGroup = () => {
+    if (!layers.selectionExists) return;
+    output.setRollbackPoint();
+    const id = layerGroups.createGroup({});
+    layerGroups.addLayers(id, layers.selectedIds);
     output.commit();
 };
 </script>

--- a/src/image/layer_toolbar/group.svg
+++ b/src/image/layer_toolbar/group.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="7" height="7"/>
+  <rect x="14" y="3" width="7" height="7"/>
+  <rect x="3" y="14" width="7" height="7"/>
+</svg>

--- a/src/image/layer_toolbar/index.js
+++ b/src/image/layer_toolbar/index.js
@@ -3,11 +3,13 @@ import copy from './copy.svg';
 import merge from './merge.svg';
 import split from './split.svg';
 import empty from './empty.svg';
+import group from './group.svg';
 
 export default {
   add,
   copy,
   merge,
   split,
-  empty
+  empty,
+  group
 };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,5 +1,6 @@
 import { useInputStore } from './input';
 import { useLayerStore } from './layers';
+import { useLayerGroupStore } from './layerGroups';
 import { useOutputStore } from './output';
 import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
@@ -7,6 +8,7 @@ import { useViewportEventStore } from './viewportEvent';
 export {
     useInputStore,
     useLayerStore,
+    useLayerGroupStore,
     useOutputStore,
     useViewportStore,
     useViewportEventStore
@@ -15,6 +17,7 @@ export {
 export const useStore = () => ({
     input: useInputStore(),
     layers: useLayerStore(),
+    layerGroups: useLayerGroupStore(),
     output: useOutputStore(),
     viewport: useViewportStore(),
     viewportEvent: useViewportEventStore()

--- a/src/stores/layerGroups.js
+++ b/src/stores/layerGroups.js
@@ -1,0 +1,133 @@
+import { defineStore } from 'pinia';
+import { reactive, readonly } from 'vue';
+
+export const useLayerGroupStore = defineStore('layerGroups', {
+    state: () => ({
+        _order: [],
+        _name: {},
+        _visibility: {},
+        _locked: {},
+        _layers: {}, // groupId -> array of layer ids
+        _groupOf: {} // layerId -> groupId
+    }),
+    getters: {
+        exists: (state) => state._order.length > 0,
+        order: (state) => readonly(state._order),
+        layersOf: (state) => (groupId) => readonly(state._layers[groupId] || []),
+        groupOfLayer: (state) => (layerId) => state._groupOf[layerId] ?? null,
+        isVisible: (state) => (groupId) => groupId == null ? true : !!state._visibility[groupId],
+        isLocked: (state) => (groupId) => groupId == null ? false : !!state._locked[groupId],
+        getProperties: (state) => (id) => ({
+            id,
+            name: state._name[id],
+            visibility: !!state._visibility[id],
+            locked: !!state._locked[id],
+            layers: (state._layers[id] || []).slice()
+        }),
+        ungrouped: (state) => (ids = []) => ids.filter(id => state._groupOf[id] == null)
+    },
+    actions: {
+        _allocId() {
+            let id = Date.now();
+            while (this._name[id] != null) id++;
+            return id;
+        },
+        createGroup(props = {}) {
+            const id = this._allocId();
+            this._name[id] = props.name || 'Group';
+            this._visibility[id] = props.visibility ?? true;
+            this._locked[id] = props.locked ?? false;
+            this._layers[id] = [];
+            this._order.push(id);
+            return id;
+        },
+        addLayers(groupId, layerIds = []) {
+            const arr = this._layers[groupId];
+            if (!arr || this._locked[groupId]) return;
+            for (const lid of layerIds) {
+                const prev = this._groupOf[lid];
+                if (prev != null) this.removeLayers(prev, [lid]);
+                arr.push(lid);
+                this._groupOf[lid] = groupId;
+            }
+        },
+        removeLayers(groupId, layerIds = []) {
+            const arr = this._layers[groupId];
+            if (!arr) return;
+            this._layers[groupId] = arr.filter(id => !layerIds.includes(id));
+            for (const lid of layerIds) {
+                if (this._groupOf[lid] === groupId) delete this._groupOf[lid];
+            }
+        },
+        toggleVisibility(id) {
+            if (this._name[id] == null) return;
+            this._visibility[id] = !this._visibility[id];
+        },
+        toggleLock(id) {
+            if (this._name[id] == null) return;
+            this._locked[id] = !this._locked[id];
+        },
+        deleteGroup(id) {
+            if (this._name[id] == null) return;
+            for (const lid of this._layers[id]) {
+                delete this._groupOf[lid];
+            }
+            delete this._name[id];
+            delete this._visibility[id];
+            delete this._locked[id];
+            delete this._layers[id];
+            this._order = this._order.filter(gid => gid !== id);
+        },
+        updateProperties(id, props) {
+            if (this._name[id] == null) return;
+            if (props.name !== undefined) this._name[id] = props.name;
+            if (props.visibility !== undefined) this._visibility[id] = !!props.visibility;
+            if (props.locked !== undefined) this._locked[id] = !!props.locked;
+            if (props.layers !== undefined) {
+                this._layers[id] = props.layers.slice();
+                for (const lid of props.layers) this._groupOf[lid] = id;
+            }
+        },
+        syncFromLayerOrder(order = []) {
+            const pos = new Map(order.map((id, idx) => [id, idx]));
+            for (const gid of this._order) {
+                const arr = this._layers[gid];
+                arr.sort((a, b) => (pos.get(a) ?? 0) - (pos.get(b) ?? 0));
+            }
+        },
+        serialize() {
+            return {
+                order: this._order.slice(),
+                byId: Object.fromEntries(this._order.map(id => [id, {
+                    name: this._name[id],
+                    visibility: !!this._visibility[id],
+                    locked: !!this._locked[id],
+                    layers: this._layers[id].slice()
+                }]))
+            };
+        },
+        applySerialized(payload) {
+            const order = payload?.order || [];
+            const byId = payload?.byId || {};
+            this._order = [];
+            this._name = {};
+            this._visibility = {};
+            this._locked = {};
+            this._layers = {};
+            this._groupOf = {};
+            for (const idStr of order) {
+                const id = +idStr;
+                const info = byId[idStr] || byId[id];
+                if (!info) continue;
+                this._name[id] = info.name || 'Group';
+                this._visibility[id] = !!info.visibility;
+                this._locked[id] = !!info.locked;
+                const layerArr = info.layers ? info.layers.slice() : [];
+                this._layers[id] = layerArr;
+                for (const lid of layerArr) this._groupOf[lid] = id;
+                this._order.push(id);
+            }
+        }
+    }
+});
+

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { readonly, reactive } from 'vue';
 import { coordToKey, keyToCoord, pixelsToUnionPath, randColorU32, groupConnectedPixels } from '../utils';
+import { useLayerGroupStore } from './layerGroups';
 
 export const useLayerStore = defineStore('layers', {
     state: () => ({
@@ -57,20 +58,26 @@ export const useLayerStore = defineStore('layers', {
         selectionExists: (state) => state._selection.size > 0,
         isSelected: (state) => (id) => state._selection.has(id),
         compositeColorAt: (state) => (coord) => {
+            const groups = useLayerGroupStore();
             const key = coordToKey(coord);
             for (let i = state._order.length - 1; i >= 0; i--) {
                 const id = state._order[i];
                 if (!state._visibility[id]) continue;
+                const gid = groups.groupOfLayer(id);
+                if (!groups.isVisible(gid)) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return (state._color[id] >>> 0);
             }
             return 0x00000000 >>> 0;
         },
         topVisibleIdAt: (state) => (coord) => {
+            const groups = useLayerGroupStore();
             const key = coordToKey(coord);
             for (let i = state._order.length - 1; i >= 0; i--) {
                 const id = state._order[i];
                 if (!state._visibility[id]) continue;
+                const gid = groups.groupOfLayer(id);
+                if (!groups.isVisible(gid)) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return id;
             }
@@ -103,6 +110,8 @@ export const useLayerStore = defineStore('layers', {
         /** Update properties of a layer */
         updateProperties(id, props) {
             if (this._name[id] == null) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             if (props.name !== undefined) this._name[id] = props.name;
             if (props.visibility !== undefined) this._visibility[id] = !!props.visibility;
             if (props.locked !== undefined) this._locked[id] = !!props.locked;
@@ -111,24 +120,34 @@ export const useLayerStore = defineStore('layers', {
         },
         toggleVisibility(id) {
             if (this._name[id] == null) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             this._visibility[id] = !this._visibility[id];
         },
         toggleLock(id) {
             if (this._name[id] == null) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             this._locked[id] = !this._locked[id];
         },
         addPixels(id, pixels) {
             if (this._locked[id]) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             const set = this._pixels[id];
             for (const coord of pixels) set.add(coordToKey(coord));
         },
         removePixels(id, pixels) {
             if (this._locked[id]) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             const set = this._pixels[id];
             for (const coord of pixels) set.delete(coordToKey(coord));
         },
         togglePixel(id, coord) {
             if (this._locked[id]) return;
+            const groups = useLayerGroupStore();
+            if (groups.isLocked(groups.groupOfLayer(id))) return;
             const set = this._pixels[id];
             const key = coordToKey(coord);
             if (set.has(key)) set.delete(key);
@@ -136,9 +155,12 @@ export const useLayerStore = defineStore('layers', {
         },
         /** Remove layers by ids */
         deleteLayers(ids) {
+            const groups = useLayerGroupStore();
             const idSet = new Set(ids);
             this._order = this._order.filter(id => !idSet.has(id));
             for (const id of idSet) {
+                const gid = groups.groupOfLayer(id);
+                if (gid != null) groups.removeLayers(gid, [id]);
                 delete this._name[id];
                 delete this._color[id];
                 delete this._visibility[id];
@@ -157,6 +179,8 @@ export const useLayerStore = defineStore('layers', {
             const selectionInStack = this._order.filter(id => selectionSet.has(id));
             keptIds.splice(targetIndex, 0, ...selectionInStack);
             this._order = keptIds;
+            const groups = useLayerGroupStore();
+            groups.syncFromLayerOrder(this._order);
         },
         deleteEmptyLayers() {
             const emptyIds = this._order.filter(id => {

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -16,10 +16,12 @@ export const useOutputStore = defineStore('output', {
     },
     actions: {
         _apply(snapshot) {
-            const { layers } = useStore();
+            const { layers, layerGroups } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
+            layerGroups.applySerialized(parsed.layerGroupsState);
             layers.applySerialized(parsed.layersState);
+            layerGroups.syncFromLayerOrder(layers.order);
             layerPanel.applySerialized(parsed.layerPanelState);
             this._commitVersion++; // ← Undo/Redo/롤백 시에도 썸네일 갱신
         },
@@ -46,10 +48,11 @@ export const useOutputStore = defineStore('output', {
             })
         },
         currentSnap() {
-            const { layers } = useStore();
+            const { layers, layerGroups } = useStore();
             const layerPanel = useLayerPanelService();
             return JSON.stringify({
                 layersState: layers.serialize(),
+                layerGroupsState: layerGroups.serialize(),
                 layerPanelState: layerPanel.serialize()
             });
         },


### PR DESCRIPTION
## Summary
- add layer group store and icon
- support grouping, visibility, and locking of layers
- expose group operations in toolbar and panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aede0b0cc0832c8fa22c2545cb2953