### PR TITLE
Restore previous tool when switching selection modes

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -50,8 +50,10 @@ const { viewport: viewportStore, layers, output, viewportEvent: viewportEvents }
 const { toolSelection: toolSelectionService } = useService();
 
 let previousTool = null;
+let lastSingleTool = 'draw';
+let lastMultiTool = 'select';
 const selectables = ref(MULTI_SELECTION_TOOLS);
-toolSelectionService.setPrepared('select');
+toolSelectionService.setPrepared(lastMultiTool);
 toolSelectionService.setShape('stroke');
 
 watch(() => viewportEvents.recent.keyboard.down, (downs) => {
@@ -86,14 +88,18 @@ watch(() => viewportEvents.recent.keyboard.up, (ups) => {
 });
 watch(() => layers.selectionCount, (size, prev) => {
     if (size === 1) {
+        if (prev !== 1) lastMultiTool = toolSelectionService.prepared;
         selectables.value = SINGLE_SELECTION_TOOLS;
-        toolSelectionService.setPrepared('draw');
-        previousTool = 'draw';
+        const tool = lastSingleTool;
+        toolSelectionService.setPrepared(tool);
+        previousTool = tool;
     }
     else if (prev === 1) {
+        lastSingleTool = toolSelectionService.prepared;
         selectables.value = MULTI_SELECTION_TOOLS;
-        toolSelectionService.setPrepared('select');
-        previousTool = 'select';
+        const tool = lastMultiTool;
+        toolSelectionService.setPrepared(tool);
+        previousTool = tool;
     }
 });
 


### PR DESCRIPTION
## Summary
- remember the last tool used for single-layer and multi-layer modes
- automatically restore previous mode-specific tool when layer selection count changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6f8e823c832ca849d897b9d93672