### PR TITLE
Refactor hamiltonian recursion

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -65,27 +65,31 @@ function solve(pixels, opts = {}) {
     return bestIdx;
   }
 
+  const path = [];
+
   function search(activeCount, acc) {
     if (best.paths && acc.length >= best.paths.length) return;
     if (activeCount === 0) {
-      best.paths = acc.map((p) => p.slice());
+      best.paths = acc.slice();
       return;
     }
     const isFirst = acc.length === 0;
     const startNode = isFirst && start != null ? start : chooseStart();
     remove(startNode);
-    extend(startNode, [startNode], activeCount - 1, acc, isFirst);
+    path.push(startNode);
+    extend(startNode, activeCount - 1, acc, isFirst);
+    path.pop();
     restore(startNode);
   }
 
-  function extend(node, path, activeCount, acc, isFirst) {
+  function extend(node, activeCount, acc, isFirst) {
     if (best.paths && acc.length + 1 >= best.paths.length) return;
 
     for (const nb of neighbors[node]) {
       if (!remaining[nb]) continue;
       remove(nb);
       path.push(nb);
-      extend(nb, path, activeCount - 1, acc, isFirst);
+      extend(nb, activeCount - 1, acc, isFirst);
       path.pop();
       restore(nb);
     }


### PR DESCRIPTION
## Summary
- reuse single path array during backtracking
- avoid extra copying when storing best paths

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b44d086d74832c845a5693c544b009