### PR TITLE
feat: add tiling strategy for hamiltonian solver

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -65,7 +65,10 @@ function getComponents(neighbors) {
 }
 
 // Core solver using backtracking to find minimum path cover
-function solve(pixels, opts = {}) {
+// This function works on a single connected set of pixels and does not
+// perform any tiling optimisation.  It is intentionally kept isolated so
+// that higher level routines can compose the results from multiple tiles.
+function baseSolve(pixels, opts = {}) {
   const { nodes, neighbors, degrees, indexMap } = buildGraph(pixels);
   const total = nodes.length;
   const remaining = new Uint8Array(total);
@@ -137,6 +140,153 @@ function solve(pixels, opts = {}) {
 
   search(total, []);
   return best.paths ? best.paths.map((p) => p.map((i) => nodes[i])) : [];
+}
+
+// -------------------- Tiling helpers --------------------
+
+// Split the graph into two components around a degree-2 vertex.  The
+// function returns two arrays of node indices representing the two sides.
+function splitAroundDegreeTwo(idx, neighbors) {
+  if (neighbors[idx].length !== 2) return null;
+  const [a, b] = neighbors[idx];
+
+  const gather = (start, blocked) => {
+    const stack = [start];
+    const visited = new Set([idx, blocked]);
+    const comp = [];
+    while (stack.length) {
+      const node = stack.pop();
+      comp.push(node);
+      for (const nb of neighbors[node]) {
+        if (!visited.has(nb)) {
+          visited.add(nb);
+          stack.push(nb);
+        }
+      }
+    }
+    return comp;
+  };
+
+  return [gather(a, b), gather(b, a)];
+}
+
+// Combine two sets of paths with the splitting vertex in-between.
+function stitchPaths(pivotPixel, pathsA, pathsB) {
+  const result = [...pathsA, ...pathsB];
+  if (pathsA.length && pathsB.length) {
+    const lastA = result[pathsA.length - 1];
+    const firstB = result[pathsA.length];
+    const combined = [...lastA, pivotPixel, ...firstB];
+    result.splice(pathsA.length - 1, 2, combined);
+  } else if (pathsA.length) {
+    result[pathsA.length - 1].push(pivotPixel);
+  } else if (pathsB.length) {
+    result[0].unshift(pivotPixel);
+  } else {
+    result.push([pivotPixel]);
+  }
+  return result;
+}
+
+// Extract clusters of high degree nodes (>=6).  Each cluster is returned as
+// a Set of node indices containing only vertices of degree >=3.
+function getHighDegreeTiles(neighbors, degrees) {
+  const visited = new Uint8Array(degrees.length);
+  const tiles = [];
+  for (let i = 0; i < degrees.length; i++) {
+    if (visited[i] || degrees[i] < 6) continue;
+    const stack = [i];
+    const tile = new Set();
+    while (stack.length) {
+      const node = stack.pop();
+      if (visited[node]) continue;
+      visited[node] = 1;
+      if (degrees[node] >= 3) tile.add(node);
+      for (const nb of neighbors[node]) {
+        if (degrees[nb] >= 3 && !visited[nb]) stack.push(nb);
+      }
+    }
+    if (tile.size) tiles.push(tile);
+  }
+  return tiles;
+}
+
+// Insert tile paths into the main paths after a boundary vertex.  The tile is
+// given as a Set of node indices.  Both mainPaths and tilePaths contain pixel
+// identifiers (not indices).
+function insertTilePaths(mainPaths, tilePaths, tile, nodes, neighbors) {
+  let boundaryInside = null;
+  let boundaryOutside = null;
+  for (const idx of tile) {
+    for (const nb of neighbors[idx]) {
+      if (!tile.has(nb)) {
+        boundaryInside = nodes[idx];
+        boundaryOutside = nodes[nb];
+        break;
+      }
+    }
+    if (boundaryInside) break;
+  }
+
+  if (boundaryOutside != null) {
+    for (const path of mainPaths) {
+      const pos = path.indexOf(boundaryOutside);
+      if (pos !== -1) {
+        // Merge first tile path directly into the main path
+        if (tilePaths.length) {
+          const first = tilePaths[0];
+          path.splice(pos + 1, 0, ...first);
+          for (let i = 1; i < tilePaths.length; i++) {
+            mainPaths.push(tilePaths[i]);
+          }
+        }
+        return mainPaths;
+      }
+    }
+  }
+
+  // No boundary match, simply append
+  return mainPaths.concat(tilePaths);
+}
+
+// High level solver that performs tiling optimisations before delegating to
+// the core backtracking solver.
+function solve(pixels, opts = {}) {
+  const { nodes, neighbors, degrees } = buildGraph(pixels);
+
+  // Step 1: split on a degree-2 vertex if possible
+  const splitIdx = degrees.findIndex((d) => d === 2);
+  if (splitIdx !== -1) {
+    const parts = splitAroundDegreeTwo(splitIdx, neighbors);
+    if (parts) {
+      const pivotPixel = nodes[splitIdx];
+      const leftPixels = parts[0].map((i) => nodes[i]);
+      const rightPixels = parts[1].map((i) => nodes[i]);
+      const leftPaths = solve(leftPixels, opts);
+      const rightPaths = solve(rightPixels, opts);
+      return stitchPaths(pivotPixel, leftPaths, rightPaths);
+    }
+  }
+
+  // Step 2: group high degree tiles
+  const tiles = getHighDegreeTiles(neighbors, degrees);
+  if (tiles.length) {
+    const used = new Uint8Array(nodes.length);
+    for (const tile of tiles) {
+      for (const idx of tile) used[idx] = 1;
+    }
+    const mainPixels = nodes.filter((_, idx) => !used[idx]);
+    let result = baseSolve(mainPixels, opts);
+    for (const tile of tiles) {
+      const tilePixels = Array.from(tile, (i) => nodes[i]);
+      const tilePaths = baseSolve(tilePixels, opts);
+      result = insertTilePaths(result, tilePaths, tile, nodes, neighbors);
+    }
+    return result;
+  }
+
+  // Fallback to base solver
+  return baseSolve(pixels, opts);
 }
 
 export const useHamiltonianService = () => {


### PR DESCRIPTION
## Summary
- split puzzles at degree-2 vertices and stitch results
- tile adjacent high-degree pixels and merge their paths into the main traverse

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5a5e2f94c832c9614759fc31de202