### PR TITLE
Ensure deterministic directional traversal for equal-degree neighbors

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -30,7 +30,29 @@ function buildGraph(pixels) {
   }
 
   const degrees = neighbors.map((nbs) => nbs.length);
-  for (const nbs of neighbors) nbs.sort((a, b) => degrees[a] - degrees[b]);
+  function dirOrder(dx, dy) {
+    if (dx === 0 && dy === -1) return 0; // up
+    if (dx === 1 && dy === 0) return 1; // right
+    if (dx === 0 && dy === 1) return 2; // down
+    if (dx === -1 && dy === 0) return 3; // left
+    if (dx === -1 && dy === -1) return 4; // left-up
+    if (dx === -1 && dy === 1) return 5; // left-down
+    if (dx === 1 && dy === 1) return 6; // right-down
+    if (dx === 1 && dy === -1) return 7; // right-up
+    return 8;
+  }
+
+  for (let i = 0; i < neighbors.length; i++) {
+    const nbs = neighbors[i];
+    nbs.sort((a, b) => {
+      const da = degrees[a];
+      const db = degrees[b];
+      if (da !== db) return da - db;
+      const orderA = dirOrder(xs[a] - xs[i], ys[a] - ys[i]);
+      const orderB = dirOrder(xs[b] - xs[i], ys[b] - ys[i]);
+      return orderA - orderB;
+    });
+  }
 
   return { nodes, neighbors, degrees, indexMap };
 }

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -27,3 +27,28 @@ const pixels = [A, B, C, D];
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
 }
+
+// Test neighbor order when degrees are equal
+{
+  const center = coordToIndex(2, 2);
+  const grid = [];
+  for (let x = 0; x <= 4; x++) {
+    for (let y = 0; y <= 4; y++) {
+      grid.push(coordToIndex(x, y));
+    }
+  }
+  const { nodes, neighbors, indexMap } = buildGraph(grid);
+  const centerIdx = indexMap.get(center);
+  const neighborPixels = neighbors[centerIdx].map((i) => nodes[i]);
+  const expected = [
+    coordToIndex(2, 1), // up
+    coordToIndex(3, 2), // right
+    coordToIndex(2, 3), // down
+    coordToIndex(1, 2), // left
+    coordToIndex(1, 1), // left-up
+    coordToIndex(1, 3), // left-down
+    coordToIndex(3, 3), // right-down
+    coordToIndex(3, 1), // right-up
+  ];
+  assert.deepStrictEqual(neighborPixels, expected);
+}


### PR DESCRIPTION
## Summary
- Tie-break neighbor selection by direction in Hamiltonian graph builder so nodes with equal degree traverse in Up, Right, Down, Left, Left-Up, Left-Down, Right-Down, Right-Up order
- Add unit test covering new traversal order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d8207f00832c95547f3a74bd1794