### PR TITLE
refactor: extract pixel store and sync selection removal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
-const { input, viewport: viewportStore, nodeTree, nodes, output } = useStore();
+const { input, viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const { layerPanel, layerQuery } = useService();
 
 // Width control between display and layers
@@ -85,14 +85,14 @@ onMounted(async () => {
   const autoSegments = input.isLoaded ? input.segment(40) : [];
   if (autoSegments.length) {
     const ids = [];
-    for (let i = 0; i < autoSegments.length; i++) {
+      for (let i = 0; i < autoSegments.length; i++) {
       const segment = autoSegments[i];
       const id = nodes.createLayer({
         name: `Auto ${i+1}`,
         color: segment.colorU32,
-        visibility: true,
-        pixels: segment.pixels
+        visibility: true
       });
+      if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
       ids.push(id);
     }
     nodeTree.insert(ids);

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="viewportStore.display!=='result'" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="nodes.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->
@@ -27,7 +27,7 @@ import { ref, computed, onMounted, nextTick } from 'vue';
 import { useStore } from '../stores';
 import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, output } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const text = ref('');
 const textareaElement = ref(null);
 

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -6,7 +6,7 @@
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="nodes.pathOfLayer(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOfLayer(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <div class="min-w-0 flex-1">
@@ -31,7 +31,7 @@
         <div v-if="item.depth===0" @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path :d="nodes.pathOfLayer(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path :d="pixelStore.pathOfLayer(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <!-- 색상 -->
@@ -44,9 +44,9 @@
             <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
           </div>
           <div class="text-xs text-slate-400">
-            <template v-if="nodes.disconnectedCountOfLayer(item.id) > 1">
+            <template v-if="pixelStore.disconnectedCountOfLayer(item.id) > 1">
               <span class="cursor-pointer" @click.stop="onDisconnectedClick(item.id)">⚠️</span>
-              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ nodes.disconnectedCountOfLayer(item.id) }} piece</span>
+              <span class="cursor-pointer" @click.stop="onDisconnectedCountClick(item.id)">{{ pixelStore.disconnectedCountOfLayer(item.id) }} piece</span>
               <span class="mx-1">|</span>
             </template>
             <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.props.pixels.length }} px</span>
@@ -78,7 +78,7 @@ import blockIcons from '../image/layer_block';
 
 import { useService } from '../services';
 
-const { viewport: viewportStore, nodeTree, nodes, output, keyboardEvent: keyboardEvents } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
 const { layerPanel, layerQuery, viewport, stageResize: stageResizeService } = useService();
 
 const dragging = ref(false);
@@ -102,7 +102,8 @@ const flatNodes = computed(() => {
   };
   walk(nodeTree.tree, 0);
   const propsList = nodes.getProperties(ids);
-  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].type === 'group', props: propsList[i] }));
+  const pixelList = pixelStore.getProperties(ids);
+  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].type === 'group', props: { ...propsList[i], pixels: pixelList[i].pixels } }));
 });
 
 const patternUrl = computed(() => `url(#${ensureCheckerboardPattern(document.body)})`);
@@ -131,7 +132,7 @@ function descendantProps(id) {
   }
 
   function onPixelCountClick(id) {
-      const count = (nodes.getProperty(id, 'pixels') || []).length;
+      const count = pixelStore.get(id).length;
       const ids = count === 0 ? [id] : layerQuery.byPixelCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
@@ -158,7 +159,7 @@ function descendantProps(id) {
   }
 
   function onDisconnectedCountClick(id) {
-      const count = nodes.disconnectedCountOfLayer(id);
+      const count = pixelStore.disconnectedCountOfLayer(id);
       const ids = count <= 1 ? [id] : layerQuery.byDisconnectedCount(count);
       if (ids.length <= 1) {
           layerPanel.setRange(id, id);
@@ -270,7 +271,9 @@ function deleteLayer(id) {
     output.setRollbackPoint();
     const targets = nodeTree.selectedNodeIds.includes(id) ? nodeTree.selectedNodeIds : [id];
     const belowId = layerQuery.below(layerQuery.lowermost(targets));
-    nodes.remove(targets);
+    const removed = nodeTree.remove(targets);
+    nodes.remove(removed);
+    pixelStore.remove(removed);
     const newSelectId = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
@@ -287,8 +290,9 @@ function deleteSelection() {
     output.setRollbackPoint();
     const belowId = layerQuery.below(layerQuery.lowermost(nodeTree.selectedLayerIds));
     const ids = nodeTree.selectedLayerIds;
-    nodes.remove(ids);
-    nodeTree.removeFromSelection(ids);
+    const removed = nodeTree.remove(ids);
+    nodes.remove(removed);
+    pixelStore.remove(removed);
     const newSelect = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
     layerPanel.setRange(newSelect, newSelect);
     layerPanel.setScrollRule({ type: 'follow', target: newSelect });

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -27,11 +27,11 @@ import { useService } from '../services';
 import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
-const { nodeTree, nodes, output } = useStore();
+const { nodeTree, nodes, pixels: pixelStore, output } = useStore();
 const { layerTool: layerSvc, layerPanel, layerQuery } = useService();
 
-const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => (nodes.getProperty(id, 'pixels') || []).length === 0));
-const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => nodes.disconnectedCountOfLayer(id) > 1));
+const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => pixelStore.get(id).length === 0));
+const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => pixelStore.disconnectedCountOfLayer(id) > 1));
 
 const onAdd = () => {
     output.setRollbackPoint();

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -28,7 +28,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="nodes.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->
@@ -75,7 +75,7 @@ import { useService } from '../services';
 import { OVERLAY_STYLES, GRID_STROKE_COLOR } from '@/constants';
 import { rgbaCssU32, ensureCheckerboardPattern } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, viewportEvent: viewportEvents } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, viewportEvent: viewportEvents } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = useTemplateRef('viewportEl');
 const stage = viewportStore.stage;

