### PR TITLE
Improve layers panel with groups and DFS range selection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -178,10 +178,10 @@ onMounted(async () => {
       });
       ids.push(id);
     }
-    layers.insertLayers(ids);
+    layers.insert(ids);
   } else {
     const ids = [layers.createLayer({}), layers.createLayer({})];
-    layers.insertLayers(ids);
+    layers.insert(ids);
   }
 
   layerPanel.setScrollRule({ type: "follow", target: layers.order[layers.order.length - 1] });

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,45 +1,66 @@
 <template>
-  <div v-memo="[output.commitVersion, layers.selectedIds, layers.count]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="props in layers.getProperties(layers.idsTopToBottom)" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="props.id" :data-id="props.id" :class="{ selected: layers.isSelected(props.id), anchor: layerPanel.anchorId===props.id, dragging: dragId===props.id }" draggable="true" @click="layerPanel.onLayerClick(props.id,$event)" @dragstart="onDragStart(props.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(props.id,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(props.id,$event)">
-      <!-- 썸네일 -->
-      <div @click.stop="onThumbnailClick(props.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
-        <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
-          <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-          <path :d="layers.pathOf(props.id)" :fill="rgbaCssU32(props.color)" :opacity="props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
-        </svg>
-      </div>
-      <!-- 색상 -->
-      <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-        <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': props.locked }" :disabled="props.locked" :value="rgbaToHexU32(props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(props.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
-      </div>
-      <!-- 이름/픽셀 -->
-      <div class="min-w-0 flex-1">
-        <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
-          <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(props.id)" @keydown="onNameKey(props.id,$event)" @blur="finishRename(props.id,$event)">{{ props.name }}</span>
+  <div v-memo="[output.commitVersion, layers.selectedIds, layers.count, foldedMemo]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
+    <div v-for="item in flatNodes" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="item.id" :data-id="item.id" :style="{ marginLeft: (item.depth * 16) + 'px' }" :class="{ selected: layers.isSelected(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item,$event)">
+      <template v-if="item.isGroup">
+        <div class="w-4 text-center cursor-pointer" @click.stop="toggleFold(item.id)">{{ folded[item.id] ? '▶' : '▼' }}</div>
+        <div class="min-w-0 flex-1">
+          <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
+            <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
+          </div>
         </div>
-        <div class="text-xs text-slate-400">
-          <template v-if="layers.disconnectedCountOf(props.id) > 1">
-            <span class="cursor-pointer" @click.stop="onDisconnectedClick(props.id)">⚠️</span>
-            <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(props.id)">{{ layers.disconnectedCountOf(props.id) }} piece</span>
-            <span class="mx-1">|</span>
-          </template>
-          <span class="cursor-pointer" @click.stop="onPixelCountClick(props.id)" title="같은 크기의 모든 레이어 선택">{{ props.pixels.length }} px</span>
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+          </div>
         </div>
-      </div>
-      <!-- 액션 -->
-      <div class="flex gap-1 justify-end">
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-          <img :src="(props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(props.id)" />
+      </template>
+      <template v-else>
+        <!-- 썸네일 -->
+        <div @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
+          <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
+            <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
+            <path :d="layers.pathOf(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+          </svg>
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-          <img :src="(props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(props.id)" />
+        <!-- 색상 -->
+        <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
+          <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.props.locked }" :disabled="item.props.locked" :value="rgbaToHexU32(item.props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
         </div>
-        <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-          <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(props.id)" />
+        <!-- 이름/픽셀 -->
+        <div class="min-w-0 flex-1">
+          <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
+            <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
+          </div>
+          <div class="text-xs text-slate-400">
+            <template v-if="layers.disconnectedCountOf(item.id) > 1">
+              <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
+              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ layers.disconnectedCountOf(item.id) }} piece</span>
+              <span class="mx-1">|</span>
+            </template>
+            <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.props.pixels.length }} px</span>
+          </div>
         </div>
+        <!-- 액션 -->
+        <div class="flex gap-1 justify-end">
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+            <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+            <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+          </div>
+          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+          </div>
         </div>
+      </template>
     </div>
-      <div v-show="layers.idsTopToBottom.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
+    <div v-show="flatNodes.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>
 
@@ -59,8 +80,29 @@ const dragId = ref(null);
 const editingId = ref(null);
 const listElement = ref(null);
 const icons = reactive(blockIcons);
