### PR TITLE
feat: add ungroup option to group context menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@
       </aside>
     </div>
     <StageResizePopup />
+    <ContextMenu />
 </template>
 
 <script setup>
@@ -42,6 +43,7 @@ import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
+import ContextMenu from './components/ContextMenu.vue';
 const { input, viewport: viewportStore } = useStore();
 
 // Width control between display and layers

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,0 +1,37 @@
+<template>
+  <ul v-if="visible" class="context-menu" :style="{ left: x + 'px', top: y + 'px' }">
+    <li v-for="(item, i) in items" :key="i" @click="select(item)" class="menu-item">
+      {{ item.label }}
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { useContextMenuService } from '../services/contextMenu';
+
+const { visible, x, y, items, close } = useContextMenuService();
+
+function select(item) {
+  close();
+  item.action && item.action();
+}
+</script>
+
+<style scoped>
+.context-menu {
+  position: fixed;
+  z-index: 1000;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 4px 0;
+  min-width: 120px;
+}
+.menu-item {
+  padding: 4px 12px;
+  cursor: pointer;
+}
+.menu-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+</style>

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-memo="[output.commitVersion, nodeTree.selectedLayerIds, nodeTree.layerCount, foldedMemo]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="item in flatNodes" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="item.id" :data-id="item.id" :style="{ marginLeft: (item.depth * 32) + 'px' }" :class="{ selected: nodeTree.selectedNodeIds.includes(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item,$event)">
+    <div v-for="item in flatNodes" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="item.id" :data-id="item.id" :style="{ marginLeft: (item.depth * 32) + 'px' }" :class="{ selected: nodeTree.selectedNodeIds.includes(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item,$event)" @contextmenu.prevent="onContextMenu(item,$event)">
       <template v-if="item.isGroup">
         <div class="w-4 text-center cursor-pointer" @click.stop="toggleFold(item.id)">{{ folded[item.id] ? '▶' : '▼' }}</div>
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
@@ -79,7 +79,7 @@ import blockIcons from '../image/layer_block';
 import { useService } from '../services';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
-const { layerPanel, layerQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc } = useService();
+const { layerPanel, layerQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc, contextMenu } = useService();
 
 const dragging = ref(false);
 const dragId = ref(null);
@@ -265,6 +265,23 @@ function toggleLock(id) {
         nodes.toggleLock(id);
     }
     output.commit();
+}
+
+function onContextMenu(item, event) {
+    if (!item.isGroup) return;
+    if (!nodeTree.selectedNodeIds.includes(item.id)) {
+        layerPanel.setRange(item.id, item.id);
+    }
+    contextMenu.open(event, [
+        {
+            label: 'Ungroup',
+            action: () => {
+                output.setRollbackPoint();
+                layerSvc.ungroupSelected();
+                output.commit();
+            }
+        }
+    ]);
 }
 
 function deleteLayer(id) {

--- a/src/services/contextMenu.js
+++ b/src/services/contextMenu.js
@@ -1,0 +1,27 @@
+import { defineStore } from 'pinia';
+import { reactive, toRefs } from 'vue';
+
+export const useContextMenuService = defineStore('contextMenuService', () => {
+  const state = reactive({
+    visible: false,
+    x: 0,
+    y: 0,
+    items: [],
+  });
+
+  function open(event, items = []) {
+    state.x = event.clientX;
+    state.y = event.clientY;
+    state.items = items;
+    state.visible = true;
+    document.addEventListener('click', close);
+  }
+
+  function close() {
+    state.visible = false;
+    state.items = [];
+    document.removeEventListener('click', close);
+  }
+
+  return { ...toRefs(state), open, close };
+});

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -6,6 +6,7 @@ import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEr
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
+import { useContextMenuService } from './contextMenu';
 
 export {
     useLayerPanelService,
@@ -21,7 +22,8 @@ export {
     useCutToolService,
     useToolSelectionService,
     useViewportService,
-    useStageResizeService
+    useStageResizeService,
+    useContextMenuService
 };
 
 export const useService = () => ({
@@ -40,5 +42,6 @@ export const useService = () => ({
     },
     toolSelection: useToolSelectionService(),
     viewport: useViewportService(),
-    stageResize: useStageResizeService()
+    stageResize: useStageResizeService(),
+    contextMenu: useContextMenuService()
 });

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -129,11 +129,32 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         return id;
     }
 
+    function ungroupSelected() {
+        const groupIds = nodeTree.selectedNodeIds.filter(id => nodes.getProperty(id, 'type') === 'group');
+        const newSelection = nodeTree.selectedNodeIds.slice();
+        for (const groupId of groupIds) {
+            const info = nodeTree._findNode(groupId);
+            if (!info) continue;
+            const parentArr = info.parent ? info.parent.children : nodeTree._tree;
+            const index = info.index;
+            const children = info.node.children ? info.node.children.map(c => c.id) : [];
+            parentArr.splice(index, 1, ...(info.node.children || []));
+            nodes.remove([groupId]);
+            const selIdx = newSelection.indexOf(groupId);
+            if (selIdx >= 0) {
+                newSelection.splice(selIdx, 1, ...children);
+            }
+        }
+        nodeTree.replaceSelection(newSelection);
+        return groupIds;
+    }
+
     return {
         mergeSelected,
         copySelected,
         splitSelected,
         groupSelected,
+        ungroupSelected,
     };
 });
 


### PR DESCRIPTION
## Summary
- add generic context menu service and component
- enable ungrouping groups via context menu on layer blocks
- support ungroup operation in layer tool service

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b285b68bf4832c8013ddf52ec6218e