### PR TITLE
refactor: extract pixel store and sync selection removal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
-const { input, viewport: viewportStore, nodeTree, nodes, output } = useStore();
+const { input, viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const { layerPanel, layerQuery } = useService();
 
 // Width control between display and layers
@@ -85,14 +85,14 @@ onMounted(async () => {
   const autoSegments = input.isLoaded ? input.segment(40) : [];
   if (autoSegments.length) {
     const ids = [];
-    for (let i = 0; i < autoSegments.length; i++) {
+      for (let i = 0; i < autoSegments.length; i++) {
       const segment = autoSegments[i];
       const id = nodes.createLayer({
         name: `Auto ${i+1}`,
         color: segment.colorU32,
-        visibility: true,
-        pixels: segment.pixels
+        visibility: true
       });
+      if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
       ids.push(id);
     }
     nodeTree.insert(ids);

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="viewportStore.display!=='result'" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="nodes.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->
@@ -27,7 +27,7 @@ import { ref, computed, onMounted, nextTick } from 'vue';
 import { useStore } from '../stores';
 import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, output } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const text = ref('');
 const textareaElement = ref(null);
 

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -6,7 +6,7 @@
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="nodes.pathOfLayer(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOfLayer(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <div class="min-w-0 flex-1">
@@ -31,7 +31,7 @@
         <div v-if="item.depth===0" @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path :d="nodes.pathOfLayer(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path :d="pixelStore.pathOfLayer(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <!-- 색상 -->
@@ -44,9 +44,9 @@
             <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
           </div>
           <div class="text-xs text-slate-400">
-            <template v-if="nodes.disconnectedCountOfLayer(item.id) > 1">
+            <template v-if="pixelStore.disconnectedCountOfLayer(item.id) > 1">
               <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
-              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ nodes.disconnectedCountOfLayer(item.id) }} piece</span>
+              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ pixelStore.disconnectedCountOfLayer(item.id) }} piece</span>
               <span class="mx-1">|</span>
             </template>
             <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.props.pixels.length }} px</span>
@@ -78,7 +78,7 @@ import blockIcons from '../image/layer_block';
 
 import { useService } from '../services';
 
-const { viewport: viewportStore, nodeTree, nodes, output, keyboardEvent: keyboardEvents } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
 const { layerPanel, layerQuery, viewport, stageResize: stageResizeService } = useService();
 
 const dragging = ref(false);
@@ -102,7 +102,8 @@ const flatNodes = computed(() => {
   };
   walk(nodeTree.tree, 0);
   const propsList = nodes.getProperties(ids);
-  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].type === 'group', props: propsList[i] }));
+  const pixelList = pixelStore.getProperties(ids);
+  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].type === 'group', props: { ...propsList[i], pixels: pixelList[i].pixels } }));
 });
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
@@ -131,7 +132,7 @@ function descendantProps(id) {
   }
 
   function onPixelCountClick(id) {
-      const count = (nodes.getProperty(id, 'pixels') || []).length;
+      const count = pixelStore.get(id).length;
       const ids = count === 0 ? [id] : layerQuery.byPixelCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
@@ -158,7 +159,7 @@ function descendantProps(id) {
   }
 
   function onDisconnectedCountClick(id) {
-      const count = nodes.disconnectedCountOfLayer(id);
+      const count = pixelStore.disconnectedCountOfLayer(id);
       const ids = count <= 1 ? [id] : layerQuery.byDisconnectedCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
@@ -270,7 +271,9 @@ function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = nodeTree.selectedNodeIds.includes(id) ? nodeTree.selectedNodeIds : [id];
     const belowId = layerQuery.below(layerQuery.lowermost(targets));
-    nodes.remove(targets);
+    const removed = nodeTree.remove(targets);
+    nodes.remove(removed);
+    pixelStore.remove(removed);
     const newSelectId = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
@@ -287,8 +290,9 @@ function deleteSelection() {
     output.setRollbackPoint();
     const belowId = layerQuery.below(layerQuery.lowermost(nodeTree.selectedLayerIds));
     const ids = nodeTree.selectedLayerIds;
-    nodes.remove(ids);
-    nodeTree.removeFromSelection(ids);
+    const removed = nodeTree.remove(ids);
+    nodes.remove(removed);
+    pixelStore.remove(removed);
     const newSelect = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
     layerPanel.setRange(newSelect, newSelect);
     layerPanel.setScrollRule({ type: 'follow', target: newSelect });

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -27,11 +27,11 @@ import { useService } from '../services';
 import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
-const { nodeTree, nodes, output } = useStore();
+const { nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const { layerTool: layerSvc, layerPanel, layerQuery } = useService();
 
-const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => (nodes.getProperty(id, 'pixels') || []).length === 0));
-const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => nodes.disconnectedCountOfLayer(id) > 1));
+const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => pixelStore.get(id).length === 0));
+const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => pixelStore.disconnectedCountOfLayer(id) > 1));
 
 const onAdd = () => {
     output.setRollbackPoint();

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -28,7 +28,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="nodes.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->
@@ -75,7 +75,7 @@ import { useService } from '../services';
 import { OVERLAY_STYLES, GRID_STROKE_COLOR } from '@/constants';
 import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, viewportEvent: viewportEvents } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, viewportEvent: viewportEvents } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = useTemplateRef('viewportEl');
 const stage = viewportStore.stage;

