### PR TITLE
Add pixel path service for one-stroke traversal

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -4,6 +4,7 @@ export const SINGLE_SELECTION_TOOLS = [
   { type: 'draw', name: 'Draw', icon: stageIcons.draw },
   { type: 'erase', name: 'Erase', icon: stageIcons.erase },
   { type: 'cut', name: 'Cut', icon: stageIcons.cut },
+  { type: 'trace', name: 'Trace', icon: stageIcons.path },
   { type: 'top', name: 'To Top', icon: stageIcons.top },
 ];
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,10 +2,11 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
-import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, usePathToolService } from './tools';
+import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, usePathToolService, useTraceToolService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
+import { usePixelPathService } from './pixelPath';
 
 export {
     useLayerPanelService,
@@ -16,12 +17,14 @@ export {
     useDrawToolService,
     useEraseToolService,
     useTopToolService,
+    useTraceToolService,
     usePathToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
     useViewportService,
-    useStageResizeService
+    useStageResizeService,
+    usePixelPathService
 };
 
 export const useService = () => ({
@@ -35,10 +38,12 @@ export const useService = () => ({
         erase: useEraseToolService(),
         globalErase: useGlobalEraseToolService(),
         path: usePathToolService(),
+        trace: useTraceToolService(),
         cut: useCutToolService(),
         top: useTopToolService(),
     },
     toolSelection: useToolSelectionService(),
     viewport: useViewportService(),
-    stageResize: useStageResizeService()
+    stageResize: useStageResizeService(),
+    pixelPath: usePixelPathService()
 });

--- a/src/services/pixelPath.js
+++ b/src/services/pixelPath.js
@@ -1,0 +1,141 @@
+import { coordToKey, keyToCoord, findPixelComponents } from '../utils';
+
+const DIRECTIONS = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, 1],
+  [-1, -1],
+  [1, -1],
+  [-1, 1]
+];
+
+const getNeighbors = ([x, y]) => {
+  return DIRECTIONS.map(([dx, dy]) => [x + dx, y + dy]);
+};
+
+function buildAdjacency(pixels) {
+  const set = new Set(pixels.map(coordToKey));
+  const map = new Map();
+  for (const p of pixels) {
+    const key = coordToKey(p);
+    const ns = [];
+    for (const n of getNeighbors(p)) {
+      if (set.has(coordToKey(n))) ns.push(n);
+    }
+    map.set(key, ns);
+  }
+  return map;
+}
+
+function search(adjacency, total, currentKey, endKey, visited, path) {
+  if (path.length === total) {
+    if (!endKey || currentKey === endKey) return [...path];
+    return null;
+  }
+  const neighbors = adjacency.get(currentKey) || [];
+  neighbors.sort((a, b) => adjacency.get(coordToKey(a)).length - adjacency.get(coordToKey(b)).length);
+  for (const n of neighbors) {
+    const key = coordToKey(n);
+    if (visited.has(key)) continue;
+    visited.add(key);
+    path.push(n);
+    const res = search(adjacency, total, key, endKey, visited, path);
+    if (res) return res;
+    path.pop();
+    visited.delete(key);
+  }
+  return null;
+}
+
+function findHamiltonian(component, start, end) {
+  const adjacency = buildAdjacency(component);
+  const total = component.length;
+  const endKey = end ? coordToKey(end) : null;
+  if (start) {
+    const startKey = coordToKey(start);
+    const visited = new Set([startKey]);
+    const path = [start];
+    return search(adjacency, total, startKey, endKey, visited, path);
+  }
+  for (const p of component) {
+    const startKey = coordToKey(p);
+    const visited = new Set([startKey]);
+    const path = [p];
+    const res = search(adjacency, total, startKey, endKey, visited, path);
+    if (res) return res;
+  }
+  return null;
+}
+
+function greedyPaths(component, start, end) {
+  const remaining = new Set(component.map(coordToKey));
+  const paths = [];
+  let first = true;
+  while (remaining.size) {
+    let current = first && start ? start : keyToCoord(remaining.values().next().value);
+    first = false;
+    const endKey = paths.length === 0 && end ? coordToKey(end) : null;
+    const path = [];
+    while (remaining.has(coordToKey(current))) {
+      path.push(current);
+      remaining.delete(coordToKey(current));
+      if (endKey && coordToKey(current) === endKey) break;
+      const ns = getNeighbors(current).filter(n => remaining.has(coordToKey(n)));
+      if (!ns.length) break;
+      ns.sort((a, b) => {
+        const ac = getNeighbors(a).filter(nn => remaining.has(coordToKey(nn))).length;
+        const bc = getNeighbors(b).filter(nn => remaining.has(coordToKey(nn))).length;
+        return ac - bc;
+      });
+      current = ns[0];
+    }
+    paths.push(path);
+  }
+  return paths;
+}
+
+export const usePixelPathService = () => {
+  function pathsFromStart(pixels, start) {
+    const components = findPixelComponents(pixels);
+    const startKey = coordToKey(start);
+    for (const comp of components) {
+      if (comp.some(p => coordToKey(p) === startKey)) {
+        const h = findHamiltonian(comp, start, null);
+        if (h) return [h];
+        return greedyPaths(comp, start, null);
+      }
+    }
+    return [];
+  }
+
+  function pathsFromStartEnd(pixels, start, end) {
+    const components = findPixelComponents(pixels);
+    const startKey = coordToKey(start);
+    const endKey = coordToKey(end);
+    for (const comp of components) {
+      const set = new Set(comp.map(coordToKey));
+      if (set.has(startKey) && set.has(endKey)) {
+        const h = findHamiltonian(comp, start, end);
+        if (h) return [h];
+        return greedyPaths(comp, start, end);
+      }
+    }
+    return [];
+  }
+
+  function pathsAny(pixels) {
+    const components = findPixelComponents(pixels);
+    const paths = [];
+    for (const comp of components) {
+      const h = findHamiltonian(comp, null, null);
+      if (h) paths.push(h);
+      else paths.push(...greedyPaths(comp, null, null));
+    }
+    return paths;
+  }
+
+  return { pathsFromStart, pathsFromStartEnd, pathsAny };
+};
+

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -4,6 +4,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
 import { useLayerQueryService } from './layerQuery';
