### PR TITLE
fix: prevent stage clipping on high DPI

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -10,8 +10,9 @@
          :style="{
            width: stage.width+'px',
            height: stage.height+'px',
-           transform: `translate(${stage.offset.x}px, ${stage.offset.y}px) scale(${stage.scale})`,
-           transformOrigin: 'top left'
+           transform: `translate3d(${stage.offset.x}px, ${stage.offset.y}px, 0) scale(${stage.scale})`,
+           transformOrigin: 'top left',
+           willChange: 'transform'
          }"
          @contextmenu.prevent>
       <!-- 체커보드 -->


### PR DESCRIPTION
## Summary
- ensure stage transform uses GPU-accelerated translate3d to avoid devicePixelRatio cropping
- hint browser with will-change to maintain smooth transforms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69399955c832c87d4547b89aab036