### PR TITLE
fix: adjust stage size for device pixel ratio

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -7,13 +7,7 @@
        @pointerup="viewportEvents.setPointerUp"
        @pointercancel="viewportEvents.setPointerUp">
     <div id="stage" class="absolute select-none touch-none"
-         :style="{
-           width: stage.width+'px',
-           height: stage.height+'px',
-           transform: `translate3d(${stage.offset.x}px, ${stage.offset.y}px, 0) scale(${stage.scale})`,
-           transformOrigin: 'top left',
-           willChange: 'transform'
-         }"
+         :style="stageStyle"
          @contextmenu.prevent>
       <!-- 체커보드 -->
       <svg class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
@@ -81,6 +75,19 @@ const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = useTemplateRef('viewportEl');
 const stage = viewportStore.stage;
 const image = viewportStore.imageRect;
+const dpr = window.devicePixelRatio || 1;
+
+const stageStyle = computed(() => {
+    const width = stage.width / dpr;
+    const height = stage.height / dpr;
+    return {
+        width: width + 'px',
+        height: height + 'px',
+        transform: `translate3d(${stage.offset.x}px, ${stage.offset.y}px, 0) scale(${stage.scale * dpr})`,
+        transformOrigin: 'top left',
+        willChange: 'transform'
+    };
+});
 
 const viewportViewBox = computed(() => `0 0 ${viewportStore.content.width} ${viewportStore.content.height}`);
 const marqueeRect = computed(() => {


### PR DESCRIPTION
## Summary
- prevent stage from being clipped when width/height times devicePixelRatio produce fractional pixels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b696fff090832caf895966dfb0abb1