### PR TITLE
feat: add settings popup and persist preferences

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,7 @@
     </div>
     <StageResizePopup />
     <ImageLoadPopup />
+    <SettingsPopup />
     <ContextMenu />
 </template>
 
@@ -46,6 +47,7 @@ import ExportPanel from './components/ExportPanel.vue';
 import ViewportToolbar from './components/ViewportToolbar.vue';
 import StageResizePopup from './components/StageResizePopup.vue';
 import ImageLoadPopup from './components/ImageLoadPopup.vue';
+import SettingsPopup from './components/SettingsPopup.vue';
 import ContextMenu from './components/ContextMenu.vue';
 const { input } = useStore();
 const { imageLoad: imageLoadService } = useService();

--- a/src/components/ImageLoadPopup.vue
+++ b/src/components/ImageLoadPopup.vue
@@ -2,19 +2,13 @@
   <div v-if="imageLoadService.show" class="fixed inset-0 flex items-center justify-center bg-black/50">
     <div class="bg-slate-800 p-6 rounded-lg text-xs space-y-4 w-64">
       <div class="space-y-2 text-white/70">
-        <label class="block">
-          <span>Default Direction</span>
-          <select v-model="direction" class="mt-1 w-full rounded bg-slate-700 px-2 py-1">
-            <option v-for="dir in directions" :key="dir" :value="dir">{{ dir }}</option>
-          </select>
-        </label>
         <label class="flex items-center gap-2">
-          <input type="checkbox" v-model="initialize" class="rounded bg-slate-700" />
+          <input type="checkbox" v-model="imageLoadService.initialize" class="rounded bg-slate-700" />
           <span>Initialize Layers</span>
         </label>
-        <label v-if="initialize" class="block">
+        <label class="block">
           <span>Segment Tolerance</span>
-          <input type="number" v-model.number="tolerance" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          <input type="number" v-model.number="imageLoadService.tolerance" :disabled="!imageLoadService.initialize" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
         </label>
       </div>
       <div class="flex justify-end gap-2">
@@ -26,19 +20,12 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
 import { useService } from '../services';
-import { PIXEL_DEFAULT_DIRECTIONS } from '@/stores/pixels';
 
 const { imageLoad: imageLoadService } = useService();
 
-const directions = PIXEL_DEFAULT_DIRECTIONS;
-const direction = ref(directions[0]);
-const initialize = ref(true);
-const tolerance = ref(40);
-
 function apply() {
-  imageLoadService.apply({ direction: direction.value, initialize: initialize.value, tolerance: tolerance.value });
+  imageLoadService.apply();
 }
 
 function cancel() {

--- a/src/components/SettingsPopup.vue
+++ b/src/components/SettingsPopup.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="settingsService.show" class="fixed inset-0 flex items-center justify-center bg-black/50">
+    <div class="bg-slate-800 p-6 rounded-lg text-xs w-72 space-y-4">
+      <div>
+        <div class="flex border-b border-white/20 mb-2">
+          <button v-for="tab in tabs" :key="tab" @click="currentTab = tab"
+                  :class="['px-2 py-1', currentTab === tab ? 'bg-slate-700 text-white' : 'text-white/70']">{{ tab }}</button>
+        </div>
+        <div v-if="currentTab === 'Pixels'" class="space-y-2 text-white/70">
+          <label class="block">
+            <span>Default Direction</span>
+            <select v-model="defaultDirection" class="mt-1 w-full rounded bg-slate-700 px-2 py-1">
+              <option v-for="dir in directions" :key="dir" :value="dir">{{ dir }}</option>
+            </select>
+          </label>
+        </div>
+        <div v-else-if="currentTab === 'Stage'" class="space-y-2 text-white/70">
+          <label class="block">
+            <span>Checkerboard Repeat</span>
+            <input type="number" min="1" v-model.number="checkerboardRepeat" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          </label>
+        </div>
+      </div>
+      <div class="flex justify-end gap-2">
+        <button @click="settingsService.close" class="px-2 py-1 rounded bg-white/5 hover:bg-white/10">Close</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { useService } from '../services';
+import { usePixelStore, PIXEL_DEFAULT_DIRECTIONS } from '@/stores/pixels';
+import { CHECKERBOARD_CONFIG } from '@/constants';
+import { ensureCheckerboardPattern } from '@/utils';
+
+const { settings: settingsService } = useService();
+const pixelStore = usePixelStore();
+
+const tabs = ['Pixels', 'Stage'];
+const currentTab = ref(tabs[0]);
+
+const directions = PIXEL_DEFAULT_DIRECTIONS;
+const defaultDirection = ref(pixelStore.defaultDirection);
+watch(defaultDirection, dir => pixelStore.setDefaultDirection(dir));
+
+const checkerboardRepeat = ref(CHECKERBOARD_CONFIG.REPEAT);
+watch(checkerboardRepeat, repeat => {
+  CHECKERBOARD_CONFIG.REPEAT = repeat;
+  localStorage.setItem('settings.checkerboardRepeat', String(repeat));
+  const patternEl = document.getElementById(CHECKERBOARD_CONFIG.PATTERN_ID);
+  patternEl?.parentNode?.parentNode?.remove();
+  ensureCheckerboardPattern(document.body);
+});
+</script>

--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -7,6 +7,9 @@
       <button @click="stageResizeService.open" title="Resize Canvas" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
         <img :src="stageIcons.resize" alt="resize" class="w-4 h-4">
       </button>
+      <button @click="settingsService.open" title="Settings" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+        <img :src="stageIcons.settings" alt="settings" class="w-4 h-4">
+      </button>
 
       <div class="h-4 w-px bg-white/10 mx-1"></div>
 
@@ -54,7 +57,7 @@ import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, TOOL_MODIFIERS } from '@
 import stageIcons from '../image/stage_toolbar';
 
 const { viewport: viewportStore, nodeTree, input, output, keyboardEvent: keyboardEvents } = useStore();
