### PR TITLE
Refactor layer insertion workflow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -165,18 +165,21 @@ onMounted(async () => {
 
   const autoSegments = input.isLoaded ? input.segment(40) : [];
   if (autoSegments.length) {
+    const ids = [];
     for (let i = 0; i < autoSegments.length; i++) {
       const segment = autoSegments[i];
-      layers.createLayer({
+      const id = layers.createLayer({
         name: `Auto ${i+1}`,
         color: segment.colorU32,
         visibility: true,
         pixels: segment.pixels
       });
+      ids.push(id);
     }
+    layers.insertLayers(ids);
   } else {
-    layers.createLayer({});
-    layers.createLayer({});
+    const ids = [layers.createLayer({}), layers.createLayer({})];
+    layers.insertLayers(ids);
   }
 
   layerPanel.setScrollRule({ type: "follow", target: layers.order[layers.order.length - 1] });

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -153,7 +153,7 @@ function onDrop(id, event) {
     const targetId = id;
     const rect = row.getBoundingClientRect();
     const placeBelow = (event.clientY - rect.top) > rect.height * 0.5;
-    layers.reorderLayers(layers.selectedIds, targetId, placeBelow);
+    layers.insertLayers(layers.selectedIds, targetId, placeBelow);
     output.commit();
 }
 

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -34,9 +34,7 @@ const onAdd = () => {
     output.setRollbackPoint();
     const above = layers.selectionCount ? query.uppermost(layers.selectedIds) : null;
     const id = layers.createLayer({});
-    if (above !== null) {
-        layers.reorderLayers([id], above, false);
-    }
+    layers.insertLayers([id], above, false);
     layerPanel.setRange(id, id);
     output.commit();
 };

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -129,12 +129,13 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (!cutCoords.length || cutKeys.size === sourceKeys.size) return;
 
         layers.removePixels(sourceId, cutCoords);
-        layers.createLayer({
+        const id = layers.createLayer({
             name: `Cut of ${layers.getProperty(sourceId, 'name')}`,
             color: layers.getProperty(sourceId, 'color'),
             visibility: layers.getProperty(sourceId, 'visibility'),
             pixels: cutCoords,
-        }, sourceId);
+        });
+        layers.insertLayers([id], sourceId, false);
 
         layers.replaceSelection([sourceId]);
         layerPanel.setScrollRule({ type: 'follow', target: sourceId });
@@ -175,7 +176,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             tool.setCursor({ stroke: CURSOR_CONFIG.LOCKED, rect: CURSOR_CONFIG.LOCKED });
         }
         else {
-            layers.reorderLayers([id], layers.idsTopToBottom[0], false);
+            layers.insertLayers([id], layers.idsTopToBottom[0], false);
             layers.replaceSelection([id]);
             layerPanel.setScrollRule({ type: 'follow', target: id });
             tool.setCursor({ stroke: CURSOR_CONFIG.TOP, rect: CURSOR_CONFIG.TOP });


### PR DESCRIPTION
## Summary
- rename `reorderLayers` to `insertLayers` and allow inserting new layers
- have `createLayer` only allocate and return an id
- update layer creation code to call `insertLayers` for ordering
- batch layer insertions instead of inserting within loops

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afc24d742c832cadcb9f46c6b82c4d