### PR TITLE
feat: add flip order context option

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,6 +1,12 @@
 <template>
   <ul v-if="visible" class="context-menu" :style="{ left: x + 'px', top: y + 'px' }">
-    <li v-for="(item, i) in items" :key="i" @click="select(item)" class="menu-item">
+    <li
+      v-for="(item, i) in items"
+      :key="i"
+      @click="select(item)"
+      class="menu-item"
+      :class="{ disabled: item.disabled }"
+    >
       {{ item.label }}
     </li>
   </ul>
@@ -14,6 +20,7 @@ const menuStore = useContextMenuStore();
 const { visible, x, y, items } = storeToRefs(menuStore);
 
 function select(item) {
+  if (item.disabled) return;
   menuStore.close();
   item.action && item.action();
 }
@@ -35,5 +42,12 @@ function select(item) {
 }
 .menu-item:hover {
   background: rgba(255, 255, 255, 0.1);
+}
+.menu-item.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.menu-item.disabled:hover {
+  background: transparent;
 }
 </style>

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -273,6 +273,14 @@ function onContextMenu(item, event) {
     if (!nodeTree.selectedIds.includes(item.id)) {
         layerPanel.setRange(item.id, item.id);
     }
+    const selected = nodeTree.selectedIds;
+    let flipEnabled = false;
+    if (selected.length === 1) {
+        flipEnabled = nodes.getProperty(selected[0], 'type') === 'group';
+    } else if (selected.length > 1) {
+        const infos = selected.map(id => nodeTree._findNode(id));
+        if (infos.every(info => info && info.parent === infos[0].parent)) flipEnabled = true;
+    }
     const items = [
         {
             label: 'Group',
@@ -291,6 +299,16 @@ function onContextMenu(item, event) {
                 const ids = layerSvc.copySelected();
                 nodeTree.replaceSelection(ids);
                 layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
+                output.commit();
+            }
+        },
+        {
+            label: 'Flip Order',
+            disabled: !flipEnabled,
+            action: () => {
+                if (!flipEnabled) return;
+                output.setRollbackPoint();
+                layerSvc.flipOrderSelected();
                 output.commit();
             }
         }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -143,12 +143,33 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         return groupIds;
     }
 
+    function flipOrderSelected() {
+        const selected = nodeTree.selectedIds;
+        if (selected.length === 1 && nodes.getProperty(selected[0], 'type') === 'group') {
+            const info = nodeTree._findNode(selected[0]);
+            if (info?.node.children) info.node.children.reverse();
+            return;
+        }
+        if (selected.length < 2) return;
+        const infos = selected.map(id => nodeTree._findNode(id)).filter(Boolean);
+        if (!infos.length) return;
+        const parent = infos[0].parent ?? null;
+        if (!infos.every(info => (info.parent ?? null) === parent)) return;
+        const parentArr = parent ? parent.children : nodeTree._tree;
+        const sorted = infos.slice().sort((a, b) => a.index - b.index);
+        const nodesReversed = sorted.map(info => info.node).reverse();
+        sorted.forEach((info, idx) => {
+            parentArr[info.index] = nodesReversed[idx];
+        });
+    }
+
     return {
         mergeSelected,
         copySelected,
         splitSelected,
         groupSelected,
         ungroupSelected,
+        flipOrderSelected,
     };
 });
 


### PR DESCRIPTION
## Summary
- add flip order action to layer panel context menu
- support disabled state in context menu items

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69044d86c832c8d88f00b09659c32