+const folded = layerPanel.folded;
+const foldedMemo = computed(() => JSON.stringify(folded));
+
+const flatNodes = computed(() => {
+  const result = [];
+  const walk = (nodes, depth) => {
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const node = nodes[i];
+      const isGroup = !!node.children;
+      result.push({ id: node.id, depth, isGroup });
+      if (isGroup && !folded[node.id]) walk(node.children, depth + 1);
+    }
+  };
+  walk(layers.tree, 0);
+  const propsList = layers.getProperties(result.map(r => r.id));
+  return result.map((r, i) => ({ ...r, props: propsList[i] }));
+});
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
+
+function toggleFold(id) {
+  layerPanel.toggleFold(id);
+}
 
 
   function onThumbnailClick(id) {
@@ -130,30 +172,40 @@ function onDragEnd() {
     dragId.value = null;
 }
 
-function onDragOver(id, event) {
+function onDragOver(item, event) {
     const row = event.currentTarget;
-    if (layers.isSelected(id)) {
-        row.classList.remove('insert-before', 'insert-after');
+    if (layers.isSelected(item.id)) {
+        row.classList.remove('insert-before', 'insert-after', 'insert-into');
         event.dataTransfer.dropEffect = 'none';
         return;
     }
     const rect = row.getBoundingClientRect();
-    const before = (event.clientY - rect.top) < rect.height * 0.5;
-    row.classList.toggle('insert-before', before);
-    row.classList.toggle('insert-after', !before);
+    const y = event.clientY - rect.top;
+    row.classList.remove('insert-before', 'insert-after', 'insert-into');
+    if (item.isGroup && y > rect.height / 3 && y < rect.height * 2 / 3) {
+        row.classList.add('insert-into');
+    } else {
+        const before = y < rect.height * 0.5;
+        row.classList.add(before ? 'insert-before' : 'insert-after');
+    }
 }
 
 function onDragLeave(event) {
-    event.currentTarget.classList.remove('insert-before', 'insert-after');
+    event.currentTarget.classList.remove('insert-before', 'insert-after', 'insert-into');
 }
 
-function onDrop(id, event) {
+function onDrop(item, event) {
     const row = event.currentTarget;
-    row.classList.remove('insert-before', 'insert-after');
-    const targetId = id;
+    row.classList.remove('insert-before', 'insert-after', 'insert-into');
     const rect = row.getBoundingClientRect();
-    const placeBelow = (event.clientY - rect.top) > rect.height * 0.5;
-    layers.insertLayers(layers.selectedIds, targetId, placeBelow);
+    const y = event.clientY - rect.top;
+    const ids = layers.selectedNodeIds;
+    if (item.isGroup && y > rect.height / 3 && y < rect.height * 2 / 3) {
+        layers.putIn(ids, item.id, true);
+    } else {
+        const placeBelow = y > rect.height * 0.5;
+        layers.insert(ids, item.id, placeBelow);
+    }
     output.commit();
 }
 
@@ -382,6 +434,7 @@ onUnmounted(() => {
 /* 레이어 재정렬 표시 */
 .insert-before{box-shadow:inset 0 3px 0 0 rgba(56,189,248,.7)}
 .insert-after{box-shadow:inset 0 -3px 0 0 rgba(56,189,248,.7)}
+.insert-into{box-shadow:inset 0 0 0 2px rgba(56,189,248,.7)}
 
 /* 선택 강조 */
 .layer.selected{

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -3,6 +3,9 @@
         <button @click="onAdd" title="Add layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img :src="toolbarIcons.add" alt="Add layer" class="w-4 h-4">
         </button>
+        <button @click="onAddGroup" title="Add group" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+          <img :src="toolbarIcons.group" alt="Add group" class="w-4 h-4">
+        </button>
         <button @click="onCopy" :disabled="!layers.selectionExists" title="Copy layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.copy" alt="Copy layer" class="w-4 h-4">
         </button>
@@ -34,8 +37,24 @@ const onAdd = () => {
     output.setRollbackPoint();
     const above = layers.selectionCount ? query.uppermost(layers.selectedIds) : null;
     const id = layers.createLayer({});
-    layers.insertLayers([id], above, false);
+    layers.insert([id], above, false);
     layers.replaceSelection([id]);
+    layerPanel.setScrollRule({ type: 'follow', target: id });
+    output.commit();
+};
+const onAddGroup = () => {
+    output.setRollbackPoint();
+    const selected = layers.selectedNodeIds;
+    const id = layers.createGroup({});
+    if (selected.length === 0) {
+        layers.putIn([id], null, false);
+    } else {
+        const lowermost = selected[0];
+        layers.insert([id], lowermost, true);
+        layers.putIn(selected, id, true);
+    }
+    layers.replaceSelection([id]);
+    layerPanel.setRange(id, id);
     layerPanel.setScrollRule({ type: 'follow', target: id });
     output.commit();
 };

--- a/src/image/layer_toolbar/index.js
+++ b/src/image/layer_toolbar/index.js
@@ -3,9 +3,11 @@ import copy from './copy.svg';
 import merge from './merge.svg';
 import split from './split.svg';
 import empty from './empty.svg';
+import group from './group.svg';
 
 export default {
   add,
+  group,
   copy,
   merge,
   split,

--- a/src/services/layerPanel.js
+++ b/src/services/layerPanel.js
@@ -1,17 +1,17 @@
 import { defineStore } from 'pinia';
 import { reactive, toRefs, watch, computed } from 'vue';
 import { useStore } from '../stores';
-import { useQueryService } from './query';
 
 export const useLayerPanelService = defineStore('layerPanelService', () => {
     const { layers } = useStore();
-    const query = useQueryService();
 
     const state = reactive({
         anchorId: null,
         tailId: null,
-        scrollRule: null
+        scrollRule: null,
     });
+
+    const folded = reactive({});
 
     const exists = computed(() => state.anchorId != null && state.tailId != null);
 
@@ -34,6 +34,31 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
         }
     }
 
+    function dfs(skipFolded = false) {
+        const order = [];
+        const ancestors = new Map();
+        const walk = (nodes, anc) => {
+            for (const node of nodes) {
+                ancestors.set(node.id, anc.slice());
+                order.push(node.id);
+                if (node.children && !(skipFolded && folded[node.id])) {
+                    walk(node.children, anc.concat(node.id));
+                }
+            }
+        };
+        walk(layers.tree, []);
+        return { order, ancestors };
+    }
+
+    function visibleAncestor(id, orderSet) {
+        let info = layers._findNode(id);
+        while (info && !orderSet.has(info.node.id)) {
+            if (!info.parent) return null;
+            info = layers._findNode(info.parent.id);
+        }
+        return info ? info.node.id : null;
+    }
+
     function setRange(anchorId = null, tailId = null) {
         disableWatch();
         if (anchorId == null || tailId == null) {
@@ -42,17 +67,24 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
             layers.clearSelection();
             return;
         }
-        const order = layers.order;
-        const start = order.indexOf(anchorId);
-        const end = order.indexOf(tailId);
-        if (start < 0 || end < 0) {
+
+        const { order, ancestors } = dfs(false);
+        const idxA = order.indexOf(anchorId);
+        const idxB = order.indexOf(tailId);
+        if (idxA === -1 || idxB === -1) {
             state.anchorId = null;
             state.tailId = null;
             layers.clearSelection();
             return;
         }
-        const [min, max] = start < end ? [start, end] : [end, start];
-        layers.replaceSelection(order.slice(min, max + 1));
+        const [start, end] = idxA < idxB ? [idxA, idxB] : [idxB, idxA];
+        const slice = order.slice(start, end + 1);
+        const ancToRemove = new Set([
+            ...(ancestors.get(anchorId) || []),
+            ...(ancestors.get(tailId) || []),
+        ]);
+        const selection = slice.filter(id => !ancToRemove.has(id));
+        layers.replaceSelection(selection);
         state.anchorId = anchorId;
         state.tailId = tailId;
         enableWatch();
@@ -81,13 +113,23 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
 
     function onArrowUp(shift, ctrl) {
         if (!layers.exists || ctrl) return;
+        const { order } = dfs(true);
+        if (!order.length) return;
+        const orderSet = new Set(order);
         if (shift) {
             if (!layers.selectionExists) return;
-            const newTail = query.above(state.tailId) ?? query.uppermost();
-            setRange(state.anchorId, newTail);
+            const tailVis = visibleAncestor(state.tailId, orderSet);
+            const anchorVis = visibleAncestor(state.anchorId, orderSet);
+            if (tailVis == null || anchorVis == null) return;
+            const idx = order.indexOf(tailVis);
+            const newTail = order[idx + 1] ?? order[order.length - 1];
+            setRange(anchorVis, newTail);
             setScrollRule({ type: 'follow-up', target: newTail });
         } else {
-            const nextId = query.above(state.anchorId) ?? state.anchorId;
+            const anchorVis = visibleAncestor(state.anchorId, orderSet);
+            if (anchorVis == null) return;
+            const idx = order.indexOf(anchorVis);
+            const nextId = order[idx + 1] ?? anchorVis;
             setRange(nextId, nextId);
             setScrollRule({ type: 'follow-up', target: nextId });
         }
@@ -95,27 +137,44 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
 
     function onArrowDown(shift, ctrl) {
         if (!layers.exists || ctrl) return;
+        const { order } = dfs(true);
+        if (!order.length) return;
+        const orderSet = new Set(order);
         if (shift) {
             if (!layers.selectionExists) return;
-            const newTail = query.below(state.tailId) ?? query.lowermost();
-            setRange(state.anchorId, newTail);
+            const tailVis = visibleAncestor(state.tailId, orderSet);
+            const anchorVis = visibleAncestor(state.anchorId, orderSet);
+            if (tailVis == null || anchorVis == null) return;
+            const idx = order.indexOf(tailVis);
+            const newTail = order[idx - 1] ?? order[0];
+            setRange(anchorVis, newTail);
             setScrollRule({ type: 'follow-down', target: newTail });
         } else {
-            const nextId = query.below(state.anchorId) ?? state.anchorId;
+            const anchorVis = visibleAncestor(state.anchorId, orderSet);
+            if (anchorVis == null) return;
+            const idx = order.indexOf(anchorVis);
+            const nextId = order[idx - 1] ?? anchorVis;
             setRange(nextId, nextId);
             setScrollRule({ type: 'follow-down', target: nextId });
         }
     }
 
+    function toggleFold(id) {
+        folded[id] = !folded[id];
+    }
+
     function selectAll() {
-        setRange(query.uppermost(), query.lowermost());
+        const { order } = dfs(false);
+        if (!order.length) return;
+        setRange(order[0], order[order.length - 1]);
     }
 
     function serialize() {
         return {
             anchor: state.anchorId,
             tailId: state.tailId,
-            scrollRule: state.scrollRule
+            scrollRule: state.scrollRule,
+            folded: { ...folded },
         };
     }
 
@@ -127,11 +186,15 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
             enableWatch();
         }
         state.scrollRule = payload?.scrollRule;
+        for (const key of Object.keys(folded)) delete folded[key];
+        Object.assign(folded, payload?.folded || {});
     }
 
     return {
         ...toRefs(state),
         exists,
+        folded,
+        toggleFold,
         setRange,
         clearRange,
         setScrollRule,
@@ -140,7 +203,7 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
         onArrowDown,
         selectAll,
         serialize,
-        applySerialized
+        applySerialized,
     };
 });
 

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -33,7 +33,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         });
         const newPixels = pixelUnion;
         if (newPixels.length) layers.addPixels(newLayerId, newPixels);
-        layers.insertLayers([newLayerId], query.lowermost(layers.selectedIds), true);
+        layers.insert([newLayerId], query.lowermost(layers.selectedIds), true);
         const ids = layers.selectedIds;
         layers.deleteLayers(ids);
         return newLayerId;
@@ -58,7 +58,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             });
             newLayerIds.push(newLayerId);
         }
-        layers.insertLayers(newLayerIds, query.uppermost(sorted), false);
+        layers.insert(newLayerIds, query.uppermost(sorted), false);
         return newLayerIds;
     }
 
@@ -99,7 +99,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             layers.deleteLayers([layerId]);
 
             const target = layers.idsBottomToTop[originalIndex];
-            layers.insertLayers(newIds, target, true);
+            layers.insert(newIds, target, true);
 
             newSelection.delete(layerId);
             for (const id of newIds) newSelection.add(id);

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -148,7 +148,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
             pixels: cutCoords,
             attributes: layers.getProperty(sourceId, 'attributes'),
         });
