### PR TITLE
refactor: reuse path array in solver

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -48,6 +48,7 @@ function solve(pixels, opts = {}) {
   if (opts.end != null && end === undefined) throw new Error('End pixel missing');
 
   const best = { paths: null };
+  const path = [];
 
   function remove(node) {
     remaining[node] = 0;
@@ -76,24 +77,26 @@ function solve(pixels, opts = {}) {
   function search(activeCount, acc) {
     if (best.paths && acc.length >= best.paths.length) return;
     if (activeCount === 0) {
-      best.paths = acc.map((p) => p.slice());
+      best.paths = acc.slice();
       return;
     }
     const isFirst = acc.length === 0;
     const startNode = isFirst && start != null ? start : chooseStart();
     remove(startNode);
-    extend(startNode, [startNode], activeCount - 1, acc, isFirst);
+    path.push(startNode);
+    extend(startNode, activeCount - 1, acc, isFirst);
+    path.pop();
     restore(startNode);
   }
 
-  function extend(node, path, activeCount, acc, isFirst) {
+  function extend(node, activeCount, acc, isFirst) {
     if (best.paths && acc.length + 1 >= best.paths.length) return;
 
     for (const nb of neighbors[node]) {
       if (!remaining[nb]) continue;
       remove(nb);
       path.push(nb);
-      extend(nb, path, activeCount - 1, acc, isFirst);
+      extend(nb, activeCount - 1, acc, isFirst);
       path.pop();
       restore(nb);
     }


### PR DESCRIPTION
## Summary
- reuse a single path array while traversing the graph
- avoid repeated path copying when storing and returning solutions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4565fe6fc832c95998f56ffaf2555