### PR TITLE
Refactor path tool naming to direction and repurpose Hamilton tool

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -7,11 +7,7 @@
       <button @click="stageResizeService.open" title="Resize Canvas" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
         <img :src="stageIcons.resize" alt="resize" class="w-4 h-4">
       </button>
-      <button @click="settingsService.open" title="Settings" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
-        <img :src="stageIcons.settings" alt="settings" class="w-4 h-4">
-      </button>
-
-      <div class="h-4 w-px bg-white/10 mx-1"></div>
+        <div class="h-4 w-px bg-white/10 mx-1"></div>
 
       <!-- Shape toggle -->
       <div class="inline-flex rounded-md overflow-hidden border border-white/15">
@@ -43,11 +39,14 @@
       <button @click="output.undo" title="Undo" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
         <img :src="stageIcons.undo" alt="Undo" class="w-4 h-4">
       </button>
-      <button @click="output.redo" title="Redo" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
-        <img :src="stageIcons.redo" alt="Redo" class="w-4 h-4">
-      </button>
-    </div>
-  </template>
+        <button @click="output.redo" title="Redo" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+          <img :src="stageIcons.redo" alt="Redo" class="w-4 h-4">
+        </button>
+        <button @click="settingsService.open" title="Settings" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+          <img :src="stageIcons.settings" alt="settings" class="w-4 h-4">
+        </button>
+      </div>
+    </template>
 
 <script setup>
 import { ref, watch } from 'vue';

