### PR TITLE
Respect locked layers across editing tools

### DIFF
--- a/src/constants/cursor.js
+++ b/src/constants/cursor.js
@@ -13,4 +13,6 @@ export const CURSOR_CONFIG = {
     GLOBAL_ERASE_RECT: `url("${cursorIcons.globalEraseRect}") 0 0, crosshair`,
     CUT_STROKE: `url("${cursorIcons.cutStroke}") 0 16, crosshair`,
     CUT_RECT: `url("${cursorIcons.cutRect}") 0 0, crosshair`,
+    NOT_ALLOWED: 'not-allowed',
+    LOCKED: `url("${cursorIcons.locked}") 8 8, not-allowed`,
 };


### PR DESCRIPTION
## Summary
- Add locked cursor icon and use it when hovering over locked layers
- Ignore locked layers in selection tool overlays and selection updates
- Skip locked pixels during global erase and fall back to locked cursor if nothing erasable
- Guard draw, erase, and cut tools from modifying locked layers and show locked cursor over them
- Skip cutting operation when it would remove all pixels from the target layer
- Display a not-allowed cursor for draw, erase, and cut tools when the layer selection count isn't exactly one

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0abaa918832ca8af23e710c76061