### PR TITLE
Fold groups by default during image layer initialization

### DIFF
--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -87,6 +87,7 @@ export const useInputStore = defineStore('input', {
                                 visibility: true
                             });
                             topIds.push(groupId);
+                            layerPanel.folded[groupId] = true;
                             const layerIds = [];
                             for (const segment of segments) {
                                 const layerId = nodes.createLayer({


### PR DESCRIPTION
## Summary
- Fold groups automatically when generating layers from an image, so newly created groups start collapsed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6ce474e74832c879b9f1bc9f0d195