### PR TITLE
Ensure scroll targets become visible and mark ancestor selections

### DIFF
--- a/src/services/layerPanel.js
+++ b/src/services/layerPanel.js
@@ -96,6 +96,32 @@ export const useLayerPanelService = defineStore('layerPanelService', () => {
     }
 
     function setScrollRule(rule) {
+        if (rule?.target != null) {
+            const info = nodeTree._findNode(rule.target);
+            if (info) {
+                const path = [];
+                let cur = info;
+                while (cur) {
+                    path.unshift(cur.node);
+                    if (!cur.parent) break;
+                    cur = nodeTree._findNode(cur.parent.id);
+                }
+                for (let i = 0; i < path.length - 1; i++) {
+                    const anc = path[i];
+                    const next = path[i + 1];
+                    if (folded[anc.id]) {
+                        folded[anc.id] = false;
+                        if (anc.children) {
+                            for (const child of anc.children) {
+                                if (child.id !== next.id && child.children) {
+                                    folded[child.id] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         state.scrollRule = rule;
     }
 


### PR DESCRIPTION
## Summary
- Expand folded ancestors of scroll targets while collapsing unrelated siblings
- Highlight nodes with selected descendants using a subtle border

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f14127d8832c849948e1f5dbbe89