### PR TITLE
feat: add ctrl+g grouping shortcut

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -79,7 +79,7 @@ import blockIcons from '../image/layer_block';
 import { useService } from '../services';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
-const { layerPanel, layerQuery, viewport, stageResize: stageResizeService } = useService();
+const { layerPanel, layerQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);
@@ -408,12 +408,20 @@ function ensureBlockVisibility({
                   }
                   break;
           }
-          if (ctrl) {
-              if (key.toLowerCase() === 'a') {
-                  e.preventDefault();
-                  layerPanel.selectAll();
-              }
-          }
+        if (ctrl) {
+            const lower = key.toLowerCase();
+            if (lower === 'a') {
+                e.preventDefault();
+                layerPanel.selectAll();
+            } else if (lower === 'g') {
+                e.preventDefault();
+                output.setRollbackPoint();
+                const id = layerSvc.groupSelected();
+                layerPanel.setRange(id, id);
+                layerPanel.setScrollRule({ type: 'follow', target: id });
+                output.commit();
+            }
+        }
       }
   });
 

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -44,16 +44,7 @@ const onAdd = () => {
 };
 const onAddGroup = () => {
     output.setRollbackPoint();
-    const selected = nodeTree.selectedIds;
-    const id = nodes.createGroup({});
-    if (selected.length === 0) {
-        nodeTree.append([id], null, false);
-    } else {
-        const lowermost = selected[0];
-        nodeTree.insert([id], lowermost, true);
-        nodeTree.append(selected, id, true);
-    }
-    nodeTree.replaceSelection([id]);
+    const id = layerSvc.groupSelected();
     layerPanel.setRange(id, id);
     layerPanel.setScrollRule({ type: 'follow', target: id });
     output.commit();

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -115,10 +115,25 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         return allNewIds;
     }
 
+    function groupSelected() {
+        const selected = nodeTree.selectedIds;
+        const id = nodes.createGroup({});
+        if (selected.length === 0) {
+            nodeTree.append([id], null, false);
+        } else {
+            const lowermost = selected[0];
+            nodeTree.insert([id], lowermost, true);
+            nodeTree.append(selected, id, true);
+        }
+        nodeTree.replaceSelection([id]);
+        return id;
+    }
+
     return {
         mergeSelected,
         copySelected,
         splitSelected,
+        groupSelected,
     };
 });
 


### PR DESCRIPTION
## Summary
- support grouping selected layers via Ctrl+G
- centralize group creation in layerTool service

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef816e20832cb99e5d9f650f76a2