### PR TITLE
feat: introduce basic layer groups

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,7 @@ import LayersToolbar from './components/LayersToolbar.vue';
 import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
-const { input, viewport: viewportStore, layers, output } = useStore();
+const { input, viewport: viewportStore, layers, output, layerGroups } = useStore();
 const { layerPanel, query } = useService();
 const viewportToolbar = ref(null);
 
@@ -178,6 +178,8 @@ onMounted(async () => {
     layers.createLayer({});
     layers.createLayer({});
   }
+
+  layerGroups.initFromLayerStore();
 
   window.addEventListener('keydown', onKeydown);
   window.addEventListener('keyup', onKeyup);

--- a/src/components/LayerRenderGroup.vue
+++ b/src/components/LayerRenderGroup.vue
@@ -1,0 +1,29 @@
+<template>
+  <g v-if="group" :visibility="group.visibility ? 'visible' : 'hidden'">
+    <template v-for="child in children" :key="child">
+      <LayerRenderGroup v-if="isGroup(child)" :id="child" />
+      <path v-else
+            :d="layers.pathOf(child)"
+            fill-rule="evenodd"
+            shape-rendering="crispEdges"
+            :fill="rgbaCssU32(layers.getProperty(child,'color'))"
+            :visibility="layers.getProperty(child,'visibility')?'visible':'hidden'" />
+    </template>
+  </g>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useStore } from '../stores';
+import { rgbaCssU32 } from '../utils';
+
+const props = defineProps({ id: String });
+
+const { layers, layerGroups } = useStore();
+
+defineOptions({ name: 'LayerRenderGroup' });
+
+const group = computed(() => layerGroups.getGroup(props.id));
+const children = computed(() => layerGroups.childrenOf(props.id));
+const isGroup = (id) => layerGroups.isGroup(id);
+</script>

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,45 +1,55 @@
 <template>
-  <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="props in layers.getProperties(layers.idsTopToBottom)" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="props.id" :data-id="props.id" :class="{ selected: layers.isSelected(props.id), anchor: layerPanel.anchorId===props.id, dragging: dragId===props.id }" draggable="true" @click="layerPanel.onLayerClick(props.id,$event)" @dragstart="onDragStart(props.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(props.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(props.id,$event)">
-      <!-- 썸네일 -->
-      <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
-        <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
-          <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
-        </svg>
-      </div>
-      <!-- 색상 -->
-      <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': props.locked }" :disabled="props.locked" :value="rgbaToHexU32(props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(props.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
-      </div>
-      <!-- 이름/픽셀 -->
-      <div class="min-w-0 flex-1">
-        <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(props.id)" @keydown="onNameKey(props.id,$event)" @blur="finishRename(props.id,$event)">{{ props.name }}</span>
+  <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent="onDropRoot">
+    <div v-for="item in treeList" :key="item.type + '-' + item.id" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 select-none" :data-id="item.type==='layer'?item.id:null" :style="{ paddingLeft: (item.depth*16)+'px' }" v-bind="{ draggable: true }" :class="{ 'cursor-grab': true, selected: item.type==='layer' && layers.isSelected(item.id), anchor: item.type==='layer' && layerPanel.anchorId===item.id, dragging: dragId===item.id }" @click="item.type==='layer' && layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent.stop="onDrop(item,$event)">
+      <template v-if="item.type==='layer'">
+        <div @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
+          <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
+            <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
+            <path :d="layers.pathOf(item.id)" :fill="rgbaCssU32(layers.getProperty(item.id,'color'))" :opacity="layers.getProperty(item.id,'visibility')?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          </svg>
         </div>
-        <div class="text-xs text-slate-400">
-          <template v-if="layers.disconnectedCountOf(props.id) > 1">
-            <span class="cursor-pointer" @click.stop="onDisconnectedClick(props.id)">⚠️</span>
-            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
-            <span class="mx-1">|</span>
-          </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels.length }} px</span>
+        <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
+          <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': layers.getProperty(item.id,'locked') }" :disabled="layers.getProperty(item.id,'locked')" :value="rgbaToHexU32(layers.getProperty(item.id,'color'))" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
         </div>
