### PR TITLE
Simplify pixel directions and handle cycling in path tool

### DIFF
--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -1,13 +1,13 @@
 import { defineStore } from 'pinia';
 import { coordToIndex, indexToCoord, pixelsToUnionPath, groupConnectedPixels } from '../utils';
 
-export const PIXEL_KINDS = ['bltl', 'brtr', 'tltr', 'blbr', 'tlbl', 'trbr', 'trtl', 'brbl'];
-const DEFAULT_KIND = PIXEL_KINDS[0];
+export const PIXEL_DIRECTIONS = ['none', 'vertical', 'horizontal'];
+const DEFAULT_DIRECTION = PIXEL_DIRECTIONS[0];
 
 function unionSet(state, id) {
     const merged = new Set();
-    for (const kind of PIXEL_KINDS) {
-        const set = state[kind][id];
+    for (const direction of PIXEL_DIRECTIONS) {
+        const set = state[direction][id];
         if (!set) continue;
         for (const pixel of set) merged.add(pixel);
     }
@@ -16,14 +16,9 @@ function unionSet(state, id) {
 
 export const usePixelStore = defineStore('pixels', {
     state: () => ({
-        'bltl': {},
-        'brtr': {},
-        'tltr': {},
-        'blbr': {},
-        'tlbl': {},
-        'trbr': {},
-        'trtl': {},
-        'brbl': {}
+        'none': {},
+        'vertical': {},
+        'horizontal': {}
     }),
     getters: {
         get: (state) => (id) => {
@@ -48,8 +43,8 @@ export const usePixelStore = defineStore('pixels', {
             };
         },
         has: (state) => (id, pixel) => {
-            for (const kind of PIXEL_KINDS) {
-                const set = state[kind][id];
+            for (const direction of PIXEL_DIRECTIONS) {
+                const set = state[direction][id];
                 if (set && set.has(pixel)) return true;
             }
             return false;
@@ -57,88 +52,68 @@ export const usePixelStore = defineStore('pixels', {
     },
     actions: {
         set(id, pixels = []) {
-            for (const kind of PIXEL_KINDS) delete this[kind][id];
-            this[DEFAULT_KIND][id] = new Set(pixels);
+            for (const direction of PIXEL_DIRECTIONS) delete this[direction][id];
+            this[DEFAULT_DIRECTION][id] = new Set(pixels);
         },
         remove(ids = []) {
             for (const id of ids) {
-                for (const kind of PIXEL_KINDS) delete this[kind][id];
+                for (const direction of PIXEL_DIRECTIONS) delete this[direction][id];
             }
         },
-        addPixels(id, pixels, kind = DEFAULT_KIND) {
-            if (!this[kind][id]) this[kind][id] = new Set();
+        addPixels(id, pixels, direction = DEFAULT_DIRECTION) {
+            if (!this[direction][id]) this[direction][id] = new Set();
             for (const pixel of pixels) {
-                for (const kind of PIXEL_KINDS) this[kind][id]?.delete(pixel);
-                this[kind][id].add(pixel);
+                for (const dir of PIXEL_DIRECTIONS) this[dir][id]?.delete(pixel);
+                this[direction][id].add(pixel);
             }
         },
         removePixels(id, pixels) {
-            for (const kind of PIXEL_KINDS) {
-                const set = this[kind][id];
+            for (const direction of PIXEL_DIRECTIONS) {
+                const set = this[direction][id];
                 if (!set) continue;
                 for (const pixel of pixels) set.delete(pixel);
             }
         },
-        cycleKind(id, pixel) {
-            const idx = PIXEL_KINDS.findIndex(k => this[k][id]?.has(pixel));
-            if (idx >= 0) {
-                const current = PIXEL_KINDS[idx];
-                this[current][id].delete(pixel);
-                const next = PIXEL_KINDS[(idx + 1) % PIXEL_KINDS.length];
-                if (!this[next][id]) this[next][id] = new Set();
-                this[next][id].add(pixel);
-            }
-            else {
-                const target = this[DEFAULT_KIND][id];
-                if (target) target.add(pixel);
-            }
-        },
-        changeKind(id, pixel, kind) {
-            switch (kind) {
-                case 'up': kind = 'bltl'; break;
-                case 'right': kind = 'tltr'; break;
-                case 'down': kind = 'tlbl'; break;
-                case 'left': kind = 'trtl'; break;
-            }
-            const idx = PIXEL_KINDS.findIndex(k => this[k][id]?.has(pixel));
+        setDirection(id, pixel, direction) {
+            const idx = PIXEL_DIRECTIONS.findIndex(k => this[k][id]?.has(pixel));
             if (idx === -1) return;
-            const current = PIXEL_KINDS[idx];
+            const current = PIXEL_DIRECTIONS[idx];
             this[current][id].delete(pixel);
-            if (!this[kind][id]) this[kind][id] = new Set();
-            this[kind][id].add(pixel);
+            if (!this[direction][id]) this[direction][id] = new Set();
+            this[direction][id].add(pixel);
         },
         togglePixel(id, pixel) {
-            for (const kind of PIXEL_KINDS) {
-                const set = this[kind][id];
+            for (const direction of PIXEL_DIRECTIONS) {
+                const set = this[direction][id];
                 if (set && set.has(pixel)) {
                     set.delete(pixel);
                     return;
                 }
             }
-            const target = this[DEFAULT_KIND][id];
+            const target = this[DEFAULT_DIRECTION][id];
             if (target) target.add(pixel);
         },
         translateAll(dx = 0, dy = 0) {
             dx |= 0; dy |= 0;
             if (dx === 0 && dy === 0) return;
-            for (const kind of PIXEL_KINDS) {
-                const ids = Object.keys(this[kind]);
+            for (const direction of PIXEL_DIRECTIONS) {
+                const ids = Object.keys(this[direction]);
                 for (const id of ids) {
-                    const set = this[kind][id];
+                    const set = this[direction][id];
                     const moved = new Set();
                     for (const pixel of set) {
                         const [x, y] = indexToCoord(pixel);
                         moved.add(coordToIndex(x + dx, y + dy));
                     }
-                    this[kind][id] = moved;
+                    this[direction][id] = moved;
                 }
             }
         },
         serialize() {
             const result = {};
             const ids = new Set();
-            for (const kind of PIXEL_KINDS) {
-                for (const id of Object.keys(this[kind])) ids.add(id);
+            for (const direction of PIXEL_DIRECTIONS) {
+                for (const id of Object.keys(this[direction])) ids.add(id);
             }
             for (const id of ids) {
                 result[id] = [...unionSet(this, id)];
@@ -146,9 +121,9 @@ export const usePixelStore = defineStore('pixels', {
             return result;
         },
         applySerialized(byId = {}) {
-            for (const kind of PIXEL_KINDS) this[kind] = {};
+            for (const direction of PIXEL_DIRECTIONS) this[direction] = {};
             for (const id of Object.keys(byId)) {
-                this[DEFAULT_KIND][id] = new Set(byId[id]);
+                this[DEFAULT_DIRECTION][id] = new Set(byId[id]);
             }
         }
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -64,8 +64,8 @@ export function ensureCheckerboardPattern(target = document.body) {
     return id;
 }
 
-export function ensurePathPattern(kind, target = document.body) {
-    const id = `pixel-kind-${kind}`;
+export function ensurePathPattern(direction, target = document.body) {
+    const id = `pixel-direction-${direction}`;
     if (document.getElementById(id)) return id;
     const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
     svg.setAttribute('width', '0');
@@ -78,70 +78,24 @@ export function ensurePathPattern(kind, target = document.body) {
     pattern.setAttribute('width', '1');
     pattern.setAttribute('height', '1');
     pattern.setAttribute('patternUnits', 'userSpaceOnUse');
-
-    const cornerSize = 0.1;
-    const cornerPos = {
-        tl: [0, 0],
-        tr: [1 - cornerSize, 0],
-        bl: [0, 1 - cornerSize],
-        br: [1 - cornerSize, 1 - cornerSize]
-    };
-    const opposite = { tl: 'br', tr: 'bl', bl: 'tr', br: 'tl' };
-    const directions = {
-        tltr: 'right',
-        tlbl: 'down',
-        trtl: 'left',
-        trbr: 'down',
-        bltl: 'up',
-        blbr: 'right',
-        brtr: 'up',
-        brbl: 'left'
-    };
-    const arrowPath = {
-        right: 'M.6.7.8.5.6.3M.8.5H.2',
-        left: 'M.4.3.2.5.4.7M.2.5H.8',
-        down: 'M.3.6.5.8.7.6M.5.8V.2',
-        up: 'M.7.4.5.2.3.4M.5.2V.8'
-    };
-
-    const start = cornerPos[kind.slice(0, 2)];
-    const end = cornerPos[opposite[kind.slice(0, 2)]];
-    const direction = directions[kind];
-
-    const s = document.createElementNS(SVG_NAMESPACE, 'rect');
-    s.setAttribute('x', String(start[0]));
-    s.setAttribute('y', String(start[1]));
-    s.setAttribute('width', String(cornerSize));
-    s.setAttribute('height', String(cornerSize));
-    s.setAttribute('fill', '#00ff00');
-    s.setAttribute('stroke-width', String(cornerSize / 15));
-    s.setAttribute('stroke', '#000000');
-
-    const e = document.createElementNS(SVG_NAMESPACE, 'rect');
-    e.setAttribute('x', String(end[0]));
-    e.setAttribute('y', String(end[1]));
-    e.setAttribute('width', String(cornerSize));
-    e.setAttribute('height', String(cornerSize));
-    e.setAttribute('fill', '#ff0000');
-    e.setAttribute('stroke-width', String(cornerSize / 15));
-    e.setAttribute('stroke', '#000000');
-
-    const ba = document.createElementNS(SVG_NAMESPACE, 'path');
-    ba.setAttribute('d', arrowPath[direction]);
-    ba.setAttribute('stroke-width', String(cornerSize / 1.5));
-    ba.setAttribute('fill', 'none');
-    ba.setAttribute('stroke', '#000000');
-
-    const a = document.createElementNS(SVG_NAMESPACE, 'path');
-    a.setAttribute('d', arrowPath[direction]);
-    a.setAttribute('stroke-width', String(cornerSize / 2));
-    a.setAttribute('fill', 'none');
-    a.setAttribute('stroke', '#ffffff');
-
-    pattern.appendChild(s);
-    pattern.appendChild(e);
-    pattern.appendChild(ba);
-    pattern.appendChild(a);
+    if (direction === 'vertical' || direction === 'horizontal') {
+        const line = document.createElementNS(SVG_NAMESPACE, 'line');
+        if (direction === 'vertical') {
+            line.setAttribute('x1', '.5');
+            line.setAttribute('y1', '0');
+            line.setAttribute('x2', '.5');
+            line.setAttribute('y2', '1');
+        }
+        else {
+            line.setAttribute('x1', '0');
+            line.setAttribute('y1', '.5');
+            line.setAttribute('x2', '1');
+            line.setAttribute('y2', '.5');
+        }
+        line.setAttribute('stroke', '#000000');
+        line.setAttribute('stroke-width', '.1');
+        pattern.appendChild(line);
+    }
     defs.appendChild(pattern);
     svg.appendChild(defs);
     target.appendChild(svg);


### PR DESCRIPTION
## Summary
- rename pixel *kind* terminology to *direction* and adjust store API
- cycle and update directions directly in path tool service
- draw directional path patterns for vertical and horizontal segments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6a186ec88832cb74f4d3a279c3556