-const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService } = useService();
+const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService, settings: settingsService } = useService();
 
 const fileInput = ref(null);
 function openFileDialog() {

--- a/src/constants/stage.js
+++ b/src/constants/stage.js
@@ -6,5 +6,5 @@ export const CHECKERBOARD_CONFIG = {
     PATTERN_ID: 'chk',
     COLOR_A: '#0a1f33',
     COLOR_B: '#0c2742',
-    REPEAT: 1,
+    REPEAT: Number(localStorage.getItem('settings.checkerboardRepeat')) || 1,
 };

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -10,6 +10,7 @@ import resize from './resize.svg';
 import undo from './undo.svg';
 import redo from './redo.svg';
 import path from './path.svg';
+import settings from './settings.svg';
 
 export default {
   stroke,
@@ -24,4 +25,5 @@ export default {
   resize,
   undo,
   redo,
+  settings,
 };

--- a/src/services/imageLoad.js
+++ b/src/services/imageLoad.js
@@ -1,10 +1,15 @@
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { useStore } from '../stores';
 
 export const useImageLoadService = defineStore('imageLoadService', () => {
   const show = ref(false);
-  const { input, pixels } = useStore();
+  const { input } = useStore();
+  const initialize = ref(localStorage.getItem('imageLoad.initialize') !== 'false');
+  const tolerance = ref(Number(localStorage.getItem('imageLoad.tolerance')) || 40);
+
+  watch(initialize, v => localStorage.setItem('imageLoad.initialize', v));
+  watch(tolerance, v => localStorage.setItem('imageLoad.tolerance', v));
 
   function open() {
     show.value = true;
@@ -19,11 +24,10 @@ export const useImageLoadService = defineStore('imageLoadService', () => {
     close();
   }
 
-  function apply({ direction, initialize, tolerance }) {
-    pixels.setDefaultDirection(direction);
-    input.initialize({ initializeLayers: initialize, segmentTolerance: tolerance });
+  function apply() {
+    input.initialize({ initializeLayers: initialize.value, segmentTolerance: tolerance.value });
     close();
   }
 
-  return { show, open, close, apply, cancel };
+  return { show, open, close, apply, cancel, initialize, tolerance };
 });

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -8,6 +8,7 @@ import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
 import { useImageLoadService } from './imageLoad';
+import { useSettingsService } from './settings';
 
 export {
     useLayerPanelService,
@@ -26,7 +27,8 @@ export {
     useViewportService,
     useStageResizeService,
     useHamiltonianService,
-    useImageLoadService
+    useImageLoadService,
+    useSettingsService
 };
 
 export const useService = () => ({
@@ -48,5 +50,6 @@ export const useService = () => ({
     viewport: useViewportService(),
     stageResize: useStageResizeService(),
     hamiltonian: useHamiltonianService(),
-    imageLoad: useImageLoadService()
+    imageLoad: useImageLoadService(),
+    settings: useSettingsService()
 });

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -1,0 +1,9 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useSettingsService = defineStore('settingsService', () => {
+  const show = ref(false);
+  function open() { show.value = true; }
+  function close() { show.value = false; }
+  return { show, open, close };
+});

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -19,7 +19,7 @@ export const usePixelStore = defineStore('pixels', {
         'none': {},
         'vertical': {},
         'horizontal': {},
-        defaultDirection: PIXEL_DEFAULT_DIRECTIONS[0]
+        defaultDirection: localStorage.getItem('settings.defaultDirection') || PIXEL_DEFAULT_DIRECTIONS[0]
     }),
     getters: {
         get: (state) => (id) => {
@@ -149,7 +149,10 @@ export const usePixelStore = defineStore('pixels', {
             }
         },
         setDefaultDirection(direction) {
-            if (PIXEL_DEFAULT_DIRECTIONS.includes(direction)) this.defaultDirection = direction;
+            if (PIXEL_DEFAULT_DIRECTIONS.includes(direction)) {
+                this.defaultDirection = direction;
+                localStorage.setItem('settings.defaultDirection', direction);
+            }
         }
     }
 });


### PR DESCRIPTION
## Summary
- add settings popup accessed from toolbar with pixel and stage tabs
- move default direction setting and add checkerboard repeat
- persist image load and settings options via local storage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6c558179c832c82f47368be762390