### PR TITLE
Show wait cursor during path processing

### DIFF
--- a/src/constants/cursor.js
+++ b/src/constants/cursor.js
@@ -20,5 +20,6 @@ export const CURSOR_STYLE = {
     RIGHT: `url("${cursorIcons.right}") 8 8, crosshair`,
     CHANGE: `url("${cursorIcons.change}") 8 8, crosshair`,
     LOCKED: `url("${cursorIcons.locked}") 8 8, not-allowed`,
+    WAIT: 'wait',
     NOT_ALLOWED: 'not-allowed',
 };

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -225,8 +225,13 @@ export const usePathToolService = defineStore('pathToolService', () => {
         const layerId = nodeTree.selectedLayerIds[0];
         if (!pixelStore.has(layerId, startPixel)) return;
 
+        tool.setCursor({ stroke: CURSOR_STYLE.WAIT, rect: CURSOR_STYLE.WAIT });
+
         const allPixels = pixelStore.get(layerId);
         const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
+
+        tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
+
         if (!paths.length) return;
 
         const color = nodes.getProperty(layerId, 'color');


### PR DESCRIPTION
## Summary
- add WAIT cursor style
- display wait cursor while path tool computes paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6e0e06b1c832c8493394a57cfdbe0