### PR TITLE
Use path cursor for path tool

### DIFF
--- a/src/constants/cursor.js
+++ b/src/constants/cursor.js
@@ -18,6 +18,7 @@ export const CURSOR_STYLE = {
     DOWN: `url("${cursorIcons.down}") 8 8, crosshair`,
     LEFT: `url("${cursorIcons.left}") 8 8, crosshair`,
     RIGHT: `url("${cursorIcons.right}") 8 8, crosshair`,
+    PATH: `url("${cursorIcons.path}") 8 8, crosshair`,
     CHANGE: `url("${cursorIcons.change}") 8 8, crosshair`,
     LOCKED: `url("${cursorIcons.locked}") 8 8, not-allowed`,
     WAIT: 'wait',

--- a/src/image/stage_cursor/index.js
+++ b/src/image/stage_cursor/index.js
@@ -10,6 +10,7 @@ import globalEraseStroke from './global_erase_stroke.svg';
 import globalEraseRect from './global_erase_rect.svg';
 import cutStroke from './cut_stroke.svg';
 import cutRect from './cut_rect.svg';
+import path from './path.svg';
 import top from './top.svg';
 import up from './up.svg';
 import down from './down.svg';
@@ -31,6 +32,7 @@ export default {
   globalEraseRect,
   cutStroke,
   cutRect,
+  path,
   top,
   up,
   down,

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -214,7 +214,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
 
     watch(() => tool.prepared === 'path', (isActive) => {
         if (!isActive) return;
-        tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
+        tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
     });
 
     watch(() => tool.affectedPixels, (pixels) => {
@@ -230,7 +230,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         const allPixels = pixelStore.get(layerId);
         const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
 
-        tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
+        tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
 
         if (!paths.length) return;
 


### PR DESCRIPTION
## Summary
- export path cursor image
- map path tool to dedicated cursor with 8x8 offset
- update path tool service to apply new cursor

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6e449e0b8832c95633ee5eac678e1