-      </div>
-      <!-- 액션 -->
-      <div class="flex gap-1 justify-end">
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
+        <div class="min-w-0 flex-1">
+          <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
+            <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ layers.getProperty(item.id,'name') }}</span>
+          </div>
+          <div class="text-xs text-slate-400">
+            <template v-if="layers.disconnectedCountOf(item.id) > 1">
+              <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
+              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ layers.disconnectedCountOf(item.id) }} piece</span>
+              <span class="mx-1">|</span>
+            </template>
+            <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ layers.getProperty(item.id,'pixels').length }} px</span>
+          </div>
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-          <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(layers.getProperty(item.id,'visibility')?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(layers.getProperty(item.id,'locked')?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+          </div>
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(props.id)" />
+      </template>
+      <template v-else>
+        <div class="w-4 text-center cursor-pointer" @click.stop="layerGroups.toggleExpanded(item.id)">{{ layerGroups.getGroup(item.id).expanded ? '▼' : '▶' }}</div>
+        <div class="min-w-0 flex-1 font-semibold truncate text-sm">{{ layerGroups.getGroup(item.id).name }}</div>
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(layerGroups.getGroup(item.id).visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="layerGroups.toggleVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(layerGroups.getGroup(item.id).locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="layerGroups.toggleLock(item.id)" />
+          </div>
         </div>
-        </div>
+      </template>
     </div>
-      <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
+      <div v-show="treeList.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>
 
@@ -51,16 +61,37 @@ import blockIcons from '../image/layer_block';
 
 import { useService } from '../services';
 
-const { viewport: viewportStore, layers, output } = useStore();
+const { viewport: viewportStore, layers, output, layerGroups } = useStore();
 const { layerPanel, query, viewport } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);
+const dragType = ref(null);
 const editingId = ref(null);
 const listElement = ref(null);
 const icons = reactive(blockIcons);
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
+
+const treeList = computed(() => {
+    const result = [];
+    const traverse = (id, depth) => {
+        if (layerGroups.isGroup(id)) {
+            if (id !== layerGroups.rootId) {
+                const group = layerGroups.getGroup(id);
+                result.push({ type: 'group', id, depth });
+                if (!group.expanded) return;
+                depth += 1;
+            }
+            const children = [...layerGroups.childrenOf(id)].reverse();
+            for (const child of children) traverse(child, depth);
+        } else {
+            result.push({ type: 'layer', id, depth });
+        }
+    };
+    traverse(layerGroups.rootId, 0);
+    return result;
+});
 
 
   function onThumbnailClick(id) {
@@ -118,42 +149,64 @@ const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.bod
       });
   }
 
