### PR TITLE
feat: add Ctrl+G grouping shortcut

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -299,6 +299,23 @@ function deleteSelection() {
     output.commit();
 }
 
+function groupSelection() {
+    output.setRollbackPoint();
+    const selected = nodeTree.selectedIds;
+    const id = nodes.createGroup({});
+    if (selected.length === 0) {
+        nodeTree.append([id], null, false);
+    } else {
+        const lowermost = selected[0];
+        nodeTree.insert([id], lowermost, true);
+        nodeTree.append(selected, id, true);
+    }
+    nodeTree.replaceSelection([id]);
+    layerPanel.setRange(id, id);
+    layerPanel.setScrollRule({ type: 'follow', target: id });
+    output.commit();
+}
+
 function ensureBlockVisibility({
     type,
     target
@@ -409,9 +426,13 @@ function ensureBlockVisibility({
                   break;
           }
           if (ctrl) {
-              if (key.toLowerCase() === 'a') {
+              const lower = key.toLowerCase();
+              if (lower === 'a') {
                   e.preventDefault();
                   layerPanel.selectAll();
+              } else if (lower === 'g') {
+                  e.preventDefault();
+                  groupSelection();
               }
           }
       }


### PR DESCRIPTION
## Summary
- allow grouping with Ctrl+G shortcut
- watch keyboard input for Ctrl+G and call existing group logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef816e20832cb99e5d9f650f76a2