### PR TITLE
Enable copying of selected nodes above originals

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -6,8 +6,8 @@
         <button @click="onAddGroup" title="Add group" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img :src="toolbarIcons.group" alt="Add group" class="w-4 h-4">
         </button>
-        <button @click="onCopy" :disabled="!nodeTree.layerSelectionExists" title="Copy layer" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
-          <img :src="toolbarIcons.copy" alt="Copy layer" class="w-4 h-4">
+        <button @click="onCopy" :disabled="nodeTree.selectedNodeCount === 0" title="Copy" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
+          <img :src="toolbarIcons.copy" alt="Copy" class="w-4 h-4">
         </button>
         <button @click="onMerge" :disabled="nodes.selectedLayerCount < 2" title="Merge layers" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed">
           <img :src="toolbarIcons.merge" alt="Merge layers" class="w-4 h-4">


### PR DESCRIPTION
## Summary
- Allow copy action to duplicate any selected node, including groups
- Insert each copied node directly above its original
- Enable toolbar copy button whenever any node is selected

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6c9cf4c44832c8eb27b72a151f89f