### PR TITLE
feat: update layer deletion handling

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,6 +2,7 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
+import { useNodeQueryService } from './nodeQuery';
 import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, useDirectionToolService, usePathToolService } from './tools';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
@@ -15,6 +16,7 @@ export {
     useLayerToolService,
     useOverlayService,
     useLayerQueryService,
+    useNodeQueryService,
     useSelectService,
     useDrawToolService,
     useEraseToolService,
@@ -36,6 +38,7 @@ export const useService = () => ({
     layerTool: useLayerToolService(),
     overlay: useOverlayService(),
     layerQuery: useLayerQueryService(),
+    nodeQuery: useNodeQueryService(),
     select: useSelectService(),
     tools: {
         draw: useDrawToolService(),

--- a/src/services/nodeQuery.js
+++ b/src/services/nodeQuery.js
@@ -1,0 +1,44 @@
+import { defineStore } from 'pinia';
+import { useStore } from '../stores';
+
+export const useNodeQueryService = defineStore('nodeQueryService', () => {
+    const { nodeTree } = useStore();
+
+    function lowermost(ids) {
+        const order = nodeTree.allNodeIds;
+        if (ids == null) {
+            return order[0] ?? null;
+        }
+        const idSet = new Set(ids);
+        if (!idSet.size) return null;
+        const index = Math.min(
+            ...order.map((id, idx) => (idSet.has(id) ? idx : Infinity))
+        );
+        return isFinite(index) ? order[index] : null;
+    }
+
+    function below(id) {
+        if (id == null) return null;
+        const info = nodeTree._findNode(id);
+        if (!info) return null;
+        const siblings = info.parent ? info.parent.children : nodeTree.tree;
+        return siblings[info.index - 1]?.id ?? null;
+    }
+
+    function parentOf(id) {
+        const info = nodeTree._findNode(id);
+        return info?.parent?.id ?? null;
+    }
+
+    function childrenOf(id) {
+        if (id == null) {
+            return nodeTree.tree.map(n => n.id);
+        }
+        const info = nodeTree._findNode(id);
+        const children = info?.node?.children;
+        return children ? children.map(n => n.id) : [];
+    }
+
+    return { lowermost, below, parentOf, childrenOf };
+});
+


### PR DESCRIPTION
## Summary
- add childrenOf query helper for node relationships
- select next sibling, or lowest remaining sibling, or parent after node deletions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd76d148832c825cb80b509688fa