--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -5,13 +5,13 @@ export const SINGLE_SELECTION_TOOLS = [
   { type: 'erase', name: 'Erase', icon: stageIcons.erase },
   { type: 'cut', name: 'Cut', icon: stageIcons.cut },
   { type: 'top', name: 'To Top', icon: stageIcons.top },
-  { type: 'hamStart', name: 'Hamilton', label: 'H' },
+  { type: 'path', name: 'Path', icon: stageIcons.path },
 ];
 
 export const MULTI_SELECTION_TOOLS = [
   { type: 'select', name: 'Select', icon: stageIcons.select },
   { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
-  { type: 'path', name: 'Path', icon: stageIcons.path },
+  { type: 'direction', name: 'Direction', icon: stageIcons.direction },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -10,6 +10,7 @@ import resize from './resize.svg';
 import undo from './undo.svg';
 import redo from './redo.svg';
 import path from './path.svg';
+import direction from './direction.svg';
 import settings from './settings.svg';
 
 export default {
@@ -22,6 +23,7 @@ export default {
   globalErase,
   top,
   path,
+  direction,
   resize,
   undo,
   redo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,7 +2,7 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
-import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, usePathToolService, useHamStartToolService } from './tools';
+import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, useDirectionToolService, usePathToolService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
@@ -19,10 +19,10 @@ export {
     useDrawToolService,
     useEraseToolService,
     useTopToolService,
+    useDirectionToolService,
     usePathToolService,
     useGlobalEraseToolService,
     useCutToolService,
-    useHamStartToolService,
     useToolSelectionService,
     useViewportService,
     useStageResizeService,
@@ -41,10 +41,10 @@ export const useService = () => ({
         draw: useDrawToolService(),
         erase: useEraseToolService(),
         globalErase: useGlobalEraseToolService(),
-        path: usePathToolService(),
+        direction: useDirectionToolService(),
         cut: useCutToolService(),
         top: useTopToolService(),
-        hamStart: useHamStartToolService(),
+        path: usePathToolService(),
     },
     toolSelection: useToolSelectionService(),
     viewport: useViewportService(),

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -7,7 +7,7 @@ import { useLayerQueryService } from './layerQuery';
 import { useHamiltonianService } from './hamiltonian';
 import { useStore } from '../stores';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
-import { indexToCoord, ensurePathPattern } from '../utils';
+import { indexToCoord, ensureDirectionPattern } from '../utils';
 import { PIXEL_DIRECTIONS } from '../stores/pixels';
 
 export const useDrawToolService = defineStore('drawToolService', () => {
@@ -206,19 +206,19 @@ export const useTopToolService = defineStore('topToolService', () => {
     return {};
 });
 
-export const useHamStartToolService = defineStore('hamStartToolService', () => {
+export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
     const hamiltonian = useHamiltonianService();
     const layerQuery = useLayerQueryService();
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
 
-    watch(() => tool.prepared === 'hamStart', (isActive) => {
+    watch(() => tool.prepared === 'path', (isActive) => {
         if (!isActive) return;
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
 
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'hamStart' || nodeTree.selectedLayerCount !== 1) return;
+        if (tool.prepared !== 'path' || nodeTree.selectedLayerCount !== 1) return;
         if (pixels.length !== 1) return;
 
         const startPixel = pixels[0];
@@ -357,15 +357,15 @@ export const useSelectService = defineStore('selectService', () => {
     return {};
 });
 
-export const usePathToolService = defineStore('pathToolService', () => {
-    const { nodeTree, pixels: pixelStore } = useStore();
+export const useDirectionToolService = defineStore('directionToolService', () => {
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const tool = useToolSelectionService();
     const layerQuery = useLayerQueryService();
     const overlayService = useOverlayService();
     const overlays = PIXEL_DIRECTIONS.map(direction => {
         const id = overlayService.createOverlay();
         overlayService.setStyles(id, {
-            FILL_COLOR: `url(#${ensurePathPattern(direction)})`,
+            FILL_COLOR: `url(#${ensureDirectionPattern(direction)})`,
             STROKE_COLOR: 'none',
             STROKE_WIDTH_SCALE: 0,
             FILL_RULE: 'evenodd'
@@ -373,21 +373,41 @@ export const usePathToolService = defineStore('pathToolService', () => {
         return id;
     });
     function rebuild() {
-        if (tool.prepared !== 'path') return;
+        if (tool.prepared !== 'direction') return;
         const layerIds = nodeTree.selectedLayerIds;
+        const showAll = layerIds.length === 0;
         PIXEL_DIRECTIONS.forEach((direction, idx) => {
             const overlayId = overlays[idx];
             overlayService.clear(overlayId);
-            for (const id of layerIds) {
-                const set = pixelStore[direction][id];
-                if (!set) continue;
-                overlayService.addPixels(overlayId, [...set]);
+            if (showAll) {
+                const seen = new Set();
+                const add = new Set();
+                for (let i = nodeTree.layerOrder.length - 1; i >= 0; i--) {
+                    const id = nodeTree.layerOrder[i];
+                    if (!nodes.getProperty(id, 'visibility')) continue;
+                    const set = pixelStore[direction][id];
+                    if (!set) continue;
+                    for (const pixel of set) {
+                        if (seen.has(pixel)) continue;
+                        if (layerQuery.topVisibleAt(pixel) === id) {
+                            add.add(pixel);
+                            seen.add(pixel);
+                        }
+                    }
+                }
+                overlayService.addPixels(overlayId, [...add]);
+            }
+            else {
+                for (const id of layerIds) {
+                    const set = pixelStore[direction][id];
+                    if (!set) continue;
+                    overlayService.addPixels(overlayId, [...set]);
+                }
             }
         });
     }
-    watch(() => tool.prepared === 'path', (isPath) => {
-        console.log(0)
-        if (!isPath) {
+    watch(() => tool.prepared === 'direction', (isDirection) => {
+        if (!isDirection) {
             overlays.forEach(id => overlayService.clear(id));
             return;
         }
@@ -395,13 +415,18 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'path' || !pixel) return;
+        if (tool.prepared !== 'direction' || !pixel) return;
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.dragPixel, (pixel, prevPixel) => {
-        if (tool.prepared !== 'path' || pixel == null) return;
+        if (tool.prepared !== 'direction' || pixel == null) return;
         const target = layerQuery.topVisibleAt(pixel);
-        if (nodeTree.selectedLayerIds.includes(target)) {
+        const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
+        if (target != null && editable) {
+            if (nodes.getProperty(target, 'locked')) {
+                tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
+                return;
+            }
             if (prevPixel == null) {
                 const idx = PIXEL_DIRECTIONS.findIndex(k => pixelStore[k][target]?.has(pixel));
                 const current = idx >= 0 ? PIXEL_DIRECTIONS[idx] : 'none';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -64,7 +64,7 @@ export function ensureCheckerboardPattern(target = document.body) {
     return id;
 }
 
-export function ensurePathPattern(direction, target = document.body) {
+export function ensureDirectionPattern(direction, target = document.body) {
     const id = `pixel-direction-${direction}`;
     if (document.getElementById(id)) return id;
     const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
@@ -111,8 +111,8 @@ export function ensurePathPattern(direction, target = document.body) {
     defs.appendChild(pattern);
     svg.appendChild(defs);
     target.appendChild(svg);
-    return id;
-}
+      return id;
+  }
 
 // --- color helpers (32-bit unsigned RGBA packed as 0xAABBGGRR) ---
 export const packRGBA = (color) => {


### PR DESCRIPTION
## Summary
- Rename former Path tool to Direction tool and move settings button after redo
- Transfer Path name and icon to Hamilton tool for path traversal
- Add Direction icon and replace path references with direction patterns
- Display and edit direction state of top-visible pixels even without layer selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6b33404832cae9aefd6ee30b0e0