### PR TITLE
feat: enable image upload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,7 +34,6 @@
 <script setup>
 import { onMounted, ref, computed, onUnmounted } from 'vue';
 import { useStore } from './stores';
-import { useService } from './services';
 
 import Viewport from './components/Viewport.vue';
 import ViewportInfo from './components/ViewportInfo.vue';
@@ -43,8 +42,7 @@ import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
-const { input, viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
-const { layerPanel, layerQuery } = useService();
+const { input, viewport: viewportStore } = useStore();
 
 // Width control between display and layers
 const container = ref(null);
@@ -75,34 +73,11 @@ onMounted(async () => {
   try {
     await input.loadFromQuery();
   } catch {}
-  if (!input.isLoaded) {
+  if (input.isLoaded) {
+    input.initialize();
+  } else {
     viewportStore.setSize(21, 18);
-  } else {
-    viewportStore.setSize(input.width, input.height);
-    viewportStore.setImage(input.src || '', input.width, input.height);
   }
-
-  const autoSegments = input.isLoaded ? input.segment(40) : [];
-  if (autoSegments.length) {
-    const ids = [];
-      for (let i = 0; i < autoSegments.length; i++) {
-      const segment = autoSegments[i];
-      const id = nodes.createLayer({
-        name: `Auto ${i+1}`,
-        color: segment.colorU32,
-        visibility: true
-      });
-      if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
-      ids.push(id);
-    }
-    nodeTree.insert(ids);
-  } else {
-    const ids = [nodes.createLayer({}), nodes.createLayer({})];
-    nodeTree.insert(ids);
-  }
-
-      layerPanel.setScrollRule({ type: "follow", target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });
-
   window.addEventListener('mousemove', onDrag);
   window.addEventListener('mouseup', stopDrag);
 });

--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="flex items-center gap-2 p-2 flex-wrap">
-      <button @click="viewportStore.toggleView" class="inline-flex items-center px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">{{ viewportStore.toggleLabel }}</button>
+      <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileChange" />
+      <button v-if="input.isLoaded" @click="viewportStore.toggleView" class="inline-flex items-center px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">{{ viewportStore.toggleLabel }}</button>
+      <button v-else @click="openFileDialog" class="inline-flex items-center px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">Load</button>
       <!-- Stage resize -->
       <button @click="stageResizeService.open" title="Resize Canvas" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
         <img :src="stageIcons.resize" alt="resize" class="w-4 h-4">
@@ -50,8 +52,20 @@ import { useService } from '../services';
 import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, TOOL_MODIFIERS } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
 
-const { viewport: viewportStore, nodeTree, output, keyboardEvent: keyboardEvents } = useStore();
+const { viewport: viewportStore, nodeTree, input, output, keyboardEvent: keyboardEvents } = useStore();
 const { toolSelection: toolSelectionService, stageResize: stageResizeService } = useService();
+
+const fileInput = ref(null);
+function openFileDialog() {
+  fileInput.value?.click();
+}
+async function onFileChange(e) {
+  const file = e.target.files?.[0];
+  if (!file) return;
+  await input.loadFile(file);
+  input.initialize();
+  e.target.value = '';
+}
 
 let previousTool = null;
 let lastSingleTool = 'draw';

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -1,4 +1,6 @@
 import { defineStore } from 'pinia';
+import { useStore } from '.';
+import { useLayerPanelService } from '../services/layerPanel';
 import { packRGBA, averageColorU32 } from '../utils';
 
 export const useInputStore = defineStore('input', {
@@ -44,8 +46,39 @@ export const useInputStore = defineStore('input', {
             const data = context.getImageData(0, 0, w, h).data;
             this.createImage({ src, width: w, height: h, buffer: data });
         },
+        async loadFile(file) {
+            if (!file) return;
+            const url = URL.createObjectURL(file);
+            await this.load(url);
+            URL.revokeObjectURL(url);
+        },
         async loadFromQuery() {
             await this.load(new URL(location.href).searchParams.get('pixel'));
+        },
+        initialize() {
+            const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore } = useStore();
+            const layerPanel = useLayerPanelService();
+            viewportStore.setSize(this.width, this.height);
+            viewportStore.setImage(this.src || '', this.width, this.height);
+            const autoSegments = this.segment(40);
+            if (autoSegments.length) {
+                const ids = [];
+                for (let i = 0; i < autoSegments.length; i++) {
+                    const segment = autoSegments[i];
+                    const id = nodes.createLayer({
+                        name: `Auto ${i + 1}`,
+                        color: segment.colorU32,
+                        visibility: true
+                    });
+                    if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
+                    ids.push(id);
+                }
+                nodeTree.insert(ids);
+            } else {
+                const ids = [nodes.createLayer({}), nodes.createLayer({})];
+                nodeTree.insert(ids);
+            }
+            layerPanel.setScrollRule({ type: 'follow', target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });
         },
         isWithin([x, y]) {
             return x >= 0 && y >= 0 && x < this._width && y < this._height;


### PR DESCRIPTION
## Summary
- allow uploading image files and show a Load button before image is available
- initialize project with uploaded image and hide original/result toggle until ready
- support loading images from local files in input store
- centralize project initialization in the input store and invoke it from components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2691eba3c832ca6f79cec5571a18b