### PR TITLE
feat: add stage resizing support

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -4,6 +4,16 @@
 
       <div class="h-4 w-px bg-white/10 mx-1"></div>
 
+      <!-- Stage resize -->
+      <div class="inline-flex rounded-md overflow-hidden border border-white/15">
+        <button @click="e => resize('top', e)" title="Expand Up (Shift to shrink)" class="p-1 bg-white/5 hover:bg-white/10">↑</button>
+        <button @click="e => resize('bottom', e)" title="Expand Down (Shift to shrink)" class="p-1 bg-white/5 hover:bg-white/10">↓</button>
+        <button @click="e => resize('left', e)" title="Expand Left (Shift to shrink)" class="p-1 bg-white/5 hover:bg-white/10">←</button>
+        <button @click="e => resize('right', e)" title="Expand Right (Shift to shrink)" class="p-1 bg-white/5 hover:bg-white/10">→</button>
+      </div>
+
+      <div class="h-4 w-px bg-white/10 mx-1"></div>
+
       <!-- Shape toggle -->
       <div class="inline-flex rounded-md overflow-hidden border border-white/15">
         <button @click="toolSelectionService.setShape('stroke')"
@@ -47,7 +57,12 @@ import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, TOOL_MODIFIERS } from '@
 import stageIcons from '../image/stage_toolbar';
 
 const { viewport: viewportStore, layers, output, viewportEvent: viewportEvents } = useStore();
-const { toolSelection: toolSelectionService } = useService();
+const { toolSelection: toolSelectionService, stageResize: stageResizeService } = useService();
+
+function resize(direction, event) {
+    const delta = event.shiftKey ? -1 : 1;
+    stageResizeService.resize(direction, delta);
+}
 
 let previousTool = null;
 let lastSingleTool = 'draw';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -5,6 +5,7 @@ import { useQueryService } from './query';
 import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
+import { useStageResizeService } from './stageResize';
 
 export {
     useLayerPanelService,
@@ -18,7 +19,8 @@ export {
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
-    useViewportService
+    useViewportService,
+    useStageResizeService
 };
 
 export const useService = () => ({
@@ -35,5 +37,6 @@ export const useService = () => ({
         top: useTopToolService(),
     },
     toolSelection: useToolSelectionService(),
-    viewport: useViewportService()
+    viewport: useViewportService(),
+    stageResize: useStageResizeService()
 });

--- a/src/services/stageResize.js
+++ b/src/services/stageResize.js
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+import { useStore } from '../stores';
+
+export const useStageResizeService = defineStore('stageResizeService', () => {
+  const { viewport } = useStore();
+
+  function resize(direction, delta = 1) {
+    const payload = { top: 0, bottom: 0, left: 0, right: 0 };
+    if (direction === 'top') payload.top = delta;
+    else if (direction === 'bottom') payload.bottom = delta;
+    else if (direction === 'left') payload.left = delta;
+    else if (direction === 'right') payload.right = delta;
+    viewport.resizeByEdges(payload);
+  }
+
+  function expand(direction, amount = 1) {
+    resize(direction, Math.abs(amount));
+  }
+
+  function shrink(direction, amount = 1) {
+    resize(direction, -Math.abs(amount));
+  }
+
+  return { resize, expand, shrink };
+});

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -177,6 +177,19 @@ export const useLayerStore = defineStore('layers', {
         clearSelection() {
             this._selection.clear();
         },
+        translateAll(dx = 0, dy = 0) {
+            dx |= 0; dy |= 0;
+            if (dx === 0 && dy === 0) return;
+            for (const id of this._order) {
+                const set = this._pixels[id];
+                const moved = new Set();
+                for (const key of set) {
+                    const { x, y } = keyToCoord(key);
+                    moved.add(coordToKey({ x: x + dx, y: y + dy }));
+                }
+                this._pixels[id] = reactive(moved);
+            }
+        },
         /** Serialization */
         serialize() {
             return {


### PR DESCRIPTION
## Summary
- add layer translation helper
- support resizing stage by edges and shifting pixels
- wire up stage resize service and toolbar controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcb0c9bdc832c8c587e6a6c884308