-        layers.insertLayers([id], sourceId, false);
+        layers.insert([id], sourceId, false);
 
         layers.replaceSelection([sourceId]);
         layerPanel.setScrollRule({ type: 'follow', target: sourceId });
@@ -193,7 +193,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             tool.setCursor({ stroke: CURSOR_CONFIG.LOCKED, rect: CURSOR_CONFIG.LOCKED });
         }
         else {
-            layers.insertLayers([id], layers.idsTopToBottom[0], false);
+            layers.insert([id], layers.idsTopToBottom[0], false);
             layers.replaceSelection([id]);
             layerPanel.setScrollRule({ type: 'follow', target: id });
             tool.setCursor({ stroke: CURSOR_CONFIG.TOP, rect: CURSOR_CONFIG.TOP });

--- a/src/stores/layers.js
+++ b/src/stores/layers.js
@@ -2,25 +2,104 @@ import { defineStore } from 'pinia';
 import { readonly, reactive } from 'vue';
 import { coordToKey, keyToCoord, pixelsToUnionPath, randColorU32, groupConnectedPixels } from '../utils';
 
+/**
+ * Helper: flatten tree nodes to layer id list.
+ */
+function flatten(nodes, result = []) {
+    for (const node of nodes) {
+        if (node.children) flatten(node.children, result);
+        else result.push(node.id);
+    }
+    return result;
+}
+
+/** Build reactive tree from serialized plain object */
+function buildTree(nodes) {
+    return nodes.map(n => n.children
+        ? { id: n.id, children: reactive(buildTree(n.children)) }
+        : { id: n.id });
+}
+
+/** Deep clone tree for serialization */
+function cloneTree(nodes) {
+    return nodes.map(n => n.children
+        ? { id: n.id, children: cloneTree(n.children) }
+        : { id: n.id });
+}
+
+/** Locate node with id and its parent */
+function findNode(nodes, id, parent = null) {
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (node.id === id) return { node, parent, index: i };
+        if (node.children) {
+            const res = findNode(node.children, id, node);
+            if (res) return res;
+        }
+    }
+    return null;
+}
+
+/** Return an array of nodes from root to the node with the given id */
+function pathTo(nodes, id, stack = []) {
+    for (const node of nodes) {
+        stack.push(node);
+        if (node.id === id) return [...stack];
+        if (node.children) {
+            const res = pathTo(node.children, id, stack);
+            if (res) return res;
+        }
+        stack.pop();
+    }
+    return null;
+}
+
+/** Collect all layer ids within a node (recursively) */
+function collectLayerIds(node, result = []) {
+    if (!node) return result;
+    if (node.children) {
+        for (const child of node.children) collectLayerIds(child, result);
+    } else {
+        // Support both array and Set results
+        if (Array.isArray(result)) result.push(node.id);
+        else result.add(node.id);
+    }
+    return result;
+}
+
+/**
+ * Flatten selection that may contain groups into a list of layer ids
+ */
+function flattenSelection(tree, selection) {
+    const result = new Set();
+    for (const id of selection) {
+        const info = findNode(tree, id);
+        if (info) collectLayerIds(info.node, result);
+    }
+    return [...result];
+}
+
 export const useLayerStore = defineStore('layers', {
     state: () => ({
-        _order: [],
+        _tree: reactive([]),
         _name: {},
         _color: {},
         _visibility: {},
         _locked: {},
         _pixels: {},
         _attributes: {},
-        _selection: new Set()
+        _selection: new Set(),
+        _isGroup: {}
     }),
     getters: {
-        exists: (state) => state._order.length > 0,
-        order: (state) => readonly(state._order),
+        exists: (state) => flatten(state._tree).length > 0,
+        order: (state) => readonly(flatten(state._tree)),
+        tree: (state) => readonly(state._tree),
         has: (state) => (id) => state._name[id] != null,
-        count: (state) => state._order.length,
-        idsBottomToTop: (state) => readonly(state._order),
-        idsTopToBottom: (state) => readonly([...state._order].reverse()),
-        indexOfLayer: (state) => (id) => state._order.indexOf(id),
+        count: (state) => flatten(state._tree).length,
+        idsBottomToTop: (state) => readonly(flatten(state._tree)),
+        idsTopToBottom: (state) => readonly([...flatten(state._tree)].reverse()),
+        indexOfLayer: (state) => (id) => flatten(state._tree).indexOf(id),
         pathOf: (state) => (id) => pixelsToUnionPath([...state._pixels[id]].map(keyToCoord)),
         disconnectedCountOf: (state) => (id) => groupConnectedPixels([...state._pixels[id]].map(keyToCoord)).length,
         getProperty: (state) => (id, prop) => {
@@ -56,14 +135,36 @@ export const useLayerStore = defineStore('layers', {
                 return propsOf(ids);
             };
         },
-        selectedIds: (state) => [...state._selection],
-        selectionCount: (state) => state._selection.size,
-        selectionExists: (state) => state._selection.size > 0,
-        isSelected: (state) => (id) => state._selection.has(id),
+        selectedIds: (state) => flattenSelection(state._tree, state._selection),
+        selectedNodeIds: (state) => {
+            const set = state._selection;
+            const result = [];
+            const walk = (nodes) => {
+                for (const n of nodes) {
+                    if (set.has(n.id)) result.push(n.id);
+                    if (n.children) walk(n.children);
+                }
+            };
+            walk(state._tree);
+            return result;
+        },
+        selectionCount: (state) => flattenSelection(state._tree, state._selection).length,
+        selectionExists: (state) => flattenSelection(state._tree, state._selection).length > 0,
+        isSelected: (state) => (id) => {
+            if (state._selection.has(id)) return true;
+            const info = findNode(state._tree, id);
+            let parent = info?.parent;
+            while (parent) {
+                if (state._selection.has(parent.id)) return true;
+                parent = findNode(state._tree, parent.id)?.parent;
+            }
+            return false;
+        },
         compositeColorAt: (state) => (coord) => {
             const key = coordToKey(coord);
-            for (let i = state._order.length - 1; i >= 0; i--) {
-                const id = state._order[i];
+            const order = flatten(state._tree);
+            for (let i = order.length - 1; i >= 0; i--) {
+                const id = order[i];
                 if (!state._visibility[id]) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return (state._color[id] >>> 0);
@@ -72,8 +173,9 @@ export const useLayerStore = defineStore('layers', {
         },
         topVisibleIdAt: (state) => (coord) => {
             const key = coordToKey(coord);
-            for (let i = state._order.length - 1; i >= 0; i--) {
-                const id = state._order[i];
+            const order = flatten(state._tree);
+            for (let i = order.length - 1; i >= 0; i--) {
+                const id = order[i];
                 if (!state._visibility[id]) continue;
                 const set = state._pixels[id];
                 if (set.has(key)) return id;
@@ -82,12 +184,21 @@ export const useLayerStore = defineStore('layers', {
         },
     },
     actions: {
+        _findNode(id) {
+            return findNode(this._tree, id);
+        },
+        _removeFromTree(id) {
+            const info = findNode(this._tree, id);
+            if (!info) return null;
+            const parentArr = info.parent ? info.parent.children : this._tree;
+            return parentArr.splice(info.index, 1)[0];
+        },
         _allocId() {
             let id = Date.now();
             while (this.has(id)) id++;
             return id;
         },
-        /** Create a layer and return its id. Use insertLayers to place it in order. */
+        /** Create a layer and return its id. Use insert to place it in order. */
         createLayer(layerProperties = {}) {
             const id = this._allocId();
             this._name[id] = layerProperties.name || 'Layer';
@@ -98,6 +209,19 @@ export const useLayerStore = defineStore('layers', {
             this._pixels[id] = reactive(new Set(keyedPixels));
             const attrs = layerProperties.attributes ? layerProperties.attributes.map(a => ({ ...a })) : [];
             this._attributes[id] = reactive(attrs);
+            this._isGroup[id] = false;
+            return id;
+        },
+        /** Create an empty group and return its id. Use insert/putIn to place it. */
+        createGroup(groupProperties = {}) {
+            const id = this._allocId();
+            this._name[id] = groupProperties.name || 'Group';
+            this._visibility[id] = groupProperties.visibility ?? true;
+            this._locked[id] = groupProperties.locked ?? false;
+            this._color[id] = (groupProperties.color ?? randColorU32()) >>> 0;
+            this._pixels[id] = reactive(new Set());
+            this._attributes[id] = reactive([]);
+            this._isGroup[id] = true;
             return id;
         },
         /** Update properties of a layer */
@@ -152,10 +276,14 @@ export const useLayerStore = defineStore('layers', {
             if (set.has(key)) set.delete(key);
             else set.add(key);
         },
-        /** Remove layers by ids */
+        /** Remove layers or groups by ids */
         deleteLayers(ids) {
-            const idSet = new Set(ids);
-            this._order = this._order.filter(id => !idSet.has(id));
+            const removed = [];
+            for (const id of ids) {
+                const node = this._removeFromTree(id);
+                if (node) collectLayerIds(node, removed);
+            }
+            const idSet = new Set(removed);
             for (const id of idSet) {
                 delete this._name[id];
                 delete this._color[id];
@@ -163,41 +291,101 @@ export const useLayerStore = defineStore('layers', {
                 delete this._locked[id];
                 delete this._pixels[id];
                 delete this._attributes[id];
+                delete this._isGroup[id];
             }
         },
-        /** Insert given ids relative to targetId. Works for existing or new layers. */
-        insertLayers(ids, targetId, placeBelow = true) {
-            const idSet = new Set(ids);
-            const keptIds = this._order.filter(id => !idSet.has(id));
-            let targetIndex = keptIds.indexOf(targetId);
-            if (targetIndex < 0) targetIndex = keptIds.length;
-            if (!placeBelow) targetIndex = targetIndex + 1;
-            const inStack = this._order.filter(id => idSet.has(id));
-            const notInStack = ids.filter(id => !inStack.includes(id));
-            keptIds.splice(targetIndex, 0, ...inStack, ...notInStack);
-            this._order = keptIds;
+        /**
+         * Insert given ids relative to targetId within the same group.
+         * ids can include layers or groups. Existing nodes are moved.
+         */
+        insert(ids, targetId, placeBelow = true) {
+            const nodes = ids.map(id => this._removeFromTree(id) || (this._isGroup[id] ? { id, children: reactive([]) } : { id }));
+            const targetInfo = targetId != null ? this._findNode(targetId) : null;
+            let parentArr = this._tree;
+            let index = parentArr.length;
+            if (targetInfo) {
+                parentArr = targetInfo.parent ? targetInfo.parent.children : this._tree;
+                index = targetInfo.index;
+                if (!placeBelow) index++;
+            }
+            parentArr.splice(index, 0, ...nodes);
+        },
+        /**
+         * Move ids into the specified group at top or bottom.
+         * groupId null refers to root.
+         */
+        putIn(ids, groupId, placeTop = true) {
+            const nodes = ids.map(id => this._removeFromTree(id) || (this._isGroup[id] ? { id, children: reactive([]) } : { id }));
+            let targetArr = this._tree;
+            if (groupId != null) {
+                const info = this._findNode(groupId);
+                if (info && info.node.children) targetArr = info.node.children;
+            }
+            const index = placeTop ? 0 : targetArr.length;
+            targetArr.splice(index, 0, ...nodes);
         },
         deleteEmptyLayers() {
-            const emptyIds = this._order.filter(id => {
+            const order = flatten(this._tree);
+            const emptyIds = order.filter(id => {
                 const set = this._pixels[id];
                 return set.size === 0;
             });
             if (emptyIds.length) this.deleteLayers(emptyIds);
             return emptyIds;
         },
+        _selectedAncestor(id) {
+            let info = this._findNode(id);
+            let parent = info?.parent;
+            while (parent) {
+                if (this._selection.has(parent.id)) return parent;
+                parent = this._findNode(parent.id)?.parent;
+            }
+            return null;
+        },
+        _collapseSelection() {
+            const traverse = (nodes, ancestorSelected) => {
+                for (const node of nodes) {
+                    const selected = this._selection.has(node.id);
+                    if (ancestorSelected && selected) this._selection.delete(node.id);
+                    if (node.children) traverse(node.children, ancestorSelected || selected);
+                }
+            };
+            traverse(this._tree, false);
+        },
+        _deselect(id) {
+            if (this._selection.delete(id)) return;
+            const ancestor = this._selectedAncestor(id);
+            if (!ancestor) return;
+            const path = pathTo(this._tree, id);
+            if (!path) return;
+            const start = path.findIndex(n => n.id === ancestor.id);
+            if (start === -1) return;
+            for (const node of path.slice(start, -1)) {
+                if (node.children) {
+                    for (const child of node.children) this._selection.add(child.id);
+                }
+            }
+            this._selection.delete(ancestor.id);
+            this._selection.delete(id);
+        },
         replaceSelection(ids = []) {
             this._selection = new Set(ids);
+            this._collapseSelection();
         },
         addToSelection(ids = []) {
-            for (const id of ids) this._selection.add(id);
+            for (const id of ids) {
+                if (!this._selectedAncestor(id)) this._selection.add(id);
+            }
+            this._collapseSelection();
         },
         removeFromSelection(ids = []) {
-            for (const id of ids) this._selection.delete(id);
+            for (const id of ids) this._deselect(id);
+            this._collapseSelection();
         },
         toggleSelection(id) {
             if (id == null) return;
-            if (this._selection.has(id)) this._selection.delete(id);
-            else this._selection.add(id);
+            if (this.isSelected(id)) this.removeFromSelection([id]);
+            else this.addToSelection([id]);
         },
         clearSelection() {
             this._selection.clear();
@@ -205,7 +393,8 @@ export const useLayerStore = defineStore('layers', {
         translateAll(dx = 0, dy = 0) {
             dx |= 0; dy |= 0;
             if (dx === 0 && dy === 0) return;
-            for (const id of this._order) {
+            const order = flatten(this._tree);
+            for (const id of order) {
                 const set = this._pixels[id];
                 const moved = new Set();
                 for (const key of set) {
@@ -217,9 +406,10 @@ export const useLayerStore = defineStore('layers', {
         },
         /** Serialization */
         serialize() {
+            const order = flatten(this._tree);
             return {
-                order: this._order.slice(),
-                byId: Object.fromEntries(this._order.map(id => [id, {
+                tree: cloneTree(this._tree),
+                byId: Object.fromEntries(order.map(id => [id, {
                     name: this._name[id],
                     visibility: !!this._visibility[id],
                     locked: !!this._locked[id],
@@ -231,20 +421,25 @@ export const useLayerStore = defineStore('layers', {
             };
         },
         applySerialized(payload) {
-            const order = payload?.order || [];
+            const treePayload = payload?.tree;
+            const orderPayload = payload?.order;
             const byId = payload?.byId || {};
             // reset
-            this._order = [];
+            this._tree = reactive([]);
             this._name = {};
             this._color = {};
             this._visibility = {};
             this._locked = {};
             this._pixels = {};
             this._attributes = {};
-            // rebuild
-            for (const idStr of order) {
-                const id = +idStr;
-                const info = byId[idStr] || byId[id];
+            this._isGroup = {};
+            // rebuild tree
+            if (Array.isArray(treePayload)) this._tree = reactive(buildTree(treePayload));
+            else if (Array.isArray(orderPayload)) this._tree = reactive(orderPayload.map(id => ({ id })));
+            // rebuild layer info
+            const order = flatten(this._tree);
+            for (const id of order) {
+                const info = byId[id] || byId[id.toString()];
                 if (!info) continue;
                 this._name[id] = info.name || 'Layer';
                 this._visibility[id] = !!info.visibility;
@@ -254,8 +449,17 @@ export const useLayerStore = defineStore('layers', {
                 this._pixels[id] = reactive(new Set(keyedPixels));
                 const attrs = info.attributes ? info.attributes.map(a => ({ ...a })) : [];
                 this._attributes[id] = reactive(attrs);
-                this._order.push(id);
+                this._isGroup[id] = false;
             }
+            const markGroups = (nodes) => {
+                for (const n of nodes) {
+                    if (n.children) {
+                        this._isGroup[n.id] = true;
+                        markGroups(n.children);
+                    }
+                }
+            };
+            markGroups(this._tree);
             this._selection = new Set(payload?.selection || []);
         }
     }


### PR DESCRIPTION
## Summary
- Manage folded layer groups in the layer panel service and persist fold state
- Allow DFS traversal to skip folded children and use it for arrow navigation
- Layers panel component delegates folding to the service
- Expose selection including groups and add a factory for empty groups
- Enable drag-and-drop into groups and add a toolbar button to create new groups
- Render layers in top-to-bottom order and ensure the Add Group button creates real groups
- Refresh layers panel when groups are folded or unfolded
- Refine selection rules so selecting a group drops descendant selections and removing a descendant expands the path's children

## Testing
- `node --check src/services/layerPanel.js`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b017f5d68c832ca84f48a033107946