### PR TITLE
Show layer actions only on hover

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-memo="[output.commitVersion, nodeTree.selectedLayerIds, nodeTree.layerCount, foldedMemo]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
-    <div v-for="item in flatNodes" class="layer flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="item.id" :data-id="item.id" :style="{ marginLeft: (item.depth * 32) + 'px' }" :class="{ selected: nodeTree.selectedNodeIds.includes(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id, 'descendant-selected': ancestorsOfSelected.has(item.id) }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item,$event)" @contextmenu.prevent="onContextMenu(item,$event)">
+    <div v-memo="[output.commitVersion, nodeTree.selectedLayerIds, nodeTree.layerCount, foldedMemo]" ref="listElement" class="layers flex-1 overflow-auto p-2 flex flex-col gap-2 relative" :class="{ dragging: dragging }" @dragover.prevent @drop.prevent>
+      <div v-for="item in flatNodes" class="layer group relative overflow-hidden flex items-center gap-3 p-2 border border-white/15 rounded-lg bg-sky-950/30 cursor-grab select-none" :key="item.id" :data-id="item.id" :style="{ marginLeft: (item.depth * 32) + 'px' }" :class="{ selected: nodeTree.selectedNodeIds.includes(item.id), anchor: layerPanel.anchorId===item.id, dragging: dragId===item.id, 'descendant-selected': ancestorsOfSelected.has(item.id) }" draggable="true" @click="layerPanel.onLayerClick(item.id,$event)" @dragstart="onDragStart(item.id,$event)" @dragend="onDragEnd" @dragover.prevent="onDragOver(item,$event)" @dragleave="onDragLeave($event)" @drop.prevent="onDrop(item,$event)" @contextmenu.prevent="onContextMenu(item,$event)">
       <template v-if="item.isGroup">
         <div class="w-4 text-center cursor-pointer" @click.stop="toggleFold(item.id)">{{ folded[item.id] ? '▶' : '▼' }}</div>
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
@@ -9,7 +9,8 @@
             <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOfLayer(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
-        <div class="min-w-0 flex-1">
+        <div class="min-w-0 flex-1 relative overflow-hidden">
+          <div class="absolute inset-y-0 right-0 w-[8.5rem] opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity bg-gradient-to-l from-sky-950/80 to-sky-950/0"></div>
           <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
             <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
           </div>
@@ -17,19 +18,19 @@
             <span>{{ nodeTree.descendantLayerIds(item.id).length }} Layers ({{ getPixelUnion(descendantPixels(item.id)).length }}px)</span>
           </div>
         </div>
-        <div class="flex gap-1 justify-end">
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-            <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          <div class="actions pointer-events-none group-hover:pointer-events-auto opacity-0 group-hover:opacity-100 transition-opacity absolute inset-y-0 right-0 flex items-center gap-1 pl-8 pr-2 bg-gradient-to-l from-sky-950 to-sky-950/0">
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+              <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+            </div>
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+              <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+            </div>
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+              <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
+            </div>
           </div>
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-            <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
-          </div>
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
-          </div>
-        </div>
-      </template>
-      <template v-else>
+        </template>
+        <template v-else>
         <!-- 썸네일 -->
         <div v-if="item.depth===0" @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
@@ -42,7 +43,8 @@
           <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.props.locked }" :disabled="item.props.locked" :value="rgbaToHexU32(item.props.color)" @pointerdown.stop @mousedown.stop @click.stop="onColorDown()" @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
         </div>
         <!-- 이름/픽셀 -->
-        <div class="min-w-0 flex-1">
+        <div class="min-w-0 flex-1 relative overflow-hidden">
+          <div class="absolute inset-y-0 right-0 w-[8.5rem] opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity bg-gradient-to-l from-sky-950/80 to-sky-950/0"></div>
           <div class="name font-semibold truncate text-sm pointer-events-none" title="더블클릭으로 이름 편집">
             <span class="nameText pointer-events-auto inline-block max-w-full whitespace-nowrap overflow-hidden text-ellipsis" @dblclick="startRename(item.id)" @keydown="onNameKey(item.id,$event)" @blur="finishRename(item.id,$event)">{{ item.props.name }}</span>
           </div>
@@ -55,20 +57,20 @@
             <span class="cursor-pointer" @click.stop="onPixelCountClick(item.id)" title="같은 크기의 모든 레이어 선택">{{ item.props.pixels.length }}px</span>
           </div>
         </div>
-        <!-- 액션 -->
-        <div class="flex gap-1 justify-end">
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
-            <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+          <!-- 액션 -->
+          <div class="actions pointer-events-none group-hover:pointer-events-auto opacity-0 group-hover:opacity-100 transition-opacity absolute inset-y-0 right-0 flex items-center gap-1 pl-8 pr-2 bg-gradient-to-l from-sky-950 to-sky-950/0">
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="보이기/숨기기">
+              <img :src="(item.props.visibility?icons.show:icons.hide)" alt="show/hide" class="w-4 h-4 cursor-pointer" @error="icons.show=icons.hide=''" @click.stop="toggleVisibility(item.id)" />
+            </div>
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
+              <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
+            </div>
+            <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
+              <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
+            </div>
           </div>
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="잠금/해제">
-            <img :src="(item.props.locked?icons.lock:icons.unlock)" alt="lock/unlock" class="w-4 h-4 cursor-pointer" @error="icons.lock=icons.unlock=''" @click.stop="toggleLock(item.id)" />
-          </div>
-          <div class="inline-flex items-center justify-center w-7 h-7 rounded-md" title="삭제">
-            <img :src="icons.del" alt="delete" class="w-4 h-4 cursor-pointer" @error="icons.del=''" @click.stop="deleteNode(item.id)" />
-          </div>
-        </div>
-      </template>
-    </div>
+        </template>
+      </div>
     <div v-show="flatNodes.length===0" class="text-xs text-slate-400/80 py-6 text-center">(레이어가 없습니다)</div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Restore hover action bar gradient to original look
- Fade layer names and info under actions with matching hover gradient

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b706d5d1bc832cb8279224a92147eb