+import { usePixelPathService } from './pixelPath';
 import { useStore } from '../stores';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
 import { coordToKey, keyToCoord, ensurePathPattern } from '../utils';
@@ -379,6 +380,48 @@ export const usePathToolService = defineStore('pathToolService', () => {
         rebuild();
     });
     watch(() => nodeTree.selectedIds, rebuild);
+    return {};
+});
+
+export const useTraceToolService = defineStore('traceToolService', () => {
+    const { nodeTree, pixels: pixelStore, nodes } = useStore();
+    const tool = useToolSelectionService();
+    const pixelPath = usePixelPathService();
+    const overlayService = useOverlayService();
+    const overlayId = overlayService.createOverlay();
+    overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+
+    function showPath(pixels) {
+        if (tool.prepared !== 'trace' || nodeTree.selectedLayerCount !== 1) {
+            overlayService.clear(overlayId);
+            return;
+        }
+        const start = pixels[0];
+        if (!start) {
+            overlayService.clear(overlayId);
+            return;
+        }
+        const layerId = nodeTree.selectedLayerIds[0];
+        if (nodes.getProperty(layerId, 'locked')) {
+            overlayService.clear(overlayId);
+            tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
+            return;
+        }
+        const layerPixels = pixelStore.get(layerId);
+        const paths = pixelPath.pathsFromStart(layerPixels, start);
+        overlayService.setPixels(overlayId, paths.flat());
+        tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
+    }
+
+    watch(() => tool.prepared === 'trace', (isTrace) => {
+        if (!isTrace) {
+            overlayService.clear(overlayId);
+            return;
+        }
+        tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
+    });
+    watch(() => tool.previewPixels, showPath);
+    watch(() => tool.affectedPixels, showPath);
     return {};
 });
 


### PR DESCRIPTION
## Summary
- add pixelPath service implementing one-stroke traversal helpers with optional start and end constraints
- expose pixelPath service through service index
- add trace tool leveraging pixelPath service to visualize paths from a chosen start pixel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f7cfbbac832ca747c2f9f37c9362