### PR TITLE
feat: adjust layer panel thumbnails

### DIFF
--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -110,7 +110,11 @@ export const useNodeTreeStore = defineStore('nodeTree', {
         selectedLayerCount(state) { return this._selectedLayerIds.length },
         layerSelectionExists(state) { return this._selectedLayerIds.length > 0 },
         isSelected(state) { return (id) => this._selectedNodeIdSet.has(id) },
-        allNodeIds(state) { return this._nodeIds }
+        allNodeIds(state) { return this._nodeIds },
+        descendantLayerIds(state) { return (id) => {
+            const info = findNode(state._tree, id);
+            return info ? collectLayerIds(info.node, []) : [];
+        } }
     },
     actions: {
         _findNode(id) {


### PR DESCRIPTION
## Summary
- double indentation of nested layers
- show group thumbnails composed of descendant paths
- hide thumbnails for nested layers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b072553ed0832c84367fa99be2053d