### PR TITLE
feat: support dynamic overlay list

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -38,31 +38,23 @@
           <path v-for="y in (stage.height+1)" :key="'gy'+y" :d="'M 0 '+(y-1)+' H '+stage.width"></path>
         </g>
       </svg>
-      <!-- 오버레이 (선택, 추가, 제거) -->
-      <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
-          <!-- Selection overlay (sky blue) -->
-          <path id="selectionOverlay"
-                v-if="layers.selectionExists"
-                :d="overlay.selection.path"
-                :fill="OVERLAY_CONFIG.SELECTED.FILL_COLOR"
-                :stroke="OVERLAY_CONFIG.SELECTED.STROKE_COLOR"
-                :stroke-width="OVERLAY_CONFIG.SELECTED.STROKE_WIDTH_SCALE / Math.max(1, stage.scale)"
+        <!-- 오버레이 -->
+        <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
+          <path v-for="ov in overlay.list" :key="ov.id" v-if="ov.path"
+                :id="ov.id + 'Overlay'"
+                :d="ov.path"
+                :fill="ov.config.FILL_COLOR"
+                :stroke="ov.config.STROKE_COLOR"
+                :stroke-width="ov.config.STROKE_WIDTH_SCALE / Math.max(1, stage.scale)"
+                :fill-rule="ov.config.FILL_RULE"
                 shape-rendering="crispEdges" />
-        <!-- Helper overlay -->
-        <path id="helperOverlay"
-              :d="helperOverlay.path"
-              :fill="helperOverlay.FILL_COLOR"
-              :stroke="helperOverlay.STROKE_COLOR"
-              :stroke-width="helperOverlay.STROKE_WIDTH_SCALE / Math.max(1, stage.scale)"
-              fill-rule="evenodd"
-              shape-rendering="crispEdges" />
-      </svg>
-    </div>
-    <!-- Marquee overlay -->
-    <svg class="absolute top-0 left-0 w-full h-full pointer-events-none block" :viewBox="viewportViewBox" preserveAspectRatio="none">
-        <rect id="marqueeRect"
-              :x="marqueeRect.x"
-              :y="marqueeRect.y"
+        </svg>
+      </div>
+      <!-- Marquee overlay -->
+      <svg class="absolute top-0 left-0 w-full h-full pointer-events-none block" :viewBox="viewportViewBox" preserveAspectRatio="none">
+          <rect id="marqueeRect"
+                :x="marqueeRect.x"
+                :y="marqueeRect.y"
               :width="marqueeRect.width"
               :height="marqueeRect.height"
               :visibility="marqueeRect.visibility"
@@ -107,20 +99,7 @@ const marqueeRect = computed(() => {
     };
 });
 
-const helperOverlay = computed(() => {
-    const path = overlay.helper.path;
-    if (!path) return { path }; // no style when empty
-
-    const style =  overlay.helper.config;
-    return {
-        path,
-        FILL_COLOR: style.FILL_COLOR,
-        STROKE_COLOR: style.STROKE_COLOR,
-        STROKE_WIDTH_SCALE: style.STROKE_WIDTH_SCALE,
-    };
-});
-
-const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
+  const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
 
 const onImageLoad = (e) => {
     const img = e.target;

--- a/src/constants/overlay.js
+++ b/src/constants/overlay.js
@@ -3,20 +3,24 @@ export const OVERLAY_CONFIG = {
         FILL_COLOR: 'rgba(56, 189, 248, 0.1)',
         STROKE_COLOR: 'rgba(56, 189, 248, 1.0)',
         STROKE_WIDTH_SCALE: 3,
+        FILL_RULE: 'nonzero',
     },
     MARQUEE: {
         FILL_COLOR: 'rgba(248, 229, 56, 0.0)',
         STROKE_COLOR: 'rgba(248, 229, 56, 1.0)',
         STROKE_WIDTH_SCALE: 1,
+        FILL_RULE: 'nonzero',
     },
     ADD: {
         FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
         STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
         STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
     },
     REMOVE: {
         FILL_COLOR: 'rgba(248, 113, 113, 0.25)',
         STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
         STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
     }
 };

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -39,18 +39,39 @@ export const useOverlayService = defineStore('overlayService', () => {
         return { pixels, path, clear, addLayers, setLayers, addPixels, setPixels };
     }
 
-    const selection = createOverlayState();
-    const helper = createOverlayState();
-    const helperConfig = ref(OVERLAY_CONFIG.ADD);
+    const overlays = reactive({});
+    const list = computed(() => Object.values(overlays));
+
+    function addOverlay(id, config = OVERLAY_CONFIG.ADD) {
+        if (overlays[id]) return overlays[id];
+        const state = createOverlayState();
+        overlays[id] = { id, ...state, config: ref(config) };
+        return overlays[id];
+    }
+
+    function removeOverlay(id) {
+        delete overlays[id];
+    }
+
+    addOverlay('selection', OVERLAY_CONFIG.SELECTED);
+    addOverlay('helper', OVERLAY_CONFIG.ADD);
 
     function rebuildSelection() {
-        selection.setLayers(layers.selectedIds);
+        overlays.selection.setLayers(layers.selectedIds);
     }
 
     watch(() => layers.selectedIds.slice(), rebuildSelection, { immediate: true });
 
+    function getOverlay(id) {
+        return overlays[id];
+    }
+
     return {
-        selection,
-        helper: { ...helper, config: helperConfig }
+        overlays,
+        list,
+        addOverlay,
+        removeOverlay,
+        getOverlay,
     };
 });