--- a/src/components/ViewportInfo.vue
+++ b/src/components/ViewportInfo.vue
@@ -14,11 +14,11 @@ import { useStore } from '../stores';
 import { useService } from '../services';
 import { getPixelUnion, rgbaCssU32, rgbaCssObj } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, input } = useStore();
-const { toolSelection: toolSelectionService } = useService();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, input } = useStore();
+const { toolSelection: toolSelectionService, layerQuery } = useService();
 
 const selectedAreaPixelCount = computed(() => {
-    const pixels = getPixelUnion(nodes.getProperties(nodeTree.selectedLayerIds));
+    const pixels = getPixelUnion(pixelStore.getProperties(nodeTree.selectedLayerIds));
     return pixels.length;
   });
 
@@ -30,7 +30,8 @@ const pixelInfo = computed(() => {
       const colorObject = input.readPixel(coord);
       return `[${px},${py}] ${rgbaCssObj(colorObject)}`;
     } else {
-      const colorU32 = nodes.compositeColorAt(coord);
+      const id = layerQuery.topVisibleAt(coord);
+      const colorU32 = id ? nodes.getProperty(id, 'color') : 0;
       return `[${px},${py}] ${rgbaCssU32(colorU32)}`;
     }
   });

--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -9,6 +9,7 @@ export const SINGLE_SELECTION_TOOLS = [
 
 export const MULTI_SELECTION_TOOLS = [
   { type: 'select', name: 'Select', icon: stageIcons.select },
+  { type: 'path', name: 'Path', icon: stageIcons.path },
   { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
 ];
 

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -9,6 +9,7 @@ import top from './top.svg';
 import resize from './resize.svg';
 import undo from './undo.svg';
 import redo from './redo.svg';
+import path from './path.svg';
 
 export default {
   stroke,
@@ -19,6 +20,7 @@ export default {
   select,
   globalErase,
   top,
+  path,
   resize,
   undo,
   redo,

--- a/src/image/stage_toolbar/path.svg
+++ b/src/image/stage_toolbar/path.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1" y="1" width="4" height="4" fill="#00ff00"/>
+  <rect x="11" y="11" width="4" height="4" fill="#ff0000"/>
+  <path d="M4 8H12L9 5M12 8L9 11" fill="none" stroke="#000" stroke-width="1"/>
+</svg>

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,7 +2,7 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
-import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService } from './tools';
+import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, usePathToolService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
@@ -16,6 +16,7 @@ export {
     useDrawToolService,
     useEraseToolService,
     useTopToolService,
+    usePathToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -33,6 +34,7 @@ export const useService = () => ({
         draw: useDrawToolService(),
         erase: useEraseToolService(),
         globalErase: useGlobalEraseToolService(),
+        path: usePathToolService(),
         cut: useCutToolService(),
         top: useTopToolService(),
     },

--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 
 export const useLayerQueryService = defineStore('layerQueryService', () => {
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, nodes, pixels } = useStore();
 
     function uppermost(ids) {
         const order = nodeTree.layerIdsBottomToTop;
@@ -44,12 +44,22 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         return order[idx - 1] ?? null;
     }
 
+    function topVisibleAt(coord) {
+        const order = nodeTree.layerIdsBottomToTop;
+        for (let i = order.length - 1; i >= 0; i--) {
+            const id = order[i];
+            if (!nodes._visibility[id]) continue;
+            if (pixels.has(id, coord)) return id;
+        }
+        return null;
+    }
+
     function empty() {
-        return nodeTree.layerOrder.filter(id => (nodes.getProperty(id, 'pixels') || []).length === 0);
+        return nodeTree.layerOrder.filter(id => pixels.get(id).length === 0);
     }
 
     function disconnected() {
-        return nodeTree.layerOrder.filter(layerId => nodes.disconnectedCountOfLayer(layerId) > 1);
+        return nodeTree.layerOrder.filter(layerId => pixels.disconnectedCountOfLayer(layerId) > 1);
     }
 
     function byColor(color) {
@@ -60,13 +70,13 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
 
     function byPixelCount(pixelCount) {
         return nodeTree.layerOrder.filter(
-            layerId => (nodes.getProperty(layerId, 'pixels') || []).length === pixelCount
+            layerId => pixels.get(layerId).length === pixelCount
         );
     }
 
     function byDisconnectedCount(disconnectedCount) {
         return nodeTree.layerOrder.filter(
-            layerId => nodes.disconnectedCountOfLayer(layerId) === disconnectedCount
+            layerId => pixels.disconnectedCountOfLayer(layerId) === disconnectedCount
         );
     }
 
@@ -75,6 +85,7 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         lowermost,
         above,
         below,
+        topVisibleAt,
         empty,
         disconnected,
         byColor,

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -5,7 +5,7 @@ import { coordToKey, keyToCoord, pixelsToUnionPath } from '../utils';
 import { OVERLAY_STYLES } from '@/constants';
 
 export const useOverlayService = defineStore('overlayService', () => {
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, pixels: pixelStore } = useStore();
 
     const pixelKeys = reactive({});
     const styles = reactive({});
@@ -45,7 +45,7 @@ export const useOverlayService = defineStore('overlayService', () => {
         if (!Array.isArray(ids)) ids = [ids];
         for (const layerId of ids) {
             if (layerId == null) continue;
-            const layerPixels = nodes.getProperty(layerId, 'pixels') || [];
+            const layerPixels = pixelStore.get(layerId);
             addPixels(id, layerPixels);
         }
     }

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -3,16 +3,18 @@ import { watch } from 'vue';
 import { useToolSelectionService } from './toolSelection';
 import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
+import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
-import { coordToKey } from '../utils';
+import { coordToKey, keyToCoord, ensurePathPattern } from '../utils';
+import { PIXEL_KINDS } from '../stores/pixels';
 
 export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     watch(() => tool.prepared === 'draw', (isDraw) => {
         if (!isDraw) {
             overlayService.clear(overlayId);
@@ -43,7 +45,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         if (tool.prepared !== 'draw' || nodeTree.selectedLayerCount !== 1) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
-        nodes.addPixelsToLayer(id, pixels);
+        pixelStore.addPixels(id, pixels);
     });
     return {};
 });
@@ -53,7 +55,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     watch(() => tool.prepared === 'erase', (isErase) => {
         if (!isErase) {
             overlayService.clear(overlayId);
@@ -69,7 +71,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         if (tool.prepared !== 'erase' || nodeTree.selectedLayerCount !== 1) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
-            const sourceKeys = new Set((nodes.getProperty(sourceId, 'pixels') || []).map(coordToKey));
+            const sourceKeys = new Set(pixelStore.get(sourceId).map(coordToKey));
             if (pixel && sourceKeys.has(coordToKey(pixel)))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
@@ -84,7 +86,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         if (tool.prepared !== 'erase' || nodeTree.selectedLayerCount !== 1) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
-        nodes.removePixelsFromLayer(id, pixels);
+        pixelStore.removePixels(id, pixels);
     });
     return {};
 });
@@ -95,7 +97,8 @@ export const useCutToolService = defineStore('cutToolService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const layerPanel = useLayerPanelService();
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const layerQuery = useLayerQueryService();
     watch(() => tool.prepared === 'cut', (isCut) => {
         if (!isCut) {
             overlayService.clear(overlayId);
@@ -111,7 +114,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.prepared !== 'cut' || nodeTree.selectedLayerCount !== 1) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
-            const sourceKeys = new Set((nodes.getProperty(sourceId, 'pixels') || []).map(coordToKey));
+            const sourceKeys = new Set(pixelStore.get(sourceId).map(coordToKey));
             if (pixel && sourceKeys.has(coordToKey(pixel)))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
@@ -126,7 +129,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.prepared !== 'cut' || nodeTree.selectedLayerCount !== 1) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) return;
-        const sourceKeys = new Set((nodes.getProperty(sourceId, 'pixels') || []).map(coordToKey));
+        const sourceKeys = new Set(pixelStore.get(sourceId).map(coordToKey));
 
         const cutCoords = [];
         const cutKeys = new Set();
@@ -140,14 +143,14 @@ export const useCutToolService = defineStore('cutToolService', () => {
 
         if (!cutCoords.length || cutKeys.size === sourceKeys.size) return;
 
-        nodes.removePixelsFromLayer(sourceId, cutCoords);
+        pixelStore.removePixels(sourceId, cutCoords);
         const id = nodes.createLayer({
             name: `Cut of ${nodes.getProperty(sourceId, 'name')}`,
             color: nodes.getProperty(sourceId, 'color'),
             visibility: nodes.getProperty(sourceId, 'visibility'),
-            pixels: cutCoords,
             attributes: nodes.getProperty(sourceId, 'attributes'),
         });
+        if (cutCoords.length) pixelStore.set(id, cutCoords);
         nodeTree.insert([id], sourceId, false);
 
         nodeTree.replaceSelection([sourceId]);
@@ -162,7 +165,7 @@ export const useTopToolService = defineStore('topToolService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
     const layerPanel = useLayerPanelService();
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     watch(() => tool.prepared === 'top', (isTop) => {
         if (!isTop) {
             overlayService.clear(overlayId);
@@ -176,7 +179,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        const id = nodes.topVisibleIdAt(pixel);
+        const id = layerQuery.topVisibleAt(pixel);
         if (id && nodes.getProperty(id, 'locked')) {
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
         }
@@ -187,7 +190,7 @@ export const useTopToolService = defineStore('topToolService', () => {
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'top' || nodeTree.selectedIds.length !== 1 || !pixel) return;
-        const id = nodes.topVisibleIdAt(pixel);
+        const id = layerQuery.topVisibleAt(pixel);
         if (!id) return;
         if (nodes.getProperty(id, 'locked')) {
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
@@ -209,6 +212,7 @@ export const useSelectService = defineStore('selectService', () => {
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
     const layerPanel = useLayerPanelService();
     const { nodeTree, nodes, viewportEvent: viewportEvents, keyboardEvent: keyboardEvents } = useStore();
+    const layerQuery = useLayerQueryService();
     let mode = 'select';
     watch(() => tool.prepared === 'select', (isSelect) => {
         if (!isSelect) {
@@ -223,7 +227,7 @@ export const useSelectService = defineStore('selectService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        const id = nodes.topVisibleIdAt(pixel);
+        const id = layerQuery.topVisibleAt(pixel);
         if (!keyboardEvents.isPressed('Shift')) {
             mode = 'select';
             overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
@@ -246,7 +250,7 @@ export const useSelectService = defineStore('selectService', () => {
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'select') return;
         if (pixel) {
-            const id = nodes.topVisibleIdAt(pixel);
+            const id = layerQuery.topVisibleAt(pixel);
             if (id && nodes.getProperty(id, 'locked')) {
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                 return;
@@ -258,7 +262,7 @@ export const useSelectService = defineStore('selectService', () => {
         if (tool.prepared !== 'select') return;
         const intersectedIds = [];
         for (const coord of pixels) {
-            const id = nodes.topVisibleIdAt(coord);
+            const id = layerQuery.topVisibleAt(coord);
             if (id === null) continue;
             if (!nodes.getProperty(id, 'locked')) intersectedIds.push(id);
         }
@@ -275,7 +279,7 @@ export const useSelectService = defineStore('selectService', () => {
         if (pixels.length > 0) {
             const intersectedIds = new Set();
             for (const coord of pixels) {
-            const id = nodes.topVisibleIdAt(coord);
+            const id = layerQuery.topVisibleAt(coord);
             if (id !== null && !nodes.getProperty(id, 'locked')) intersectedIds.add(id);
             }
             const currentSelection = new Set(mode === 'select' ? [] : nodeTree.selectedLayerIds);
@@ -291,6 +295,56 @@ export const useSelectService = defineStore('selectService', () => {
         } else if (mode === 'select') {
             nodeTree.clearSelection();
         }
+    });
+    return {};
+});
+
+export const usePathToolService = defineStore('pathToolService', () => {
+    const tool = useToolSelectionService();
+    const overlayService = useOverlayService();
+    const overlays = PIXEL_KINDS.map(kind => {
+        const id = overlayService.createOverlay();
+        overlayService.setStyles(id, {
+            FILL_COLOR: `url(#${ensurePathPattern(kind)})`,
+            STROKE_COLOR: 'none',
+            STROKE_WIDTH_SCALE: 0,
+            FILL_RULE: 'nonzero'
+        });
+        return id;
+    });
+    const { nodeTree, pixels: pixelStore } = useStore();
+
+    function rebuild() {
+        if (tool.prepared !== 'path') return;
+        const layerIds = nodeTree.selectedLayerIds;
+        PIXEL_KINDS.forEach((kind, idx) => {
+            const overlayId = overlays[idx];
+            overlayService.clear(overlayId);
+            for (const id of layerIds) {
+                const set = pixelStore[kind][id];
+                if (!set) continue;
+                overlayService.addPixels(overlayId, [...set].map(keyToCoord));
+            }
+        });
+    }
+
+    watch(() => tool.prepared === 'path', (isPath) => {
+        if (!isPath) {
+            overlays.forEach(id => overlayService.clear(id));
+            return;
+        }
+        tool.setCursor({ stroke: 'crosshair', rect: 'crosshair' });
+        rebuild();
+    });
+    watch(() => nodeTree.selectedLayerIds.slice(), rebuild);
+    watch(() => pixelStore.$state, rebuild, { deep: true });
+    watch(() => tool.affectedPixels, (pixels) => {
+        if (tool.prepared !== 'path' || !pixels.length) return;
+        const ids = nodeTree.selectedLayerIds;
+        for (const coord of pixels) {
+            for (const id of ids) pixelStore.cycleKind(id, coord);
+        }
+        rebuild();
     });
     return {};
 });
@@ -317,7 +371,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         if (pixel){
             const lockedIds = nodeTree.layerOrder.filter(id => nodes.getProperty(id, 'locked'));
             for (const id of lockedIds) {
-                const lockedPixels = new Set((nodes.getProperty(id, 'pixels') || []).map(coordToKey));
+                const lockedPixels = new Set(pixelStore.get(id).map(coordToKey));
                 if (lockedPixels.has(coordToKey(pixel))) {
                     tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                     return;
@@ -333,7 +387,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.getProperty(id, 'locked'));
             const unlockedPixels = new Set();
             for (const id of unlockedIds) {
-                (nodes.getProperty(id, 'pixels') || []).forEach(coord => unlockedPixels.add(coordToKey(coord)));
+                pixelStore.get(id).forEach(coord => unlockedPixels.add(coordToKey(coord)));
             }
             for (const coord of pixels) {
                 if (unlockedPixels.has(coordToKey(coord))) erasablePixels.push(coord);
@@ -346,12 +400,12 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
             .filter(id => !nodes.getProperty(id, 'locked'));
         for (const id of targetIds) {
-            const targetKeys = new Set((nodes.getProperty(id, "pixels") || []).map(coordToKey));
+            const targetKeys = new Set(pixelStore.get(id).map(coordToKey));
             const pixelsToRemove = [];
             for (const coord of pixels) {
                 if (targetKeys.has(coordToKey(coord))) pixelsToRemove.push(coord);
             }
-            if (pixelsToRemove.length) nodes.removePixelsFromLayer(id, pixelsToRemove);
+            if (pixelsToRemove.length) pixelStore.removePixels(id, pixelsToRemove);
         }
     });
     return {};

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,6 +1,7 @@
 import { useInputStore } from './input';
 import { useNodeTreeStore } from './nodeTree';
 import { useNodeStore } from './nodes';
+import { usePixelStore } from './pixels';
 import { useOutputStore } from './output';
 import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
@@ -10,6 +11,7 @@ export {
     useInputStore,
     useNodeTreeStore,
     useNodeStore,
+    usePixelStore,
     useOutputStore,
     useViewportStore,
     useViewportEventStore,
@@ -20,6 +22,7 @@ export const useStore = () => ({
     input: useInputStore(),
     nodeTree: useNodeTreeStore(),
     nodes: useNodeStore(),
+    pixels: usePixelStore(),
     output: useOutputStore(),
     viewport: useViewportStore(),
     viewportEvent: useViewportEventStore(),

--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -242,6 +242,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
                 const node = this._removeFromTree(id);
                 if (node) collectIds(node);
             }
+            for (const id of removed) this._selection.delete(id);
             return removed;
         },
         serialize() {

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -16,11 +16,12 @@ export const useOutputStore = defineStore('output', {
     },
     actions: {
         _apply(snapshot) {
-            const { nodeTree, nodes, viewport } = useStore();
+            const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
             nodeTree.applySerialized(parsed.nodeTreeState);
             nodes.applySerialized(parsed.nodeState);
+            pixels.applySerialized(parsed.pixelState);
             layerPanel.applySerialized(parsed.layerPanelState);
             viewport.applySerialized(parsed.viewportState);
             this._commitVersion++; // ← Undo/Redo/롤백 시에도 썸네일 갱신
@@ -48,11 +49,12 @@ export const useOutputStore = defineStore('output', {
             })
         },
         currentSnap() {
-            const { nodeTree, nodes, viewport } = useStore();
+            const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             return JSON.stringify({
                 nodeTreeState: nodeTree.serialize(),
                 nodeState: nodes.serialize(),
+                pixelState: pixels.serialize(),
                 layerPanelState: layerPanel.serialize(),
                 viewportState: viewport.serialize()
             });

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -1,0 +1,146 @@
+import { defineStore } from 'pinia';
+import { reactive } from 'vue';
+import { coordToKey, keyToCoord, pixelsToUnionPath, groupConnectedPixels } from '../utils';
+
+export const PIXEL_KINDS = [
+    'tltr', 'tlbl', 'trtl', 'trbr',
+    'bltl', 'blbr', 'brtr', 'brbl'
+];
+const DEFAULT_KIND = PIXEL_KINDS[0];
+
+function unionSet(state, id) {
+    const merged = new Set();
+    for (const kind of PIXEL_KINDS) {
+        const set = state[kind][id];
+        if (!set) continue;
+        for (const key of set) merged.add(key);
+    }
+    return merged;
+}
+
+export const usePixelStore = defineStore('pixels', {
+    state: () => (
+        PIXEL_KINDS.reduce((acc, k) => {
+            acc[k] = {};
+            return acc;
+        }, {})
+    ),
+    getters: {
+        get: (state) => (id) => {
+            return [...unionSet(state, id)].map(keyToCoord);
+        },
+        pathOfLayer: (state) => (id) => {
+            return pixelsToUnionPath([...unionSet(state, id)].map(keyToCoord));
+        },
+        disconnectedCountOfLayer: (state) => (id) => {
+            const coords = [...unionSet(state, id)].map(keyToCoord);
+            if (!coords.length) return 0;
+            return groupConnectedPixels(coords).length;
+        },
+        getProperties: (state) => {
+            const propsOf = (id) => ({
+                id,
+                pixels: [...unionSet(state, id)].map(keyToCoord)
+            });
+            return (ids = []) => {
+                if (Array.isArray(ids)) return ids.map(propsOf);
+                return propsOf(ids);
+            };
+        },
+        has: (state) => (id, coord) => {
+            const key = coordToKey(coord);
+            for (const kind of PIXEL_KINDS) {
+                const set = state[kind][id];
+                if (set && set.has(key)) return true;
+            }
+            return false;
+        }
+    },
+    actions: {
+        set(id, pixels = []) {
+            const keyed = pixels.map(coordToKey);
+            for (const kind of PIXEL_KINDS) delete this[kind][id];
+            this[DEFAULT_KIND][id] = reactive(new Set(keyed));
+        },
+        remove(ids = []) {
+            for (const id of ids) {
+                for (const kind of PIXEL_KINDS) delete this[kind][id];
+            }
+        },
+        addPixels(id, pixels) {
+            const set = this[DEFAULT_KIND][id];
+            if (!set) return;
+            for (const coord of pixels) set.add(coordToKey(coord));
+        },
+        removePixels(id, pixels) {
+            const keys = pixels.map(coordToKey);
+            for (const kind of PIXEL_KINDS) {
+                const set = this[kind][id];
+                if (!set) continue;
+                for (const key of keys) set.delete(key);
+            }
+        },
+        cycleKind(id, coord) {
+            const key = coordToKey(coord);
+            let index = PIXEL_KINDS.findIndex(k => this[k][id]?.has(key));
+            if (index >= 0) {
+                const current = PIXEL_KINDS[index];
+                this[current][id].delete(key);
+                const next = PIXEL_KINDS[(index + 1) % PIXEL_KINDS.length];
+                if (!this[next][id]) this[next][id] = reactive(new Set());
+                this[next][id].add(key);
+            }
+            else {
+                const target = this[DEFAULT_KIND][id];
+                if (target) target.add(key);
+            }
+        },
+        togglePixel(id, coord) {
+            const key = coordToKey(coord);
+            for (const kind of PIXEL_KINDS) {
+                const set = this[kind][id];
+                if (set && set.has(key)) {
+                    set.delete(key);
+                    return;
+                }
+            }
+            const target = this[DEFAULT_KIND][id];
+            if (target) target.add(key);
+        },
+        translateAll(dx = 0, dy = 0) {
+            dx |= 0; dy |= 0;
+            if (dx === 0 && dy === 0) return;
+            for (const kind of PIXEL_KINDS) {
+                const ids = Object.keys(this[kind]);
+                for (const id of ids) {
+                    const set = this[kind][id];
+                    const moved = new Set();
+                    for (const key of set) {
+                        const [x, y] = keyToCoord(key);
+                        moved.add(coordToKey([x + dx, y + dy]));
+                    }
+                    this[kind][id] = reactive(moved);
+                }
+            }
+        },
+        serialize() {
+            const result = {};
+            const ids = new Set();
+            for (const kind of PIXEL_KINDS) {
+                for (const id of Object.keys(this[kind])) ids.add(id);
+            }
+            for (const id of ids) {
+                result[id] = [...unionSet(this, id)].map(keyToCoord);
+            }
+            return result;
+        },
+        applySerialized(byId = {}) {
+            for (const kind of PIXEL_KINDS) this[kind] = {};
+            for (const id of Object.keys(byId)) {
+                const keyed = byId[id].map(coordToKey);
+                this[DEFAULT_KIND][id] = reactive(new Set(keyed));
+            }
+        }
+    }
+});
+

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -63,6 +63,76 @@ export function ensureCheckerboardPattern(target = document.body) {
     return id;
 }
 
+export function ensurePathPattern(kind, target = document.body) {
+    const id = `pixel-kind-${kind}`;
+    if (document.getElementById(id)) return id;
+    const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+    svg.setAttribute('width', '0');
+    svg.setAttribute('height', '0');
+    svg.style.position = 'absolute';
+    svg.style.left = '-9999px';
+    const defs = document.createElementNS(SVG_NAMESPACE, 'defs');
+    const pattern = document.createElementNS(SVG_NAMESPACE, 'pattern');
+    pattern.setAttribute('id', id);
+    pattern.setAttribute('width', '1');
+    pattern.setAttribute('height', '1');
+    pattern.setAttribute('patternUnits', 'userSpaceOnUse');
+
+    const cornerPos = {
+        tl: [0, 0],
+        tr: [0.75, 0],
+        bl: [0, 0.75],
+        br: [0.75, 0.75]
+    };
+    const opposite = { tl: 'br', tr: 'bl', bl: 'tr', br: 'tl' };
+    const directions = {
+        tltr: 'right',
+        tlbl: 'down',
+        trtl: 'left',
+        trbr: 'down',
+        bltl: 'up',
+        blbr: 'right',
+        brtr: 'up',
+        brbl: 'left'
+    };
+    const arrowPath = {
+        right: 'M0.2 0.5H0.8L0.6 0.3V0.7Z',
+        left: 'M0.8 0.5H0.2L0.4 0.3V0.7Z',
+        down: 'M0.5 0.2V0.8L0.7 0.6H0.3Z',
+        up: 'M0.5 0.8V0.2L0.7 0.4H0.3Z'
+    };
+
+    const start = cornerPos[kind.slice(0, 2)];
+    const end = cornerPos[opposite[kind.slice(0, 2)]];
+    const direction = directions[kind];
+
+    const s = document.createElementNS(SVG_NAMESPACE, 'rect');
+    s.setAttribute('x', String(start[0]));
+    s.setAttribute('y', String(start[1]));
+    s.setAttribute('width', '0.25');
+    s.setAttribute('height', '0.25');
+    s.setAttribute('fill', '#00ff00');
+
+    const e = document.createElementNS(SVG_NAMESPACE, 'rect');
+    e.setAttribute('x', String(end[0]));
+    e.setAttribute('y', String(end[1]));
+    e.setAttribute('width', '0.25');
+    e.setAttribute('height', '0.25');
+    e.setAttribute('fill', '#ff0000');
+
+    const a = document.createElementNS(SVG_NAMESPACE, 'path');
+    a.setAttribute('d', arrowPath[direction]);
+    a.setAttribute('fill', '#000000');
+
+    pattern.appendChild(s);
+    pattern.appendChild(e);
+    pattern.appendChild(a);
+    defs.appendChild(pattern);
+    svg.appendChild(defs);
+    target.appendChild(svg);
+    return id;
+}
+
 // --- color helpers (32-bit unsigned RGBA packed as 0xAABBGGRR) ---
 export const packRGBA = (color) => {
     const r = clamp((+color.r || 0), 0, 255),


### PR DESCRIPTION
## Summary
- add dedicated pixel store and strip pixel data from node store
- automatically remove selection entries when nodes are removed from the tree
- update layers, viewport, and tools to read and write pixels via the new store
- split pixel data into eight directional sets while preserving existing pixel APIs
- introduce path tool that cycles pixel path kinds and displays directional overlays

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14f78f91c832c826586d4661d6a73