### PR TITLE
refactor: remove anchor-based operations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -111,9 +111,9 @@ function onKeydown(event) {
       output.commit();
       return;
     case 'Enter':
-         if (!ctrl && !shift) {
-            const anchorId = layerPanel.anchorId;
-            const row = document.querySelector(`.layer[data-id="${anchorId}"] .nameText`)
+         if (!ctrl && !shift && layers.selectionCount === 1) {
+            const selectedId = layers.selectedIds[0];
+            const row = document.querySelector(`.layer[data-id="${selectedId}"] .nameText`)
             if (row) {
                 event.preventDefault();
                 row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -60,7 +60,7 @@ const onSelectEmpty = () => {
 };
 const onSplit = () => {
     output.setRollbackPoint();
-    const newIds = layerSvc.splitLayer(layerPanel.anchorId);
+    const newIds = layerSvc.splitSelected();
     layerPanel.setScrollRule({ type: 'follow', target: newIds[0] });
     output.commit();
 };


### PR DESCRIPTION
## Summary
- rename merge variables to "maintained" to remove anchor terminology
- allow splitting across all selected layers, keeping original and new layers selected
- enable split toolbar action whenever any selected layer can be split

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b00a5440fc832cafa0bfa037140c2c