--- a/src/components/ViewportInfo.vue
+++ b/src/components/ViewportInfo.vue
@@ -14,11 +14,11 @@ import { useStore } from '../stores';
 import { useService } from '../services';
 import { getPixelUnion, rgbaCssU32, rgbaCssObj } from '../utils';
 
-const { viewport: viewportStore, nodeTree, nodes, input } = useStore();
-const { toolSelection: toolSelectionService } = useService();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, input } = useStore();
+const { toolSelection: toolSelectionService, layerQuery } = useService();
 
 const selectedAreaPixelCount = computed(() => {
-    const pixels = getPixelUnion(nodes.getProperties(nodeTree.selectedLayerIds));
+    const pixels = getPixelUnion(pixelStore.getProperties(nodeTree.selectedLayerIds));
     return pixels.length;
   });
 
@@ -30,7 +30,8 @@ const pixelInfo = computed(() => {
       const colorObject = input.readPixel(coord);
       return `[${px},${py}] ${rgbaCssObj(colorObject)}`;
     } else {
-      const colorU32 = nodes.compositeColorAt(coord);
+      const id = layerQuery.topVisibleAt(coord);
+      const colorU32 = id ? nodes.getProperty(id, 'color') : 0;
       return `[${px},${py}] ${rgbaCssU32(colorU32)}`;
     }
   });

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -5,7 +5,7 @@ import { coordToKey, keyToCoord, pixelsToUnionPath } from '../utils';
 import { OVERLAY_STYLES } from '@/constants';
 
 export const useOverlayService = defineStore('overlayService', () => {
-    const { nodeTree, nodes } = useStore();
+    const { nodeTree, pixels: pixelStore } = useStore();
 
     const pixelKeys = reactive({});
     const styles = reactive({});
@@ -45,7 +45,7 @@ export const useOverlayService = defineStore('overlayService', () => {
         if (!Array.isArray(ids)) ids = [ids];
         for (const layerId of ids) {
             if (layerId == null) continue;
-            const layerPixels = nodes.getProperty(layerId, 'pixels') || [];
+            const layerPixels = pixelStore.get(layerId);
             addPixels(id, layerPixels);
         }
     }

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,6 +1,7 @@
 import { useInputStore } from './input';
 import { useNodeTreeStore } from './nodeTree';
 import { useNodeStore } from './nodes';
+import { usePixelStore } from './pixels';
 import { useOutputStore } from './output';
 import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
@@ -10,6 +11,7 @@ export {
     useInputStore,
     useNodeTreeStore,
     useNodeStore,
+    usePixelStore,
     useOutputStore,
     useViewportStore,
     useViewportEventStore,
@@ -20,6 +22,7 @@ export const useStore = () => ({
     input: useInputStore(),
     nodeTree: useNodeTreeStore(),
     nodes: useNodeStore(),
+    pixels: usePixelStore(),
     output: useOutputStore(),
     viewport: useViewportStore(),
     viewportEvent: useViewportEventStore(),

--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -242,6 +242,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
                 const node = this._removeFromTree(id);
                 if (node) collectIds(node);
             }
+            for (const id of removed) this._selection.delete(id);
             return removed;
         },
         serialize() {

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -16,11 +16,12 @@ export const useOutputStore = defineStore('output', {
     },
     actions: {
         _apply(snapshot) {
-            const { nodeTree, nodes, viewport } = useStore();
+            const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
             nodeTree.applySerialized(parsed.nodeTreeState);
             nodes.applySerialized(parsed.nodeState);
+            pixels.applySerialized(parsed.pixelState);
             layerPanel.applySerialized(parsed.layerPanelState);
             viewport.applySerialized(parsed.viewportState);
             this._commitVersion++; // ← Undo/Redo/롤백 시에도 썸네일 갱신
@@ -48,11 +49,12 @@ export const useOutputStore = defineStore('output', {
             })
         },
         currentSnap() {
-            const { nodeTree, nodes, viewport } = useStore();
+            const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             return JSON.stringify({
                 nodeTreeState: nodeTree.serialize(),
                 nodeState: nodes.serialize(),
+                pixelState: pixels.serialize(),
                 layerPanelState: layerPanel.serialize(),
                 viewportState: viewport.serialize()
             });

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -1,0 +1,92 @@
+import { defineStore } from 'pinia';
+import { reactive } from 'vue';
+import { coordToKey, keyToCoord, pixelsToUnionPath, groupConnectedPixels } from '../utils';
+
+export const usePixelStore = defineStore('pixels', {
+    state: () => ({
+        _pixels: {}
+    }),
+    getters: {
+        get: (state) => (id) => {
+            const set = state._pixels[id];
+            return set ? [...set].map(keyToCoord) : [];
+        },
+        pathOfLayer: (state) => (id) => {
+            const set = state._pixels[id];
+            if (!set) return pixelsToUnionPath([]);
+            return pixelsToUnionPath([...set].map(keyToCoord));
+        },
+        disconnectedCountOfLayer: (state) => (id) => {
+            const set = state._pixels[id];
+            if (!set) return 0;
+            return groupConnectedPixels([...set].map(keyToCoord)).length;
+        },
+        getProperties: (state) => {
+            const propsOf = (id) => ({
+                id,
+                pixels: state._pixels[id] ? [...state._pixels[id]].map(keyToCoord) : []
+            });
+            return (ids = []) => {
+                if (Array.isArray(ids)) return ids.map(propsOf);
+                return propsOf(ids);
+            };
+        }
+    },
+    actions: {
+        set(id, pixels = []) {
+            const keyed = pixels.map(coordToKey);
+            this._pixels[id] = reactive(new Set(keyed));
+        },
+        remove(ids = []) {
+            for (const id of ids) {
+                delete this._pixels[id];
+            }
+        },
+        addPixels(id, pixels) {
+            const set = this._pixels[id];
+            if (!set) return;
+            for (const coord of pixels) set.add(coordToKey(coord));
+        },
+        removePixels(id, pixels) {
+            const set = this._pixels[id];
+            if (!set) return;
+            for (const coord of pixels) set.delete(coordToKey(coord));
+        },
+        togglePixel(id, coord) {
+            const set = this._pixels[id];
+            if (!set) return;
+            const key = coordToKey(coord);
+            if (set.has(key)) set.delete(key);
+            else set.add(key);
+        },
+        translateAll(dx = 0, dy = 0) {
+            dx |= 0; dy |= 0;
+            if (dx === 0 && dy === 0) return;
+            const ids = Object.keys(this._pixels);
+            for (const id of ids) {
+                const set = this._pixels[id];
+                const moved = new Set();
+                for (const key of set) {
+                    const [x, y] = keyToCoord(key);
+                    moved.add(coordToKey([x + dx, y + dy]));
+                }
+                this._pixels[id] = reactive(moved);
+            }
+        },
+        serialize() {
+            const result = {};
+            for (const id of Object.keys(this._pixels)) {
+                result[id] = [...this._pixels[id]].map(keyToCoord);
+            }
+            return result;
+        },
+        applySerialized(byId = {}) {
+            this._pixels = {};
+            for (const id of Object.keys(byId)) {
+                const keyed = byId[id].map(coordToKey);
+                this._pixels[id] = reactive(new Set(keyed));
+            }
+        }
+    }
+});
+

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -3,7 +3,7 @@ import { readonly } from 'vue';
 import { clamp, keyToCoord } from '../utils';
 import { MIN_SCALE_RATIO } from '@/constants';
 import { useNodeTreeStore } from './nodeTree';
-import { useNodeStore } from './nodes';
+import { usePixelStore } from './pixels';
 
 export const useViewportStore = defineStore('viewport', {
     state: () => ({
@@ -61,12 +61,12 @@ export const useViewportStore = defineStore('viewport', {
         resizeByEdges({ top = 0, bottom = 0, left = 0, right = 0 } = {}) {
             top |= 0; bottom |= 0; left |= 0; right |= 0;
             const tree = useNodeTreeStore();
-            const nodeStore = useNodeStore();
-            if (left !== 0 || top !== 0) nodeStore.translateAllLayers(left, top);
+            const pixelStore = usePixelStore();
+            if (left !== 0 || top !== 0) pixelStore.translateAll(left, top);
             const newWidth = Math.max(1, this._stage.width + left + right);
             const newHeight = Math.max(1, this._stage.height + top + bottom);
             for (const id of tree.layerIdsBottomToTop) {
-                const set = nodeStore._pixels[id];
+                const set = pixelStore._pixels[id];
                 for (const key of [...set]) {
                     const [x, y] = keyToCoord(key);
                     if (x < 0 || y < 0 || x >= newWidth || y >= newHeight) set.delete(key);


### PR DESCRIPTION
## Summary
- add dedicated pixel store and strip pixel data from node store
- automatically remove selection entries when nodes are removed from the tree
- update layers, viewport, and tools to read and write pixels via the new store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14f78f91c832c826586d4661d6a73