### PR TITLE
feat: update layer deletion handling

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -22,7 +22,7 @@
             <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
           </div>
           <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
           </div>
         </div>
       </template>
@@ -61,7 +61,7 @@
             <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
           </div>
           <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteLayer(item.id)" />
+            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
           </div>
         </div>
       </template>
@@ -80,7 +80,7 @@ import { useService } from '../services';
 import { useContextMenuStore } from '../stores/contextMenu';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
-const { layerPanel, layerQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc } = useService();
+const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc } = useService();
 const contextMenu = useContextMenuStore();
 
 const dragging = ref(false);
@@ -326,35 +326,40 @@ function onContextMenu(item, event) {
     contextMenu.open(event, items);
 }
 
-function deleteLayer(id) {
+function deleteNode(id) {
     output.setRollbackPoint();
-    const targets = nodeTree.selectedNodeIds.includes(id) ? nodeTree.selectedNodeIds : [id];
-    const belowId = layerQuery.below(layerQuery.lowermost(targets));
+    const targets = nodeTree.selectedNodeIds.includes(id) ? nodeTree.selectedIds : [id];
+    const lowermostTarget = nodeQuery.lowermost(targets);
+    const parentId = nodeQuery.parentOf(lowermostTarget);
+    const belowId = nodeQuery.below(lowermostTarget);
     const removed = nodeTree.remove(targets);
     nodes.remove(removed);
     pixelStore.remove(removed);
-    const newSelectId = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
+    let newSelectId = null;
+    if (nodeTree.has(belowId)) newSelectId = belowId;
+    else if (nodeTree.has(parentId)) newSelectId = parentId;
     layerPanel.setRange(newSelectId, newSelectId);
     if (newSelectId) {
-        layerPanel.setScrollRule({
-            type: "follow",
-            target: newSelectId
-        });
+        layerPanel.setScrollRule({ type: 'follow', target: newSelectId });
     }
     output.commit();
 }
 
 function deleteSelection() {
-    if (!nodeTree.layerSelectionExists) return;
+    if (!nodeTree.selectedNodeCount) return;
     output.setRollbackPoint();
-    const belowId = layerQuery.below(layerQuery.lowermost(nodeTree.selectedLayerIds));
-    const ids = nodeTree.selectedLayerIds;
+    const ids = nodeTree.selectedIds;
+    const lowermostTarget = nodeQuery.lowermost(ids);
+    const parentId = nodeQuery.parentOf(lowermostTarget);
+    const belowId = nodeQuery.below(lowermostTarget);
     const removed = nodeTree.remove(ids);
     nodes.remove(removed);
     pixelStore.remove(removed);
-    const newSelect = nodeTree.has(belowId) ? belowId : layerQuery.lowermost();
+    let newSelect = null;
+    if (nodeTree.has(belowId)) newSelect = belowId;
+    else if (nodeTree.has(parentId)) newSelect = parentId;
     layerPanel.setRange(newSelect, newSelect);
-    layerPanel.setScrollRule({ type: 'follow', target: newSelect });
+    if (newSelect) layerPanel.setScrollRule({ type: 'follow', target: newSelect });
     output.commit();
 }
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,6 +2,7 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
+import { useNodeQueryService } from './nodeQuery';
 import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, useDirectionToolService, usePathToolService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
@@ -15,6 +16,7 @@ export {
     useLayerToolService,
     useOverlayService,
     useLayerQueryService,
+    useNodeQueryService,
     useSelectService,
     useDrawToolService,
     useEraseToolService,
@@ -36,6 +38,7 @@ export const useService = () => ({
     layerTool: useLayerToolService(),
     overlay: useOverlayService(),
     layerQuery: useLayerQueryService(),
+    nodeQuery: useNodeQueryService(),
     select: useSelectService(),
     tools: {
         draw: useDrawToolService(),

--- a/src/services/nodeQuery.js
+++ b/src/services/nodeQuery.js
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia';
+import { useStore } from '../stores';
+
+export const useNodeQueryService = defineStore('nodeQueryService', () => {
+    const { nodeTree } = useStore();
+
+    function lowermost(ids) {
+        const order = nodeTree.allNodeIds;
+        if (ids == null) {
+            return order[0] ?? null;
+        }
+        const idSet = new Set(ids);
+        if (!idSet.size) return null;
+        const index = Math.min(
+            ...order.map((id, idx) => (idSet.has(id) ? idx : Infinity))
+        );
+        return isFinite(index) ? order[index] : null;
+    }
+
+    function below(id) {
+        if (id == null) return null;
+        const info = nodeTree._findNode(id);
+        if (!info) return null;
+        const siblings = info.parent ? info.parent.children : nodeTree.tree;
+        return siblings[info.index - 1]?.id ?? null;
+    }
+
+    function parentOf(id) {
+        const info = nodeTree._findNode(id);
+        return info?.parent?.id ?? null;
+    }
+
+    return { lowermost, below, parentOf };
+});
+


### PR DESCRIPTION
## Summary
- remove unused nodeQuery.lowermostChild helper
- select sibling below or parent after node deletions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd76d148832c825cb80b509688fa