### PR TITLE
Fix viewport size calculations for fractional device pixel ratios

### DIFF
--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -94,10 +94,10 @@ export const useViewportStore = defineStore('viewport', {
             const paddingBottom = parseFloat(style.paddingBottom) || 0;
             const left = rect.left + paddingLeft;
             const top = rect.top + paddingTop;
-            const right = rect.right - paddingRight;
-            const bottom = rect.bottom - paddingBottom;
-            const width = (this._element.clientWidth || 0) - paddingLeft - paddingRight;
-            const height = (this._element.clientHeight || 0) - paddingTop - paddingBottom;
+            const width = rect.width - paddingLeft - paddingRight;
+            const height = rect.height - paddingTop - paddingBottom;
+            const right = left + width;
+            const bottom = top + height;
             this._content = { top, right, bottom, left, width, height };
             const containScale = Math.min(
                 width / Math.max(1, this._stage.width),


### PR DESCRIPTION
## Summary
- use bounding rectangle dimensions when recalculating viewport content size
- ensure stage centering and clientToIndex work correctly on fractional `devicePixelRatio`

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6921d2ea0832c900e40fec5220e02