### PR TITLE
feat: add checkerboard default direction

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,12 +29,14 @@
       </aside>
     </div>
     <StageResizePopup />
+    <ImageLoadPopup />
     <ContextMenu />
 </template>
 
 <script setup>
 import { onMounted, ref, computed, onUnmounted } from 'vue';
 import { useStore } from './stores';
+import { useService } from './services';
 
 import Viewport from './components/Viewport.vue';
 import ViewportInfo from './components/ViewportInfo.vue';
@@ -43,8 +45,10 @@ import LayersPanel from './components/LayersPanel.vue';
 import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
+import ImageLoadPopup from './components/ImageLoadPopup.vue';
 import ContextMenu from './components/ContextMenu.vue';
 const { input } = useStore();
+const { imageLoad: imageLoadService } = useService();
 
 // Width control between display and layers
 const container = ref(null);
@@ -76,7 +80,7 @@ onMounted(async () => {
     await input.loadFromQuery();
   } catch {}
   if (input.isLoaded) {
-    input.initialize();
+    imageLoadService.open();
   }
   window.addEventListener('mousemove', onDrag);
   window.addEventListener('mouseup', stopDrag);

--- a/src/components/ImageLoadPopup.vue
+++ b/src/components/ImageLoadPopup.vue
@@ -1,0 +1,47 @@
+<template>
+  <div v-if="imageLoadService.show" class="fixed inset-0 flex items-center justify-center bg-black/50">
+    <div class="bg-slate-800 p-6 rounded-lg text-xs space-y-4 w-64">
+      <div class="space-y-2 text-white/70">
+        <label class="block">
+          <span>Default Direction</span>
+          <select v-model="direction" class="mt-1 w-full rounded bg-slate-700 px-2 py-1">
+            <option v-for="dir in directions" :key="dir" :value="dir">{{ dir }}</option>
+          </select>
+        </label>
+        <label class="flex items-center gap-2">
+          <input type="checkbox" v-model="initialize" class="rounded bg-slate-700" />
+          <span>Initialize Layers</span>
+        </label>
+        <label v-if="initialize" class="block">
+          <span>Segment Tolerance</span>
+          <input type="number" v-model.number="tolerance" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+        </label>
+      </div>
+      <div class="flex justify-end gap-2">
+        <button @click="cancel" class="px-2 py-1 rounded bg-white/5 hover:bg-white/10">Cancel</button>
+        <button @click="apply" class="px-2 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white">Apply</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useService } from '../services';
+import { PIXEL_DEFAULT_DIRECTIONS } from '@/stores/pixels';
+
+const { imageLoad: imageLoadService } = useService();
+
+const directions = PIXEL_DEFAULT_DIRECTIONS;
+const direction = ref(directions[0]);
+const initialize = ref(true);
+const tolerance = ref(40);
+
+function apply() {
+  imageLoadService.apply({ direction: direction.value, initialize: initialize.value, tolerance: tolerance.value });
+}
+
+function cancel() {
+  imageLoadService.cancel();
+}
+</script>

--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -54,7 +54,7 @@ import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, TOOL_MODIFIERS } from '@
 import stageIcons from '../image/stage_toolbar';
 
 const { viewport: viewportStore, nodeTree, input, output, keyboardEvent: keyboardEvents } = useStore();
-const { toolSelection: toolSelectionService, stageResize: stageResizeService } = useService();
+const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService } = useService();
 
 const fileInput = ref(null);
 function openFileDialog() {
@@ -64,7 +64,7 @@ async function onFileChange(e) {
   const file = e.target.files?.[0];
   if (!file) return;
   await input.loadFile(file);
-  input.initialize();
+  imageLoadService.open();
   e.target.value = '';
 }
 

--- a/src/services/imageLoad.js
+++ b/src/services/imageLoad.js
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useStore } from '../stores';
+
+export const useImageLoadService = defineStore('imageLoadService', () => {
+  const show = ref(false);
+  const { input, pixels } = useStore();
+
+  function open() {
+    show.value = true;
+  }
+
+  function close() {
+    show.value = false;
+  }
+
+  function cancel() {
+    input.clear();
+    close();
+  }
+
+  function apply({ direction, initialize, tolerance }) {
+    pixels.setDefaultDirection(direction);
+    input.initialize({ initializeLayers: initialize, segmentTolerance: tolerance });
+    close();
+  }
+
+  return { show, open, close, apply, cancel };
+});

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,6 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
+import { useImageLoadService } from './imageLoad';
 
 export {
     useLayerPanelService,
@@ -24,7 +25,8 @@ export {
     useToolSelectionService,
     useViewportService,
     useStageResizeService,
-    useHamiltonianService
+    useHamiltonianService,
+    useImageLoadService
 };
 
 export const useService = () => ({
@@ -45,5 +47,6 @@ export const useService = () => ({
     toolSelection: useToolSelectionService(),
     viewport: useViewportService(),
     stageResize: useStageResizeService(),
-    hamiltonian: useHamiltonianService()
+    hamiltonian: useHamiltonianService(),
+    imageLoad: useImageLoadService()
 });

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -59,25 +59,30 @@ export const useInputStore = defineStore('input', {
         async loadFromQuery() {
             await this.load(new URL(location.href).searchParams.get('pixel'));
         },
-        initialize() {
+        initialize({ initializeLayers = true, segmentTolerance = 40 } = {}) {
             const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore } = useStore();
             const layerPanel = useLayerPanelService();
             viewportStore.setSize(this.width, this.height);
             viewportStore.setImage(this.src || '', this.width, this.height);
-            const autoSegments = this.segment(40);
-            if (autoSegments.length) {
-                const ids = [];
-                for (let i = 0; i < autoSegments.length; i++) {
-                    const segment = autoSegments[i];
-                    const id = nodes.createLayer({
-                        name: `Auto ${i + 1}`,
-                        color: segment.colorU32,
-                        visibility: true
-                    });
-                    if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
-                    ids.push(id);
+            if (initializeLayers) {
+                const autoSegments = this.segment(segmentTolerance);
+                if (autoSegments.length) {
+                    const ids = [];
+                    for (let i = 0; i < autoSegments.length; i++) {
+                        const segment = autoSegments[i];
+                        const id = nodes.createLayer({
+                            name: `Auto ${i + 1}`,
+                            color: segment.colorU32,
+                            visibility: true
+                        });
+                        if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
+                        ids.push(id);
+                    }
+                    nodeTree.insert(ids);
+                } else {
+                    const ids = [nodes.createLayer({}), nodes.createLayer({})];
+                    nodeTree.insert(ids);
                 }
-                nodeTree.insert(ids);
             } else {
                 const ids = [nodes.createLayer({}), nodes.createLayer({})];
                 nodeTree.insert(ids);


### PR DESCRIPTION
## Summary
- allow checkerboard as a default pixel direction
- split added pixels into horizontal or vertical sets based on position
- expose checkerboard choice in image load popup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b4efdda8832ca9e16b48d100f687