### PR TITLE
Extract global keyboard event store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
         :style="displayStyle"
       >
         <h2 class="m-0 px-3 py-2 text-xs uppercase tracking-wide text-slate-300/90 border-b border-white/10">Display</h2>
-        <viewport-toolbar ref="viewportToolbar" class="border-b border-white/10"></viewport-toolbar>
+      <viewport-toolbar class="border-b border-white/10"></viewport-toolbar>
         <Viewport class="flex-1 min-h-0"></Viewport>
         <viewport-info class="border-t border-white/10"></viewport-info>
       </section>
@@ -45,7 +45,6 @@ import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
 const { input, viewport: viewportStore, nodeTree, nodes, output } = useStore();
 const { layerPanel, layerQuery } = useService();
-const viewportToolbar = ref(null);
 
 // Width control between display and layers
 const container = ref(null);
@@ -70,88 +69,6 @@ function onDrag(event) {
 
 function stopDrag() {
   isDragging.value = false;
-}
-
-// General key handler
-function onKeydown(event) {
-  const target = event.target;
-  const typing = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
-  if (typing) return;
-
-  const key = event.key.toLowerCase();
-  const ctrl = event.ctrlKey || event.metaKey;
-  const shift = event.shiftKey;
-
-  switch (event.key) {
-    case 'Control':
-    case 'Meta':
-      return viewportToolbar.value?.ctrlKeyDown(event);
-    case 'Shift':
-      return viewportToolbar.value?.shiftKeyDown(event);
-    case 'ArrowUp':
-      event.preventDefault();
-      layerPanel.onArrowUp(shift, ctrl);
-      return;
-    case 'ArrowDown':
-      event.preventDefault();
-      layerPanel.onArrowDown(shift, ctrl);
-      return;
-    case 'Delete':
-    case 'Backspace':
-      event.preventDefault();
-      if (!nodeTree.layerSelectionExists) return;
-      output.setRollbackPoint();
-      const belowId = layerQuery.below(layerQuery.lowermost(nodeTree.selectedLayerIds));
-      const ids = nodeTree.selectedLayerIds;
-      nodes.remove(ids);
-      nodeTree.removeFromSelection(ids);
-      const newSelect = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
-      layerPanel.setRange(newSelect, newSelect);
-      layerPanel.setScrollRule({ type: "follow", target: newSelect });
-      output.commit();
-      return;
-    case 'Enter':
-         if (!ctrl && !shift && nodeTree.selectedLayerCount === 1) {
-            const selectedId = nodeTree.selectedLayerIds[0];
-            const row = document.querySelector(`.layer[data-id="${selectedId}"] .nameText`)
-            if (row) {
-                event.preventDefault();
-                row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-            }
-        }
-        return;
-    case 'Escape':
-      if (output.hasPendingRollback) {
-        event.preventDefault();
-        output.rollbackPending();
-        return;
-      }
-      nodeTree.clearSelection();
-      return;
-  }
-
-  if (ctrl) {
-    if (key === 'a') {
-      event.preventDefault();
-      layerPanel.selectAll();
-    } else if (key === 'z' && !shift) {
-      event.preventDefault();
-      output.undo();
-    } else if (key === 'y' || (key === 'z' && shift)) {
-      event.preventDefault();
-      output.redo();
-    }
-  }
-}
-
-function onKeyup(event) {
-  switch (event.key) {
-    case 'Control':
-    case 'Meta':
-      return viewportToolbar.value?.ctrlKeyUp(event);
-    case 'Shift':
-      return viewportToolbar.value?.shiftKeyUp(event);
-  }
 }
 
 onMounted(async () => {
@@ -186,8 +103,6 @@ onMounted(async () => {
 
       layerPanel.setScrollRule({ type: "follow", target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });
 
-  window.addEventListener('keydown', onKeydown);
-  window.addEventListener('keyup', onKeyup);
   window.addEventListener('mousemove', onDrag);
   window.addEventListener('mouseup', stopDrag);
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,11 @@
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import { useKeyboardEventStore } from './stores';
 
-const app = createApp(App)
-app.use(createPinia())
-app.mount('#app')
+const app = createApp(App);
+const pinia = createPinia();
+app.use(pinia);
+useKeyboardEventStore(pinia).listen();
+app.mount('#app');

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -208,7 +208,7 @@ export const useSelectService = defineStore('selectService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
     const layerPanel = useLayerPanelService();
-    const { nodeTree, nodes, viewportEvent: viewportEvents } = useStore();
+    const { nodeTree, nodes, viewportEvent: viewportEvents, keyboardEvent: keyboardEvents } = useStore();
     let mode = 'select';
     watch(() => tool.prepared === 'select', (isSelect) => {
         if (!isSelect) {
@@ -224,7 +224,7 @@ export const useSelectService = defineStore('selectService', () => {
             return;
         }
         const id = nodes.topVisibleIdAt(pixel);
-        if (!viewportEvents.isPressed('Shift')) {
+        if (!keyboardEvents.isPressed('Shift')) {
             mode = 'select';
             overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
             tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -4,6 +4,7 @@ import { useNodeStore } from './nodes';
 import { useOutputStore } from './output';
 import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
+import { useKeyboardEventStore } from './keyboardEvent';
 
 export {
     useInputStore,
@@ -11,7 +12,8 @@ export {
     useNodeStore,
     useOutputStore,
     useViewportStore,
-    useViewportEventStore
+    useViewportEventStore,
+    useKeyboardEventStore
 };
 
 export const useStore = () => ({
@@ -20,5 +22,6 @@ export const useStore = () => ({
     nodes: useNodeStore(),
     output: useOutputStore(),
     viewport: useViewportStore(),
-    viewportEvent: useViewportEventStore()
+    viewportEvent: useViewportEventStore(),
+    keyboardEvent: useKeyboardEventStore()
 });

--- a/src/stores/keyboardEvent.js
+++ b/src/stores/keyboardEvent.js
@@ -1,0 +1,76 @@
+import { defineStore } from 'pinia';
+import { readonly, nextTick } from 'vue';
+
+export const useKeyboardEventStore = defineStore('keyboardEvent', {
+    state: () => ({
+        _keyboard: {},
+        _recent: {
+            down: [],
+            up: [],
+        },
+        _recentTicks: {
+            down: 0,
+            up: 0,
+        },
+        _tick: 0,
+        _tickScheduled: false,
+    }),
+    getters: {
+        keyboard: (state) => readonly(state._keyboard),
+        recent: (state) => readonly(state._recent),
+        isPressed: (state) => (key) => {
+            const entry = state._keyboard[key];
+            return !!entry && !!entry.down && (!entry.up || entry.down.timeStamp > entry.up.timeStamp);
+        },
+        get: (state) => (type, key) => {
+            switch (type) {
+                case 'keydown':
+                    return state._keyboard[key]?.down;
+                case 'keyup':
+                    return state._keyboard[key]?.up;
+                default:
+                    return null;
+            }
+        },
+    },
+    actions: {
+        setKeyDown(event) {
+            const target = event.target;
+            const typing = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+            if (typing) return;
+            if (this._keyboard[event.key]) this._keyboard[event.key].down = event;
+            else this._keyboard[event.key] = { down: event, up: null };
+            this._pushRecent('down', event);
+        },
+        setKeyUp(event) {
+            const target = event.target;
+            const typing = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+            if (typing) return;
+            if (this._keyboard[event.key]) this._keyboard[event.key].up = event;
+            else this._keyboard[event.key] = { down: null, up: event };
+            this._pushRecent('up', event);
+        },
+        _pushRecent(type, event) {
+            if (this._recentTicks[type] !== this._tick) {
+                this._recent[type] = [];
+                this._recentTicks[type] = this._tick;
+            }
+            this._recent[type].push(event);
+            if (!this._tickScheduled) {
+                this._tickScheduled = true;
+                nextTick(() => {
+                    this._tick++;
+                    this._tickScheduled = false;
+                });
+            }
+        },
+        listen() {
+            window.addEventListener('keydown', this.setKeyDown);
+            window.addEventListener('keyup', this.setKeyUp);
+        },
+        unlisten() {
+            window.removeEventListener('keydown', this.setKeyDown);
+            window.removeEventListener('keyup', this.setKeyUp);
+        },
+    },
+});

--- a/src/stores/viewportEvent.js
+++ b/src/stores/viewportEvent.js
@@ -5,22 +5,18 @@ import { MAX_POINTER_WINDOW } from '@/constants';
 export const useViewportEventStore = defineStore('viewportEvent', {
     state: () => ({
         _pointer: {},
-        _keyboard: {},
         _wheel: null,
         _recent: {
             pointer: { down: [], move: [], up: [] },
-            keyboard: { down: [], up: [] },
         },
         _recentTicks: {
             pointer: { down: 0, move: 0, up: 0 },
-            keyboard: { down: 0, up: 0 },
         },
         _tick: 0,
         _tickScheduled: false,
     }),
     getters: {
         pointer: (state) => readonly(state._pointer),
-        keyboard: (state) => readonly(state._keyboard),
         wheel: (state) => readonly(state._wheel),
         recent: (state) => readonly(state._recent),
         pinchIds: (state) => {
@@ -35,10 +31,6 @@ export const useViewportEventStore = defineStore('viewportEvent', {
             }
             return active.length >= 2 ? active : null;
         },
-        isPressed: (state) => (key) => {
-            const entry = state._keyboard[key];
-            return !!entry && !!entry.down && (!entry.up || entry.down.timeStamp > entry.up.timeStamp);
-        },
         isDragging: (state) => (id) => {
             const entry = state._pointer[id];
             return !!entry && !!entry.down && (!entry.up || entry.down.timeStamp > entry.up.timeStamp);
@@ -51,10 +43,6 @@ export const useViewportEventStore = defineStore('viewportEvent', {
                     return state._pointer[idOrKey]?.move;
                 case 'pointerup':
                     return state._pointer[idOrKey]?.up;
-                case 'keydown':
-                    return state._keyboard[idOrKey]?.down;
-                case 'keyup':
-                    return state._keyboard[idOrKey]?.up;
                 case 'wheel':
                     return state._wheel;
                 default:
@@ -89,16 +77,6 @@ export const useViewportEventStore = defineStore('viewportEvent', {
                 this.pruneOldPointers();
             }
             this._pushRecent('pointer', 'up', event);
-        },
-        setKeyDown(event) {
-            if (this._keyboard[event.key]) this._keyboard[event.key].down = event;
-            else this._keyboard[event.key] = { down: event, up: null };
-            this._pushRecent('keyboard', 'down', event);
-        },
-        setKeyUp(event) {
-            if (this._keyboard[event.key]) this._keyboard[event.key].up = event;
-            else this._keyboard[event.key] = { down: null, up: event };
-            this._pushRecent('keyboard', 'up', event);
         },
         setWheel(event) {
             this._wheel = event;


### PR DESCRIPTION
## Summary
- Add `keyboardEvent` Pinia store to manage global key presses and expose helpers
- Remove keyboard logic from `viewportEvent` store and update components to consume the new store
- Replace direct key listeners with store-based watches for consistent keyboard handling
- Delegate keyboard shortcuts from `App.vue` to `LayersPanel` and `ViewportToolbar`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b129b9eb98832c96bd7c48823e141a