### PR TITLE
Sort moved layers by node order

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -214,7 +214,7 @@ function onDrop(item, event) {
     row.classList.remove('insert-before', 'insert-after', 'insert-into');
     const rect = row.getBoundingClientRect();
     const y = event.clientY - rect.top;
-    const ids = nodeTree.selectedIds;
+    const ids = nodeTree.orderedSelection;
     if (item.isGroup && y > rect.height / 3 && y < rect.height * 2 / 3) {
         nodeTree.append(ids, item.id, true);
     } else {
@@ -286,6 +286,8 @@ function onContextMenu(item, event) {
             label: 'Group',
             action: () => {
                 output.setRollbackPoint();
+                const ordered = nodeTree.orderedSelection;
+                nodeTree.replaceSelection(ordered);
                 const id = layerSvc.groupSelected();
                 layerPanel.setRange(id, id);
                 layerPanel.setScrollRule({ type: 'follow', target: id });
@@ -498,6 +500,8 @@ function ensureBlockVisibility({
             } else if (lower === 'g') {
                 e.preventDefault();
                 output.setRollbackPoint();
+                const ordered = nodeTree.orderedSelection;
+                nodeTree.replaceSelection(ordered);
                 const id = layerSvc.groupSelected();
                 layerPanel.setRange(id, id);
                 layerPanel.setScrollRule({ type: 'follow', target: id });

--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -99,6 +99,10 @@ export const useNodeTreeStore = defineStore('nodeTree', {
         _selectedNodeIdSet(state) { return new Set(this._selectedNodeIds) },
         tree(state) { return readonly(state._tree) },
         selectedIds(state) { return [...state._selection] },
+        orderedSelection(state) {
+            const index = new Map(this._nodeIds.map((id, idx) => [id, idx]));
+            return [...state._selection].sort((a, b) => index.get(a) - index.get(b));
+        },
         exists(state) { return this._nodeIds.length > 0 },
         has(state) { return (id) => findNode(state._tree, id) != null },
         layerOrder(state) { return readonly(this._layerIds) },


### PR DESCRIPTION
## Summary
- ensure dragged layers are inserted in node order
- preserve node order when grouping selected layers
- expose ordered selection via nodeTree getter

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6e9d0674c832cb7336361a5d9a1e3