+

--- a/src/services/toolSelection.js
+++ b/src/services/toolSelection.js
@@ -5,7 +5,8 @@ import { useOverlayService } from './overlay';
 
 export const useToolSelectionService = defineStore('toolSelectionService', () => {
     const { viewport: viewportStore, viewportEvent: viewportEvents, output } = useStore();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
 
     const active = ref(false)
     const prepared = ref(null);
@@ -136,7 +137,7 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
         marquee.visible = false;
         previewPixels.value = [];
         affectedPixels.value = [];
-        overlay.helper.clear();
+          helper.clear();
     });
 
     return {

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -9,16 +9,17 @@ import { coordToKey } from '../utils';
 
 export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const { layers } = useStore();
     watch(() => tool.prepared === 'draw', (isDraw) => {
         if (!isDraw) return;
-        overlay.helper.config = OVERLAY_CONFIG.ADD;
+        helper.config = OVERLAY_CONFIG.ADD;
         tool.setCursor({ stroke: CURSOR_CONFIG.DRAW_STROKE, rect: CURSOR_CONFIG.DRAW_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'draw') return;
-        overlay.helper.setPixels(pixel ? [pixel] : []);
+        helper.setPixels(pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'draw' || layers.selectionCount !== 1) return;
@@ -33,7 +34,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.prepared !== 'draw' || layers.selectionCount !== 1) return;
-        overlay.helper.setPixels(pixels);
+        helper.setPixels(pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'draw' || layers.selectionCount !== 1) return;
@@ -46,16 +47,17 @@ export const useDrawToolService = defineStore('drawToolService', () => {
 
 export const useEraseToolService = defineStore('eraseToolService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const { layers } = useStore();
     watch(() => tool.prepared === 'erase', (isErase) => {
         if (!isErase) return;
-        overlay.helper.config = OVERLAY_CONFIG.REMOVE;
+        helper.config = OVERLAY_CONFIG.REMOVE;
         tool.setCursor({ stroke: CURSOR_CONFIG.ERASE_STROKE, rect: CURSOR_CONFIG.ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'erase') return;
-        overlay.helper.setPixels(pixel ? [pixel] : []);
+        helper.setPixels(pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'erase' || layers.selectionCount !== 1) return;
@@ -70,7 +72,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.prepared !== 'erase' || layers.selectionCount !== 1) return;
-        overlay.helper.setPixels(pixels);
+        helper.setPixels(pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'erase' || layers.selectionCount !== 1) return;
@@ -83,17 +85,18 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
 
 export const useCutToolService = defineStore('cutToolService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const layerPanel = useLayerPanelService();
     const { layers } = useStore();
     watch(() => tool.prepared === 'cut', (isCut) => {
         if (!isCut) return;
-        overlay.helper.config = OVERLAY_CONFIG.REMOVE;
+        helper.config = OVERLAY_CONFIG.REMOVE;
         tool.setCursor({ stroke: CURSOR_CONFIG.CUT_STROKE, rect: CURSOR_CONFIG.CUT_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'cut') return;
-        overlay.helper.setPixels(pixel ? [pixel] : []);
+        helper.setPixels(pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'cut' || layers.selectionCount !== 1) return;
@@ -108,7 +111,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.prepared !== 'cut' || layers.selectionCount !== 1) return;
-        overlay.helper.setPixels(pixels);
+        helper.setPixels(pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'cut' || layers.selectionCount !== 1) return;
@@ -146,18 +149,19 @@ export const useCutToolService = defineStore('cutToolService', () => {
 
 export const useTopToolService = defineStore('topToolService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const layerPanel = useLayerPanelService();
     const { layers } = useStore();
     watch(() => tool.prepared === 'top', (isTop) => {
         if (!isTop) return;
-        overlay.helper.config = OVERLAY_CONFIG.ADD;
+        helper.config = OVERLAY_CONFIG.ADD;
         tool.setCursor({ stroke: CURSOR_CONFIG.TOP, rect: CURSOR_CONFIG.TOP });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'top') return;
         if (!pixel) {
-            overlay.helper.clear();
+            helper.clear();
             return;
         }
         const id = layers.topVisibleIdAt(pixel);
@@ -167,7 +171,7 @@ export const useTopToolService = defineStore('topToolService', () => {
         else {
             tool.setCursor({ stroke: CURSOR_CONFIG.TOP, rect: CURSOR_CONFIG.TOP });
         }
-        overlay.helper.setLayers(id ? [id] : []);
+        helper.setLayers(id ? [id] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'top' || !pixel) return;
@@ -188,7 +192,8 @@ export const useTopToolService = defineStore('topToolService', () => {
 
 export const useSelectService = defineStore('selectService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const layerPanel = useLayerPanelService();
     const { layers, viewportEvent: viewportEvents } = useStore();
     let mode = 'select';
@@ -199,28 +204,28 @@ export const useSelectService = defineStore('selectService', () => {
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'select') return;
         if (!pixel) {
-            overlay.helper.clear();
+            helper.clear();
             return;
         }
         const id = layers.topVisibleIdAt(pixel);
         if (!viewportEvents.isPressed('Shift')) {
             mode = 'select';
-            overlay.helper.config = OVERLAY_CONFIG.ADD;
+            helper.config = OVERLAY_CONFIG.ADD;
             tool.setCursor({ stroke: CURSOR_CONFIG.ADD_STROKE, rect: CURSOR_CONFIG.ADD_RECT });
         } else if (layers.isSelected(id)) {
             mode = 'remove';
-            overlay.helper.config = OVERLAY_CONFIG.REMOVE;
+            helper.config = OVERLAY_CONFIG.REMOVE;
             tool.setCursor({ stroke: CURSOR_CONFIG.REMOVE_STROKE, rect: CURSOR_CONFIG.REMOVE_RECT });
         } else {
             mode = 'add';
-            overlay.helper.config = OVERLAY_CONFIG.ADD;
+            helper.config = OVERLAY_CONFIG.ADD;
             tool.setCursor({ stroke: CURSOR_CONFIG.ADD_STROKE, rect: CURSOR_CONFIG.ADD_RECT });
         }
 
         if (id && layers.getProperty(id, 'locked')) {
             tool.setCursor({ stroke: CURSOR_CONFIG.LOCKED, rect: CURSOR_CONFIG.LOCKED });
         }
-        overlay.helper.setLayers(id ? [id] : []);
+        helper.setLayers(id ? [id] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'select') return;
@@ -247,7 +252,7 @@ export const useSelectService = defineStore('selectService', () => {
             if (mode === 'add' && layers.isSelected(id)) return;
             highlightIds.push(id);
         });
-        overlay.helper.setLayers(highlightIds);
+        helper.setLayers(highlightIds);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'select') return;
@@ -276,16 +281,17 @@ export const useSelectService = defineStore('selectService', () => {
 
 export const useGlobalEraseToolService = defineStore('globalEraseToolService', () => {
     const tool = useToolSelectionService();
-    const overlay = useOverlayService();
+    const overlayService = useOverlayService();
+    const helper = overlayService.getOverlay('helper');
     const { layers } = useStore();
     watch(() => tool.prepared === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) return
-        overlay.helper.config = OVERLAY_CONFIG.REMOVE;
+        helper.config = OVERLAY_CONFIG.REMOVE;
         tool.setCursor({ stroke: CURSOR_CONFIG.GLOBAL_ERASE_STROKE, rect: CURSOR_CONFIG.GLOBAL_ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'globalErase') return;
-        overlay.helper.setPixels(pixel ? [pixel] : []);
+        helper.setPixels(pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'globalErase') return;
@@ -314,7 +320,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
                 if (unlockedPixels.has(coordToKey(coord))) erasablePixels.push(coord);
             }
         }
-        overlay.helper.setPixels(erasablePixels);
+        helper.setPixels(erasablePixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'globalErase' || !pixels.length) return;


### PR DESCRIPTION
## Summary
- allow dynamic overlays via reactive list with add/remove API
- render overlays from stateful list and unify overlay config with fill-rule
- update tool services to use helper overlay via `getOverlay`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68affed8a9d0832c894778025fe11b69