### PR TITLE
feat: add canvas size option to image loader

### DIFF
--- a/src/components/ImageLoadPopup.vue
+++ b/src/components/ImageLoadPopup.vue
@@ -6,9 +6,22 @@
           <input type="checkbox" v-model="imageLoadService.initialize" class="rounded bg-slate-700" />
           <span>Initialize Layers</span>
         </label>
-        <label class="block">
+        <label class="block" :class="{ 'opacity-50': !imageLoadService.initialize }">
           <span>Segment Tolerance</span>
-          <input type="number" v-model.number="imageLoadService.tolerance" :disabled="!imageLoadService.initialize" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          <input
+            type="number"
+            v-model.number="imageLoadService.tolerance"
+            :disabled="!imageLoadService.initialize"
+            class="mt-1 w-full rounded bg-slate-700 px-2 py-1 disabled:cursor-not-allowed"
+          />
+        </label>
+        <label class="block">
+          <span>Canvas Width</span>
+          <input type="number" v-model.number="imageLoadService.canvasWidth" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+        </label>
+        <label class="block">
+          <span>Canvas Height</span>
+          <input type="number" v-model.number="imageLoadService.canvasHeight" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
         </label>
       </div>
       <div class="flex justify-end gap-2">

--- a/src/services/imageLoad.js
+++ b/src/services/imageLoad.js
@@ -7,11 +7,17 @@ export const useImageLoadService = defineStore('imageLoadService', () => {
   const { input } = useStore();
   const initialize = ref(localStorage.getItem('imageLoad.initialize') !== 'false');
   const tolerance = ref(Number(localStorage.getItem('imageLoad.tolerance')) || 40);
+  const canvasWidth = ref(Number(localStorage.getItem('imageLoad.canvasWidth')) || 0);
+  const canvasHeight = ref(Number(localStorage.getItem('imageLoad.canvasHeight')) || 0);
 
   watch(initialize, v => localStorage.setItem('imageLoad.initialize', v));
   watch(tolerance, v => localStorage.setItem('imageLoad.tolerance', v));
+  watch(canvasWidth, v => localStorage.setItem('imageLoad.canvasWidth', v));
+  watch(canvasHeight, v => localStorage.setItem('imageLoad.canvasHeight', v));
 
   function open() {
+    canvasWidth.value = input.width + 2;
+    canvasHeight.value = input.height + 2;
     show.value = true;
   }
 
@@ -25,9 +31,9 @@ export const useImageLoadService = defineStore('imageLoadService', () => {
   }
 
   function apply() {
-    input.initialize({ initializeLayers: initialize.value, segmentTolerance: tolerance.value });
+    input.initialize({ initializeLayers: initialize.value, segmentTolerance: tolerance.value, canvasWidth: canvasWidth.value, canvasHeight: canvasHeight.value });
     close();
   }
 
-  return { show, open, close, apply, cancel, initialize, tolerance };
+  return { show, open, close, apply, cancel, initialize, tolerance, canvasWidth, canvasHeight };
 });

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -59,10 +59,14 @@ export const useInputStore = defineStore('input', {
         async loadFromQuery() {
             await this.load(new URL(location.href).searchParams.get('pixel'));
         },
-        initialize({ initializeLayers = true, segmentTolerance = 40 } = {}) {
+        initialize({ initializeLayers = true, segmentTolerance = 40, canvasWidth, canvasHeight } = {}) {
             const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore } = useStore();
             const layerPanel = useLayerPanelService();
-            viewportStore.setSize(this.width, this.height);
+            const width = canvasWidth ?? this.width;
+            const height = canvasHeight ?? this.height;
+            const ox = Math.floor((width - this.width) / 2);
+            const oy = Math.floor((height - this.height) / 2);
+            viewportStore.setSize(width, height);
             viewportStore.setImage(this.src || '', this.width, this.height);
             if (initializeLayers) {
                 const autoSegments = this.segment(segmentTolerance);
@@ -121,6 +125,10 @@ export const useInputStore = defineStore('input', {
                 nodeTree.insert(ids);
             }
             layerPanel.setScrollRule({ type: 'follow', target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });
+            if (ox || oy) {
+                pixelStore.translateAll(ox, oy);
+                viewportStore.setImagePosition(ox, oy);
+            }
         },
         isWithin(pixel) {
             const [x, y] = indexToCoord(pixel);

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -55,6 +55,10 @@ export const useViewportStore = defineStore('viewport', {
             if (width != null) this._image.width = width;
             if (height != null) this._image.height = height;
         },
+        setImagePosition(x, y) {
+            if (x != null) this._image.x = x;
+            if (y != null) this._image.y = y;
+        },
         setScale(newScale) {
             this._stage.scale = Math.max(this._stage.minScale, newScale);
         },


### PR DESCRIPTION
## Summary
- allow specifying canvas width/height when loading images
- center image on expanded canvas and shift pixels accordingly
- store canvas size preferences in local storage
- fade disabled load options for clearer visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b74f14a338832c97cbed8a1ddcafab