### PR TITLE
feat: centralize keyboard shortcuts

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -87,8 +87,8 @@ import blockIcons from '../image/layer_block';
 import { useService } from '../services';
 import { useContextMenuStore } from '../stores/contextMenu';
 
-const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, keyboardEvent: keyboardEvents } = useStore();
-const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc } = useService();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
+const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc, clipboard } = useService();
 const contextMenu = useContextMenuStore();
 
 const dragging = ref(false);
@@ -324,11 +324,13 @@ function onContextMenu(item, event) {
         {
             label: 'Copy',
             action: () => {
-                output.setRollbackPoint();
-                const ids = layerSvc.copySelected();
-                nodeTree.replaceSelection(ids);
-                layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
-                output.commit();
+                clipboard.copySelection();
+            }
+        },
+        {
+            label: 'Paste',
+            action: () => {
+                clipboard.paste();
             }
         },
         {
@@ -380,33 +382,6 @@ function deleteNode(id) {
     if (newSelectId) {
         layerPanel.setScrollRule({ type: 'follow', target: newSelectId });
     }
-    output.commit();
-}
-
-function deleteSelection() {
-    if (!nodeTree.selectedNodeCount) return;
-    output.setRollbackPoint();
-    const ids = nodeTree.selectedIds;
-    const lowermostTarget = nodeQuery.lowermost(ids);
-    const parentId = nodeQuery.parentOf(lowermostTarget);
-    const belowId = nodeQuery.below(lowermostTarget);
-    const removed = nodeTree.remove(ids);
-    nodes.remove(removed);
-    pixelStore.remove(removed);
-    let newSelect = null;
-    if (nodeTree.has(belowId)) {
-        newSelect = belowId;
-    } else {
-        const siblings = nodeQuery.childrenOf(parentId);
-        const lowermostSibling = nodeQuery.lowermost(siblings);
-        if (nodeTree.has(lowermostSibling)) {
-            newSelect = lowermostSibling;
-        } else if (nodeTree.has(parentId)) {
-            newSelect = parentId;
-        }
-    }
-    layerPanel.setRange(newSelect, newSelect);
-    if (newSelect) layerPanel.setScrollRule({ type: 'follow', target: newSelect });
     output.commit();
 }
 
@@ -480,63 +455,6 @@ function ensureBlockVisibility({
         behavior: 'smooth'
     });
 }
-
-  watch(() => keyboardEvents.recent.down, (downs) => {
-      for (const e of downs) {
-          const key = e.key;
-          const ctrl = e.ctrlKey || e.metaKey;
-          const shift = e.shiftKey;
-          switch (key) {
-              case 'ArrowUp':
-                  e.preventDefault();
-                  layerPanel.onArrowUp(shift, ctrl);
-                  break;
-              case 'ArrowDown':
-                  e.preventDefault();
-                  layerPanel.onArrowDown(shift, ctrl);
-                  break;
-              case 'Delete':
-              case 'Backspace':
-                  e.preventDefault();
-                  deleteSelection();
-                  break;
-              case 'Enter':
-                  if (!ctrl && !shift && nodeTree.selectedLayerCount === 1) {
-                      const selectedId = nodeTree.selectedLayerIds[0];
-                      const row = document.querySelector(`.layer[data-id="${selectedId}"] .nameText`);
-                      if (row) {
-                          e.preventDefault();
-                          row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-                      }
-                  }
-                  break;
-              case 'Escape':
-                  if (output.hasPendingRollback) {
-                      e.preventDefault();
-                      output.rollbackPending();
-                  } else {
-                      nodeTree.clearSelection();
-                  }
-                  break;
-          }
-        if (ctrl) {
-            const lower = key.toLowerCase();
-            if (lower === 'a') {
-                e.preventDefault();
-                layerPanel.selectAll();
-            } else if (lower === 'g') {
-                e.preventDefault();
-                output.setRollbackPoint();
-                const ordered = nodeTree.orderedSelection;
-                nodeTree.replaceSelection(ordered);
-                const id = layerSvc.groupSelected();
-                layerPanel.setRange(id, id);
-                layerPanel.setScrollRule({ type: 'follow', target: id });
-                output.commit();
-            }
-        }
-      }
-  });
 
   watch(() => layerPanel.scrollRule, rule => nextTick(() => ensureBlockVisibility(rule)));
 

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -1,0 +1,97 @@
+import { defineStore } from 'pinia';
+import { useStore } from '../stores';
+import { useNodeQueryService } from './nodeQuery';
+import { useLayerPanelService } from './layerPanel';
+
+function serializeNode(id, nodeTree, nodes, pixelStore) {
+    const props = nodes.getProperties(id);
+    const base = {
+        name: props.name,
+        color: props.color,
+        visibility: props.visibility,
+        locked: props.locked,
+        attributes: props.attributes,
+    };
+    if (props.type === 'layer') {
+        return {
+            type: 'layer',
+            ...base,
+            pixels: pixelStore.getDirectional(id),
+        };
+    }
+    if (props.type === 'group') {
+        const info = nodeTree._findNode(id);
+        const children = info?.node.children || [];
+        return {
+            type: 'group',
+            ...base,
+            children: children.map(child => serializeNode(child.id, nodeTree, nodes, pixelStore)),
+        };
+    }
+    return null;
+}
+
+export const useClipboardService = defineStore('clipboardService', () => {
+    const { nodeTree, nodes, pixels: pixelStore, output } = useStore();
+    const nodeQuery = useNodeQueryService();
+    const layerPanel = useLayerPanelService();
+
+    let clipboardData = null;
+
+    function copySelection() {
+        const ordered = nodeTree.orderedSelection;
+        if (!ordered.length) return;
+        clipboardData = ordered.map(id => serializeNode(id, nodeTree, nodes, pixelStore));
+    }
+
+    function createFrom(data) {
+        const base = {
+            name: data.name,
+            color: data.color,
+            visibility: data.visibility,
+            locked: data.locked,
+            attributes: data.attributes,
+        };
+        if (data.type === 'layer') {
+            const id = nodes.createLayer(base);
+            if (data.pixels) pixelStore.set(id, data.pixels);
+            return { id, children: [] };
+        }
+        if (data.type === 'group') {
+            const id = nodes.createGroup(base);
+            const children = (data.children || []).map(c => createFrom(c));
+            return { id, children };
+        }
+        return { id: null, children: [] };
+    }
+
+    function paste() {
+        if (!clipboardData || !clipboardData.length) return [];
+
+        output.setRollbackPoint();
+        const infos = clipboardData.map(createFrom);
+        if (!infos.length) {
+            output.rollbackPending?.();
+            return [];
+        }
+        const topIds = infos.map(info => info.id);
+        const uppermost = nodeQuery.uppermost(nodeTree.selectedIds);
+        nodeTree.insert(topIds, uppermost, false);
+        const attach = (info) => {
+            if (info.children.length) {
+                const ids = info.children.map(c => c.id);
+                nodeTree.append(ids, info.id, false);
+                info.children.forEach(attach);
+            }
+        };
+        infos.forEach(attach);
+        nodeTree.replaceSelection(topIds);
+        layerPanel.setRange(topIds[0], topIds[topIds.length - 1]);
+        layerPanel.setScrollRule({ type: 'follow', target: topIds[0] });
+        output.commit();
+        return topIds;
+    }
+
+    return { copySelection, paste };
+});
+

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -10,6 +10,8 @@ import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
 import { useImageLoadService } from './imageLoad';
 import { useSettingsService } from './settings';
+import { useShortcutService } from './shortcut';
+import { useClipboardService } from './clipboard';
 
 export {
     useLayerPanelService,
@@ -30,7 +32,9 @@ export {
     useStageResizeService,
     useHamiltonianService,
     useImageLoadService,
-    useSettingsService
+    useSettingsService,
+    useShortcutService,
+    useClipboardService
 };
 
 export const useService = () => ({
@@ -54,5 +58,7 @@ export const useService = () => ({
     stageResize: useStageResizeService(),
     hamiltonian: useHamiltonianService(),
     imageLoad: useImageLoadService(),
-    settings: useSettingsService()
+    settings: useSettingsService(),
+    shortcut: useShortcutService(),
+    clipboard: useClipboardService()
 });

--- a/src/services/nodeQuery.js
+++ b/src/services/nodeQuery.js
@@ -17,6 +17,19 @@ export const useNodeQueryService = defineStore('nodeQueryService', () => {
         return isFinite(index) ? order[index] : null;
     }
 
+    function uppermost(ids) {
+        const order = nodeTree.allNodeIds;
+        if (ids == null) {
+            return order[order.length - 1] ?? null;
+        }
+        const idSet = new Set(ids);
+        if (!idSet.size) return null;
+        const index = Math.max(
+            ...order.map((id, idx) => (idSet.has(id) ? idx : -Infinity))
+        );
+        return isFinite(index) ? order[index] : null;
+    }
+
     function below(id) {
         if (id == null) return null;
         const info = nodeTree._findNode(id);
@@ -39,6 +52,6 @@ export const useNodeQueryService = defineStore('nodeQueryService', () => {
         return children ? children.map(n => n.id) : [];
     }
 
-    return { lowermost, below, parentOf, childrenOf };
+    return { lowermost, uppermost, below, parentOf, childrenOf };
 });
 

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -1,0 +1,169 @@
+import { defineStore } from 'pinia';
+import { watch } from 'vue';
+import { useStore } from '../stores';
+import { useLayerPanelService } from './layerPanel';
+import { useLayerToolService } from './layerTool';
+import { useNodeQueryService } from './nodeQuery';
+import { useToolSelectionService } from './toolSelection';
+import { useClipboardService } from './clipboard';
+import { TOOL_MODIFIERS } from '@/constants';
+
+export const useShortcutService = defineStore('shortcutService', () => {
+    const { keyboardEvent: keyboardEvents, nodeTree, nodes, pixels: pixelStore, output } = useStore();
+    const layerPanel = useLayerPanelService();
+    const layerSvc = useLayerToolService();
+    const nodeQuery = useNodeQueryService();
+    const toolSelectionService = useToolSelectionService();
+    const clipboard = useClipboardService();
+
+    let previousTool = toolSelectionService.prepared;
+    let modifierActive = false;
+
+    function deleteSelection() {
+        if (!nodeTree.selectedNodeCount) return;
+        output.setRollbackPoint();
+        const ids = nodeTree.selectedIds;
+        const lowermostTarget = nodeQuery.lowermost(ids);
+        const parentId = nodeQuery.parentOf(lowermostTarget);
+        const belowId = nodeQuery.below(lowermostTarget);
+        const removed = nodeTree.remove(ids);
+        nodes.remove(removed);
+        pixelStore.remove(removed);
+        let newSelect = null;
+        if (nodeTree.has(belowId)) {
+            newSelect = belowId;
+        } else {
+            const siblings = nodeQuery.childrenOf(parentId);
+            const lowermostSibling = nodeQuery.lowermost(siblings);
+            if (nodeTree.has(lowermostSibling)) {
+                newSelect = lowermostSibling;
+            } else if (nodeTree.has(parentId)) {
+                newSelect = parentId;
+            }
+        }
+        layerPanel.setRange(newSelect, newSelect);
+        if (newSelect) layerPanel.setScrollRule({ type: 'follow', target: newSelect });
+        output.commit();
+    }
+
+    watch(() => keyboardEvents.recent.down, (downs) => {
+        for (const e of downs) {
+            const key = e.key;
+            const ctrl = e.ctrlKey || e.metaKey;
+            const shift = e.shiftKey;
+
+            if (ctrl) {
+                const lower = key.toLowerCase();
+                if (lower === 'z' && !e.shiftKey) {
+                    e.preventDefault();
+                    output.undo();
+                    continue;
+                }
+                if (lower === 'y' || (lower === 'z' && e.shiftKey)) {
+                    e.preventDefault();
+                    output.redo();
+                    continue;
+                }
+                if (lower === 'c') {
+                    e.preventDefault();
+                    clipboard.copySelection();
+                    continue;
+                }
+                if (lower === 'v') {
+                    e.preventDefault();
+                    clipboard.paste();
+                    continue;
+                }
+            }
+
+            const map = TOOL_MODIFIERS[key];
+            if (map && !e.repeat) {
+                const change = map[toolSelectionService.prepared] ?? map.default;
+                if (change) {
+                    previousTool = toolSelectionService.prepared;
+                    modifierActive = true;
+                    toolSelectionService.setPrepared(change);
+                    break;
+                }
+            }
+
+            switch (key) {
+                case 'ArrowUp':
+                    e.preventDefault();
+                    layerPanel.onArrowUp(shift, ctrl);
+                    break;
+                case 'ArrowDown':
+                    e.preventDefault();
+                    layerPanel.onArrowDown(shift, ctrl);
+                    break;
+                case 'Delete':
+                case 'Backspace':
+                    e.preventDefault();
+                    deleteSelection();
+                    break;
+                case 'Enter':
+                    if (!ctrl && !shift && nodeTree.selectedLayerCount === 1) {
+                        const selectedId = nodeTree.selectedLayerIds[0];
+                        const row = document.querySelector(`.layer[data-id="${selectedId}"] .nameText`);
+                        if (row) {
+                            e.preventDefault();
+                            row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+                        }
+                    }
+                    break;
+                case 'Escape':
+                    if (output.hasPendingRollback) {
+                        e.preventDefault();
+                        output.rollbackPending();
+                    } else {
+                        nodeTree.clearSelection();
+                    }
+                    break;
+            }
+
+            if (ctrl) {
+                const lower = key.toLowerCase();
+                if (lower === 'a') {
+                    e.preventDefault();
+                    layerPanel.selectAll();
+                } else if (lower === 'g') {
+                    e.preventDefault();
+                    output.setRollbackPoint();
+                    const ordered = nodeTree.orderedSelection;
+                    nodeTree.replaceSelection(ordered);
+                    const id = layerSvc.groupSelected();
+                    layerPanel.setRange(id, id);
+                    layerPanel.setScrollRule({ type: 'follow', target: id });
+                    output.commit();
+                }
+            }
+        }
+    });
+
+    watch(() => keyboardEvents.recent.up, (ups) => {
+        for (const e of ups) {
+            if (e.key === 'Shift') {
+                if (toolSelectionService.prepared !== previousTool) {
+                    toolSelectionService.setPrepared(previousTool);
+                }
+                modifierActive = false;
+                break;
+            }
+            if (e.key === 'Control' || e.key === 'Meta') {
+                const down = keyboardEvents.get('keydown', e.key);
+                if (!down || !down.repeat) continue;
+                if (toolSelectionService.prepared !== previousTool) {
+                    toolSelectionService.setPrepared(previousTool);
+                }
+                modifierActive = false;
+                break;
+            }
+        }
+    });
+
+    watch(() => toolSelectionService.prepared, (tool) => {
+        if (!modifierActive) previousTool = tool;
+    });
+
+    return {};
+});

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -389,9 +389,9 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
                 for (let i = nodeTree.layerOrder.length - 1; i >= 0; i--) {
                     const id = nodeTree.layerOrder[i];
                     if (!nodes.getProperty(id, 'visibility')) continue;
-                    const set = pixelStore[direction][id];
-                    if (!set) continue;
-                    for (const pixel of set) {
+                    const pixels = pixelStore.getDirectionPixels(direction, id);
+                    if (!pixels.length) continue;
+                    for (const pixel of pixels) {
                         if (layerQuery.topVisibleAt(pixel) === id) {
                             add.add(pixel);
                         }
@@ -401,9 +401,9 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
             }
             else {
                 for (const id of layerIds) {
-                    const set = pixelStore[direction][id];
-                    if (!set) continue;
-                    overlayService.addPixels(overlayId, [...set]);
+                    const pixels = pixelStore.getDirectionPixels(direction, id);
+                    if (!pixels.length) continue;
+                    overlayService.addPixels(overlayId, pixels);
                 }
             }
         });
@@ -430,9 +430,9 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
                 return;
             }
             if (prevPixel == null) {
-                const idx = PIXEL_DIRECTIONS.findIndex(k => pixelStore[k][target]?.has(pixel));
-                const current = idx >= 0 ? PIXEL_DIRECTIONS[idx] : 'none';
-                const next = PIXEL_DIRECTIONS[(PIXEL_DIRECTIONS.indexOf(current) + 1) % PIXEL_DIRECTIONS.length];
+                const current = pixelStore.directionOf(target, pixel);
+                const idx = PIXEL_DIRECTIONS.indexOf(current);
+                const next = PIXEL_DIRECTIONS[(idx + 1) % PIXEL_DIRECTIONS.length];
                 pixelStore.addPixels(target, [pixel], next);
             }
             else {

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -7,7 +7,7 @@ export const PIXEL_DEFAULT_DIRECTIONS = [...PIXEL_DIRECTIONS, 'checkerboard'];
 function unionSet(state, id) {
     const merged = new Set();
     for (const direction of PIXEL_DIRECTIONS) {
-        const set = state[direction][id];
+        const set = state[`_${direction}`][id];
         if (!set) continue;
         for (const pixel of set) merged.add(pixel);
     }
@@ -16,14 +16,34 @@ function unionSet(state, id) {
 
 export const usePixelStore = defineStore('pixels', {
     state: () => ({
-        'none': {},
-        'vertical': {},
-        'horizontal': {},
-        defaultDirection: localStorage.getItem('settings.defaultDirection') || PIXEL_DEFAULT_DIRECTIONS[0]
+        _none: {},
+        _vertical: {},
+        _horizontal: {},
+        _defaultDirection: localStorage.getItem('settings.defaultDirection') || PIXEL_DEFAULT_DIRECTIONS[0]
     }),
     getters: {
+        defaultDirection: (state) => state._defaultDirection,
         get: (state) => (id) => {
             return [...unionSet(state, id)];
+        },
+        getDirectionPixels: (state) => (direction, id) => {
+            const set = state[`_${direction}`][id];
+            return set ? [...set] : [];
+        },
+        getDirectional: (state) => (id) => {
+            const result = {};
+            for (const direction of PIXEL_DIRECTIONS) {
+                const set = state[`_${direction}`][id];
+                if (set && set.size) result[direction] = [...set];
+            }
+            return result;
+        },
+        directionOf: (state) => (id, pixel) => {
+            for (const direction of PIXEL_DIRECTIONS) {
+                const set = state[`_${direction}`][id];
+                if (set && set.has(pixel)) return direction;
+            }
+            return 'none';
         },
         pathOfLayer: (state) => (id) => {
             return pixelsToUnionPath([...unionSet(state, id)]);
@@ -45,73 +65,78 @@ export const usePixelStore = defineStore('pixels', {
         },
         has: (state) => (id, pixel) => {
             for (const direction of PIXEL_DIRECTIONS) {
-                const set = state[direction][id];
+                const set = state[`_${direction}`][id];
                 if (set && set.has(pixel)) return true;
             }
             return false;
         }
     },
     actions: {
-        set(id, pixels = []) {
-            for (const direction of PIXEL_DIRECTIONS) delete this[direction][id];
-            this.addPixels(id, pixels, this.defaultDirection);
+        set(id, pixels = [], direction) {
+            for (const dir of PIXEL_DIRECTIONS) delete this[`_${dir}`][id];
+            if (Array.isArray(pixels)) {
+                this.addPixels(id, pixels, direction ?? this._defaultDirection);
+            } else {
+                for (const dir of PIXEL_DIRECTIONS) {
+                    if (pixels[dir]?.length) this.addPixels(id, pixels[dir], dir);
+                }
+            }
         },
         remove(ids = []) {
             for (const id of ids) {
-                for (const direction of PIXEL_DIRECTIONS) delete this[direction][id];
+                for (const direction of PIXEL_DIRECTIONS) delete this[`_${direction}`][id];
             }
         },
         addPixels(id, pixels, direction) {
-            direction = direction ?? this.defaultDirection;
+            direction = direction ?? this._defaultDirection;
             if (direction === 'checkerboard') {
-                if (!this['vertical'][id]) this['vertical'][id] = new Set();
-                if (!this['horizontal'][id]) this['horizontal'][id] = new Set();
+                if (!this._vertical[id]) this._vertical[id] = new Set();
+                if (!this._horizontal[id]) this._horizontal[id] = new Set();
                 for (const pixel of pixels) {
-                    for (const dir of PIXEL_DIRECTIONS) this[dir][id]?.delete(pixel);
+                    for (const dir of PIXEL_DIRECTIONS) this[`_${dir}`][id]?.delete(pixel);
                     const [x, y] = indexToCoord(pixel);
                     const orientation = (x + y) % 2 === 0 ? 'horizontal' : 'vertical';
-                    this[orientation][id].add(pixel);
+                    this[`_${orientation}`][id].add(pixel);
                 }
             }
             else {
-                if (!this[direction][id]) this[direction][id] = new Set();
+                if (!this[`_${direction}`][id]) this[`_${direction}`][id] = new Set();
                 for (const pixel of pixels) {
-                    for (const dir of PIXEL_DIRECTIONS) this[dir][id]?.delete(pixel);
-                    this[direction][id].add(pixel);
+                    for (const dir of PIXEL_DIRECTIONS) this[`_${dir}`][id]?.delete(pixel);
+                    this[`_${direction}`][id].add(pixel);
                 }
             }
         },
         removePixels(id, pixels) {
             for (const direction of PIXEL_DIRECTIONS) {
-                const set = this[direction][id];
+                const set = this[`_${direction}`][id];
                 if (!set) continue;
                 for (const pixel of pixels) set.delete(pixel);
             }
         },
         setDirection(id, pixel, direction) {
-            const idx = PIXEL_DIRECTIONS.findIndex(k => this[k][id]?.has(pixel));
-            if (idx === -1) return;
-            const current = PIXEL_DIRECTIONS[idx];
-            this[current][id].delete(pixel);
-            if (!this[direction][id]) this[direction][id] = new Set();
-            this[direction][id].add(pixel);
+            const current = this.directionOf(id, pixel);
+            if (current === 'none') return;
+            this[`_${current}`][id].delete(pixel);
+            if (!this[`_${direction}`][id]) this[`_${direction}`][id] = new Set();
+            this[`_${direction}`][id].add(pixel);
         },
         togglePixel(id, pixel) {
             for (const direction of PIXEL_DIRECTIONS) {
-                const set = this[direction][id];
+                const set = this[`_${direction}`][id];
                 if (set && set.has(pixel)) {
                     set.delete(pixel);
                     return;
                 }
             }
-            if (this.defaultDirection === 'checkerboard') {
+            if (this._defaultDirection === 'checkerboard') {
                 const [x, y] = indexToCoord(pixel);
                 const dir = (x + y) % 2 === 0 ? 'horizontal' : 'vertical';
-                if (!this[dir][id]) this[dir][id] = new Set();
-                this[dir][id].add(pixel);
+                if (!this[`_${dir}`][id]) this[`_${dir}`][id] = new Set();
+                this[`_${dir}`][id].add(pixel);
             }
             else {
-                const target = this[this.defaultDirection][id];
+                const target = this[`_${this._defaultDirection}`][id];
                 if (target) target.add(pixel);
             }
         },
@@ -119,15 +144,15 @@ export const usePixelStore = defineStore('pixels', {
             dx |= 0; dy |= 0;
             if (dx === 0 && dy === 0) return;
             for (const direction of PIXEL_DIRECTIONS) {
-                const ids = Object.keys(this[direction]);
+                const ids = Object.keys(this[`_${direction}`]);
                 for (const id of ids) {
-                    const set = this[direction][id];
+                    const set = this[`_${direction}`][id];
                     const moved = new Set();
                     for (const pixel of set) {
                         const [x, y] = indexToCoord(pixel);
                         moved.add(coordToIndex(x + dx, y + dy));
                     }
-                    this[direction][id] = moved;
+                    this[`_${direction}`][id] = moved;
                 }
             }
         },
@@ -135,7 +160,7 @@ export const usePixelStore = defineStore('pixels', {
             const result = {};
             const ids = new Set();
             for (const direction of PIXEL_DIRECTIONS) {
-                for (const id of Object.keys(this[direction])) ids.add(id);
+                for (const id of Object.keys(this[`_${direction}`])) ids.add(id);
             }
             for (const id of ids) {
                 result[id] = [...unionSet(this, id)];
@@ -143,14 +168,14 @@ export const usePixelStore = defineStore('pixels', {
             return result;
         },
         applySerialized(byId = {}) {
-            for (const direction of PIXEL_DIRECTIONS) this[direction] = {};
+            for (const direction of PIXEL_DIRECTIONS) this[`_${direction}`] = {};
             for (const id of Object.keys(byId)) {
-                this.addPixels(id, byId[id], this.defaultDirection);
+                this.addPixels(id, byId[id], this._defaultDirection);
             }
         },
         setDefaultDirection(direction) {
             if (PIXEL_DEFAULT_DIRECTIONS.includes(direction)) {
-                this.defaultDirection = direction;
+                this._defaultDirection = direction;
                 localStorage.setItem('settings.defaultDirection', direction);
             }
         }


### PR DESCRIPTION
## Summary
- encapsulate pixel store state with underscored fields and directional getters
- replace direct pixel store state access in tools with new getters
- rework clipboard to use an internal buffer, preserve pixel directions, and paste above the top selection

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7354420d8832c9fc8662bbd988802