-function onDragStart(id, event) {
+function onDragStart(item, event) {
     dragging.value = true;
-    dragId.value = id;
+    dragId.value = item.id;
+    dragType.value = item.type;
     output.setRollbackPoint();
-    event.dataTransfer.setData('text/plain', String(id));
+    event.dataTransfer.setData('text/plain', String(item.id));
 }
 
 function onDragEnd() {
     dragging.value = false;
     dragId.value = null;
+    dragType.value = null;
 }
 
-function onDragOver(id, event) {
+function onDragOver(item, event) {
     const row = event.currentTarget;
-    if (layers.isSelected(id)) {
-        row.classList.remove('insert-before', 'insert-after');
+    row.classList.remove('insert-before', 'insert-after', 'insert-in');
+    if (dragType.value === 'layer' && layers.isSelected(item.id)) {
         event.dataTransfer.dropEffect = 'none';
         return;
     }
     const rect = row.getBoundingClientRect();
-    const before = (event.clientY - rect.top) < rect.height * 0.5;
-    row.classList.toggle('insert-before', before);
-    row.classList.toggle('insert-after', !before);
+    const offset = event.clientY - rect.top;
+    const height = rect.height;
+    if (item.type === 'group' && offset > height * 0.25 && offset < height * 0.75) {
+        row.classList.add('insert-in');
+    } else {
+        const before = offset < height * 0.5;
+        row.classList.toggle('insert-before', before);
+        row.classList.toggle('insert-after', !before);
+    }
 }
 
 function onDragLeave(event) {
-    event.currentTarget.classList.remove('insert-before', 'insert-after');
+    event.currentTarget.classList.remove('insert-before', 'insert-after', 'insert-in');
 }
 
-function onDrop(id, event) {
+function onDrop(item, event) {
     const row = event.currentTarget;
-    row.classList.remove('insert-before', 'insert-after');
-    const targetId = id;
+    row.classList.remove('insert-before', 'insert-after', 'insert-in');
     const rect = row.getBoundingClientRect();
-    const placeBelow = (event.clientY - rect.top) > rect.height * 0.5;
-    layers.reorderLayers(layers.selectedIds, targetId, placeBelow);
+    const offset = event.clientY - rect.top;
+    const height = rect.height;
+    let position;
+    if (item.type === 'group' && offset > height * 0.25 && offset < height * 0.75) {
+        position = 'inside';
+    } else {
+        position = offset < height * 0.5 ? 'before' : 'after';
+    }
+    const ids = (dragType.value === 'layer' && layers.isSelected(dragId.value)) ? layers.selectedIds : [dragId.value];
+    layerGroups.moveItems(ids, item.id, position);
+    output.commit();
+}
+
+function onDropRoot() {
+    if (!dragId.value) return;
+    const ids = (dragType.value === 'layer' && layers.isSelected(dragId.value)) ? layers.selectedIds : [dragId.value];
+    layerGroups.moveItems(ids, layerGroups.rootId, 'inside');
     output.commit();
 }
 
@@ -365,6 +418,7 @@ onUnmounted(() => {
 /* 레이어 재정렬 표시 */
 .insert-before{box-shadow:inset 0 3px 0 0 rgba(56,189,248,.7)}
 .insert-after{box-shadow:inset 0 -3px 0 0 rgba(56,189,248,.7)}
+.insert-in{box-shadow:inset 0 0 0 2px rgba(56,189,248,.7)}
 
 /* 선택 강조 */
 .layer.selected{

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -9,6 +9,9 @@
         <button @click="onMerge" :disabled="layers.selectionCount < 2" title="Merge layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.merge" alt="Merge layers" class="w-4 h-4">
         </button>
+        <button @click="onGroup" title="Group layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+          <img :src="toolbarIcons.group" alt="Group layers" class="w-4 h-4">
+        </button>
         <button @click="onSplit" :disabled="!canSplit" title="Split disconnected" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.split" alt="Split disconnected" class="w-4 h-4">
         </button>
@@ -24,7 +27,7 @@ import { useService } from '../services';
 import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
-const { layers, output } = useStore();
+const { layers, output, layerGroups } = useStore();
 const { layerTool: layerSvc, layerPanel, query } = useService();
 
 const hasEmptyLayers = computed(() => layers.order.some(id => layers.getProperty(id, 'pixels').length === 0));
@@ -51,6 +54,15 @@ const onCopy = () => {
     const ids = layerSvc.copySelected();
     layers.replaceSelection(ids);
     layerPanel.clearRange();
+    output.commit();
+};
+const onGroup = () => {
+    output.setRollbackPoint();
+    if (layers.selectionExists) {
+        layerGroups.groupSelection(layers.selectedIds);
+    } else {
+        layerGroups.createGroup({});
+    }
     output.commit();
 };
 const onSelectEmpty = () => {

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -22,9 +22,7 @@
       <img v-show="viewportStore.display==='original'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :src="viewportStore.imageSrc" alt="source image" @load="onImageLoad" />
       <!-- 결과 레이어 -->
       <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
-        <g>
-            <path v-for="props in layers.getProperties(layers.idsBottomToTop)" :key="'pix-'+props.id" :d="layers.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
-        </g>
+        <LayerRenderGroup :id="layerGroups.rootId" />
       </svg>
       <!-- 그리드 -->
       <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
@@ -74,9 +72,10 @@ import { useTemplateRef, computed, onMounted, onUnmounted } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
 import { OVERLAY_CONFIG, GRID_STROKE_COLOR } from '@/constants';
-import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
+import { ensureCheckerboardPattern } from '../utils';
+import LayerRenderGroup from './LayerRenderGroup.vue';
 
-const { viewport: viewportStore, layers, viewportEvent: viewportEvents } = useStore();
+const { viewport: viewportStore, layers, viewportEvent: viewportEvents, layerGroups } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = useTemplateRef('viewportEl');
 const stage = viewportStore.stage;

--- a/src/image/layer_toolbar/index.js
+++ b/src/image/layer_toolbar/index.js
@@ -3,11 +3,13 @@ import copy from './copy.svg';
 import merge from './merge.svg';
 import split from './split.svg';
 import empty from './empty.svg';
+import group from './group.svg';
 
 export default {
   add,
   copy,
   merge,
   split,
-  empty
+  empty,
+  group
 };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,5 +1,6 @@
 import { useInputStore } from './input';
 import { useLayerStore } from './layers';
+import { useLayerGroupStore } from './layerGroups';
 import { useOutputStore } from './output';
 import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
@@ -7,6 +8,7 @@ import { useViewportEventStore } from './viewportEvent';
 export {
     useInputStore,
     useLayerStore,
+    useLayerGroupStore,
     useOutputStore,
     useViewportStore,
     useViewportEventStore
@@ -15,6 +17,7 @@ export {
 export const useStore = () => ({
     input: useInputStore(),
     layers: useLayerStore(),
+    layerGroups: useLayerGroupStore(),
     output: useOutputStore(),
     viewport: useViewportStore(),
     viewportEvent: useViewportEventStore()

--- a/src/stores/layerGroups.js
+++ b/src/stores/layerGroups.js
@@ -1,0 +1,141 @@
+import { defineStore } from 'pinia';
+import { reactive } from 'vue';
+import { useLayerStore } from './layers';
+
+export const useLayerGroupStore = defineStore('layerGroups', {
+    state: () => ({
+        _groups: {
+            root: reactive({ id: 'root', name: 'Root', expanded: true, visibility: true, locked: false, children: [] })
+        },
+        _parent: {}
+    }),
+    getters: {
+        rootId: () => 'root',
+        getGroup: (state) => (id) => state._groups[id],
+        isGroup: (state) => (id) => state._groups[id] != null,
+        childrenOf: (state) => (id) => state._groups[id]?.children || [],
+    },
+    actions: {
+        initFromLayerStore() {
+            const layers = useLayerStore();
+            const root = this._groups.root;
+            root.children = layers.idsBottomToTop.slice();
+            for (const id of root.children) this._parent[id] = 'root';
+        },
+        createGroup({ name = 'Group', parentId = 'root', childIds = [] } = {}) {
+            const id = 'g' + Date.now().toString(36) + Math.random().toString(36).slice(2);
+            const group = reactive({ id, name, expanded: true, visibility: true, locked: false, children: [] });
+            this._groups[id] = group;
+            this.addToGroup(parentId, id);
+            if (childIds.length) this.addManyToGroup(id, childIds);
+            return id;
+        },
+        addToGroup(parentId, childId, index = null) {
+            const parent = this._groups[parentId];
+            if (!parent) return;
+            const children = parent.children;
+            if (index == null || index < 0 || index > children.length) index = children.length;
+            children.splice(index, 0, childId);
+            this._parent[childId] = parentId;
+        },
+        addManyToGroup(parentId, ids) {
+            for (const id of ids) this.addToGroup(parentId, id);
+        },
+        groupSelection(ids) {
+            if (!ids.length) return null;
+            const parentId = this._parent[ids[0]] || 'root';
+            const parent = this._groups[parentId];
+            const positions = ids.map(id => parent.children.indexOf(id)).filter(i => i >= 0).sort((a, b) => a - b);
+            if (!positions.length) return null;
+            const firstIndex = positions[0];
+            const groupId = this.createGroup({ parentId });
+            this._groups[groupId].children = [];
+            for (const id of ids) {
+                const idx = parent.children.indexOf(id);
+                if (idx >= 0) parent.children.splice(idx, 1);
+                this.addToGroup(groupId, id);
+            }
+            parent.children.splice(firstIndex, 0, groupId);
+            this.rebuildLayerOrder();
+            return groupId;
+        },
+        toggleExpanded(id) {
+            const g = this._groups[id];
+            if (g) g.expanded = !g.expanded;
+        },
+        toggleVisibility(id) {
+            const layers = useLayerStore();
+            const g = this._groups[id];
+            if (!g) return;
+            g.visibility = !g.visibility;
+            const visible = g.visibility;
+            const apply = (cid) => {
+                if (this.isGroup(cid)) {
+                    const cg = this._groups[cid];
+                    cg.visibility = visible;
+                    cg.children.forEach(apply);
+                } else {
+                    layers.updateProperties(cid, { visibility: visible });
+                }
+            };
+            g.children.forEach(apply);
+        },
+        toggleLock(id) {
+            const layers = useLayerStore();
+            const g = this._groups[id];
+            if (!g) return;
+            g.locked = !g.locked;
+            const locked = g.locked;
+            const apply = (cid) => {
+                if (this.isGroup(cid)) {
+                    const cg = this._groups[cid];
+                    cg.locked = locked;
+                    cg.children.forEach(apply);
+                } else {
+                    layers.updateProperties(cid, { locked });
+                }
+            };
+            g.children.forEach(apply);
+        },
+        moveItems(ids, targetId, position = 'after') {
+            if (!ids || !ids.length) return;
+            // remove from current parents
+            for (const id of ids) {
+                const parentId = this._parent[id];
+                if (!parentId) continue;
+                const arr = this._groups[parentId]?.children;
+                const idx = arr ? arr.indexOf(id) : -1;
+                if (idx >= 0) arr.splice(idx, 1);
+            }
+            if (position === 'inside') {
+                const group = this._groups[targetId];
+                if (!group) return;
+                group.children.push(...ids);
+                for (const id of ids) this._parent[id] = targetId;
+            } else {
+                const parentId = this._parent[targetId];
+                const arr = this._groups[parentId]?.children;
+                let idx = arr ? arr.indexOf(targetId) : -1;
+                if (idx < 0) return;
+                if (position === 'after') idx += 1;
+                arr.splice(idx, 0, ...ids);
+                for (const id of ids) this._parent[id] = parentId;
+            }
+            this.rebuildLayerOrder();
+        },
+        rebuildLayerOrder() {
+            const layers = useLayerStore();
+            const order = [];
+            const traverse = (id) => {
+                const group = this._groups[id];
+                if (!group) return;
+                for (const child of group.children) {
+                    if (this.isGroup(child)) traverse(child);
+                    else order.push(child);
+                }
+            };
+            traverse(this.rootId);
+            layers._order = order;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- add a layer group store to manage nested layer hierarchies
- render groups recursively and expose basic group controls in the layer panel
- add toolbar action to create or group layers
- enable drag-and-drop reordering and grouping of layers and groups

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68aef5e0be80832cb8d65791bee80373