### PR TITLE
Rename query service to layer query service

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,7 @@ import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
 const { input, viewport: viewportStore, nodeTree, nodes, output } = useStore();
-const { layerPanel, query } = useService();
+const { layerPanel, layerQuery } = useService();
 const viewportToolbar = ref(null);
 
 // Width control between display and layers
@@ -101,11 +101,11 @@ function onKeydown(event) {
       event.preventDefault();
       if (!nodeTree.layerSelectionExists) return;
       output.setRollbackPoint();
-      const belowId = query.below(query.lowermost(nodeTree.selectedLayerIds));
+      const belowId = layerQuery.below(layerQuery.lowermost(nodeTree.selectedLayerIds));
       const ids = nodeTree.selectedLayerIds;
       nodes.remove(ids);
       nodeTree.removeFromSelection(ids);
-      const newSelect = nodeTree.has(belowId) ? belowId : query.lowermost();
+      const newSelect = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
       layerPanel.setRange(newSelect, newSelect);
       layerPanel.setScrollRule({ type: "follow", target: newSelect });
       output.commit();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -79,7 +79,7 @@ import blockIcons from '../image/layer_block';
 import { useService } from '../services';
 
 const { viewport: viewportStore, nodeTree, nodes, output } = useStore();
-const { layerPanel, query, viewport, stageResize: stageResizeService } = useService();
+const { layerPanel, layerQuery, viewport, stageResize: stageResizeService } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);
@@ -119,7 +119,7 @@ function descendantProps(id) {
 
   function onThumbnailClick(id) {
       const color = nodes.getProperty(id, 'color');
-      const ids = query.byColor(color);
+      const ids = layerQuery.byColor(color);
       if (ids.length) {
           nodeTree.replaceSelection(ids);
           layerPanel.clearRange();
@@ -132,7 +132,7 @@ function descendantProps(id) {
 
   function onPixelCountClick(id) {
       const count = (nodes.getProperty(id, 'pixels') || []).length;
-      const ids = count === 0 ? [id] : query.byPixelCount(count);
+      const ids = count === 0 ? [id] : layerQuery.byPixelCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
       } else {
@@ -146,7 +146,7 @@ function descendantProps(id) {
   }
 
   function onDisconnectedClick(id) {
-      const ids = query.disconnected();
+      const ids = layerQuery.disconnected();
       if (ids.length) {
           nodeTree.replaceSelection(ids);
           layerPanel.clearRange();
@@ -159,7 +159,7 @@ function descendantProps(id) {
 
   function onDisconnectedCountClick(id) {
       const count = nodes.disconnectedCountOfLayer(id);
-      const ids = count <= 1 ? [id] : query.byDisconnectedCount(count);
+      const ids = count <= 1 ? [id] : layerQuery.byDisconnectedCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
       } else {
@@ -269,9 +269,9 @@ function toggleLock(id) {
 function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = nodeTree.selectedNodeIds.includes(id) ? nodeTree.selectedNodeIds : [id];
-    const belowId = query.below(query.lowermost(targets));
+    const belowId = layerQuery.below(layerQuery.lowermost(targets));
     nodes.remove(targets);
-    const newSelectId = nodeTree.has(belowId) ? belowId : query.lowermost();
+    const newSelectId = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
         layerPanel.setScrollRule({

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -28,14 +28,14 @@ import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
 const { nodeTree, nodes, output } = useStore();
-const { layerTool: layerSvc, layerPanel, query } = useService();
+const { layerTool: layerSvc, layerPanel, layerQuery } = useService();
 
 const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => (nodes.getProperty(id, 'pixels') || []).length === 0));
 const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => nodes.disconnectedCountOfLayer(id) > 1));
 
 const onAdd = () => {
     output.setRollbackPoint();
-    const above = nodeTree.selectedLayerCount ? query.uppermost(nodeTree.selectedLayerIds) : null;
+    const above = nodeTree.selectedLayerCount ? layerQuery.uppermost(nodeTree.selectedLayerIds) : null;
     const id = nodes.createLayer({});
     nodeTree.insert([id], above, false);
     nodeTree.replaceSelection([id]);
@@ -73,7 +73,7 @@ const onCopy = () => {
     output.commit();
 };
 const onSelectEmpty = () => {
-    const ids = query.empty();
+    const ids = layerQuery.empty();
     nodeTree.replaceSelection(ids);
     layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
 };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,7 @@
 import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
-import { useQueryService } from './query';
+import { useLayerQueryService } from './layerQuery';
 import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
@@ -11,7 +11,7 @@ export {
     useLayerPanelService,
     useLayerToolService,
     useOverlayService,
-    useQueryService,
+    useLayerQueryService,
     useSelectService,
     useDrawToolService,
     useEraseToolService,
@@ -27,7 +27,7 @@ export const useService = () => ({
     layerPanel: useLayerPanelService(),
     layerTool: useLayerToolService(),
     overlay: useOverlayService(),
-    query: useQueryService(),
+    layerQuery: useLayerQueryService(),
     select: useSelectService(),
     tools: {
         draw: useDrawToolService(),

--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 
-export const useQueryService = defineStore('queryService', () => {
+export const useLayerQueryService = defineStore('layerQueryService', () => {
     const { nodeTree, nodes } = useStore();
 
     function uppermost(ids) {

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia';
 import { useStore } from '../stores';
-import { useQueryService } from './query';
+import { useLayerQueryService } from './layerQuery';
 import { findPixelComponents, getPixelUnion, averageColorU32 } from '../utils';
 
 export const useLayerToolService = defineStore('layerToolService', () => {
     const { nodeTree, nodes } = useStore();
-    const query = useQueryService();
+    const layerQuery = useLayerQueryService();
 
     function mergeSelected() {
         if (nodeTree.selectedLayerCount < 2) return;
@@ -33,7 +33,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         });
         const newPixels = pixelUnion;
         if (newPixels.length) nodes.addPixelsToLayer(newLayerId, newPixels);
-        nodeTree.insert([newLayerId], query.lowermost(nodeTree.selectedLayerIds), true);
+        nodeTree.insert([newLayerId], layerQuery.lowermost(nodeTree.selectedLayerIds), true);
         const ids = nodeTree.selectedLayerIds;
         nodes.remove(ids);
         return newLayerId;
@@ -58,7 +58,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             });
             newLayerIds.push(newLayerId);
         }
-        nodeTree.insert(newLayerIds, query.uppermost(sorted), false);
+        nodeTree.insert(newLayerIds, layerQuery.uppermost(sorted), false);
         return newLayerIds;
     }
 


### PR DESCRIPTION
## Summary
- rename query service to layer query service
- use `layerQuery` variable across codebase to prevent node errors

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b083d9ef0c832ca249cacf5e56816d