### PR TITLE
Optimize Hamiltonian solver with precomputed adjacency

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -1,90 +1,103 @@
 import { indexToCoord, coordToIndex } from '../utils';
 
-// Build adjacency map for pixels with 8-way connectivity
+// Build adjacency info for pixels with 8-way connectivity
+// Returns { nodes, neighbors, degrees, indexMap }
 function buildGraph(pixels) {
   const set = new Set(pixels);
-  const graph = new Map();
-  for (const pixel of pixels) {
+  const nodes = Array.from(set);
+  const indexMap = new Map(nodes.map((p, i) => [p, i]));
+  const neighbors = nodes.map(() => []);
+
+  for (let i = 0; i < nodes.length; i++) {
+    const pixel = nodes[i];
     const [x, y] = indexToCoord(pixel);
-    const neighbors = [];
     for (let dx = -1; dx <= 1; dx++) {
       for (let dy = -1; dy <= 1; dy++) {
         if (dx === 0 && dy === 0) continue;
         const nPixel = coordToIndex(x + dx, y + dy);
-        if (set.has(nPixel)) neighbors.push(nPixel);
+        if (set.has(nPixel)) neighbors[i].push(indexMap.get(nPixel));
       }
     }
-    graph.set(pixel, neighbors);
   }
-  return graph;
-}
 
-// Choose a vertex from remaining set with minimum degree
-function chooseStart(remaining, graph) {
-  let best = null;
-  let min = Infinity;
-  for (const v of remaining) {
-    const deg = graph.get(v).filter((n) => remaining.has(n)).length;
-    if (deg < min) {
-      min = deg;
-      best = v;
-    }
-  }
-  return best;
+  const degrees = neighbors.map((nbs) => nbs.length);
+  for (const nbs of neighbors) nbs.sort((a, b) => degrees[a] - degrees[b]);
+
+  return { nodes, neighbors, degrees, indexMap };
 }
 
 // Core solver using backtracking to find minimum path cover
 function solve(pixels, opts = {}) {
-  const graph = buildGraph(pixels);
-  const remaining = new Set(graph.keys());
-  const start = opts.start ?? null;
-  const end = opts.end ?? null;
+  const { nodes, neighbors, degrees, indexMap } = buildGraph(pixels);
+  const total = nodes.length;
 
-  if (start != null && !remaining.has(start)) throw new Error('Start pixel missing');
-  if (end != null && !remaining.has(end)) throw new Error('End pixel missing');
+  const start = opts.start != null ? indexMap.get(opts.start) : null;
+  const end = opts.end != null ? indexMap.get(opts.end) : null;
+
+  if (opts.start != null && start === undefined) throw new Error('Start pixel missing');
+  if (opts.end != null && end === undefined) throw new Error('End pixel missing');
 
   const best = { paths: null };
 
-  function search(rem, acc) {
+  function remove(node) {
+    const oldDeg = degrees[node];
+    degrees[node] = -1;
+    for (const nb of neighbors[node]) if (degrees[nb] >= 0) degrees[nb]--;
+    return oldDeg;
+  }
+
+  function restore(node, oldDeg) {
+    degrees[node] = oldDeg;
+    for (const nb of neighbors[node]) if (degrees[nb] >= 0) degrees[nb]++;
+  }
+
+  function chooseStart() {
+    let bestIdx = -1;
+    let min = Infinity;
+    for (let i = 0; i < degrees.length; i++) {
+      const d = degrees[i];
+      if (d >= 0 && d < min) {
+        min = d;
+        bestIdx = i;
+      }
+    }
+    return bestIdx;
+  }
+
+  function search(activeCount, acc) {
     if (best.paths && acc.length >= best.paths.length) return;
-    if (rem.size === 0) {
+    if (activeCount === 0) {
       best.paths = acc.map((p) => p.slice());
       return;
     }
     const isFirst = acc.length === 0;
-    const startNode = isFirst && start != null ? start : chooseStart(rem, graph);
-    rem.delete(startNode);
-    extend(startNode, [startNode], rem, acc, isFirst);
-    rem.add(startNode);
+    const startNode = isFirst && start != null ? start : chooseStart();
+    const oldDeg = remove(startNode);
+    extend(startNode, [startNode], activeCount - 1, acc, isFirst);
+    restore(startNode, oldDeg);
   }
 
-  function extend(node, path, rem, acc, isFirst) {
+  function extend(node, path, activeCount, acc, isFirst) {
     if (best.paths && acc.length + 1 >= best.paths.length) return;
-    const neighbors = graph
-      .get(node)
-      .filter((n) => rem.has(n))
-      .sort((a, b) =>
-        graph.get(a).filter((m) => rem.has(m)).length -
-        graph.get(b).filter((m) => rem.has(m)).length
-      );
 
-    for (const nb of neighbors) {
-      rem.delete(nb);
+    for (const nb of neighbors[node]) {
+      if (degrees[nb] < 0) continue;
+      const oldDeg = remove(nb);
       path.push(nb);
-      extend(nb, path, rem, acc, isFirst);
+      extend(nb, path, activeCount - 1, acc, isFirst);
       path.pop();
-      rem.add(nb);
+      restore(nb, oldDeg);
     }
 
     if (!isFirst || end == null || node === end) {
       acc.push(path.slice());
-      search(rem, acc);
+      search(activeCount, acc);
       acc.pop();
     }
   }
 
-  search(remaining, []);
-  return best.paths ? best.paths.map((p) => p.slice()) : [];
+  search(total, []);
+  return best.paths ? best.paths.map((p) => p.map((i) => nodes[i])) : [];
 }
 
 export const useHamiltonianService = () => {


### PR DESCRIPTION
## Summary
- precompute neighbor lists and degrees for pixel graph
- maintain degree counters for efficient traversal
- select next start node by scanning degree array

## Testing
- `node --check src/services/hamiltonian.js`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44783ffcc832cb2c4e51b2149adaa