### PR TITLE
Ensure cut pixels as path endpoints and optimize merging

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -139,15 +139,23 @@ function partitionAtCut(nodes, neighbors, cutSet) {
 }
 
 // Merge two path covers using the shared cut pixel
-function stitchPaths(left, right, cutPixel) {
-  const li = left.findIndex((p) => p.includes(cutPixel));
-  const ri = right.findIndex((p) => p.includes(cutPixel));
-  const lPath = left.splice(li, 1)[0];
-  const rPath = right.splice(ri, 1)[0];
-  if (lPath[lPath.length - 1] !== cutPixel) lPath.reverse();
-  if (rPath[0] !== cutPixel) rPath.reverse();
-  const joined = lPath.concat(rPath.slice(1));
-  return [...left, ...right, joined];
+function stitchPaths(paths, cutPixel) {
+  const segments = [];
+  for (const path of paths) {
+    const idx = path.indexOf(cutPixel);
+    if (idx === -1) continue;
+    if (idx === 0) segments.push(path);
+    else if (idx === path.length - 1) segments.push(path.slice().reverse());
+    else {
+      segments.push(path.slice(0, idx + 1).reverse());
+      segments.push(path.slice(idx));
+    }
+  }
+  let merged = segments.shift() || [];
+  for (const seg of segments) merged = merged.concat(seg);
+  if (merged[0] === cutPixel && merged.length > 1 && paths.length > 1)
+    merged = merged.slice(1);
+  return merged;
 }
 
 // Find connected components from an adjacency list
@@ -197,29 +205,38 @@ function solve(input, opts = {}) {
     const results = [];
     for (const part of parts) {
       const partOpts = {};
-      if (opts.start != null && part.nodes.includes(opts.start))
-        partOpts.start = opts.start;
-      if (opts.end != null && part.nodes.includes(opts.end))
-        partOpts.end = opts.end;
       if (opts.degreeOrder) partOpts.degreeOrder = opts.degreeOrder;
+      const partCuts = part.nodes.filter((p) => cutPixels.includes(p));
+      if (opts.start != null && part.nodes.includes(opts.start)) {
+        partOpts.start = opts.start;
+        const idx = partCuts.indexOf(opts.start);
+        if (idx !== -1) partCuts.splice(idx, 1);
+      }
+      if (opts.end != null && part.nodes.includes(opts.end)) {
+        partOpts.end = opts.end;
+        const idx = partCuts.indexOf(opts.end);
+        if (idx !== -1) partCuts.splice(idx, 1);
+      }
+      if (partCuts.length) {
+        if (partOpts.start == null) partOpts.start = partCuts.shift();
+        if (partCuts.length && partOpts.end == null) partOpts.end = partCuts.shift();
+      }
       results.push(solve(part, partOpts));
     }
-    let combined = results.shift();
-    for (const res of results) {
-      let merged = false;
-      for (const cp of cutPixels) {
-        if (
-          combined.some((p) => p.includes(cp)) &&
-          res.some((p) => p.includes(cp))
-        ) {
-          combined = stitchPaths(combined, res, cp);
-          merged = true;
-          break;
-        }
+
+    const allPaths = results.flat();
+    let remaining = allPaths.slice();
+    for (const cp of cutPixels) {
+      const withCut = [];
+      const withoutCut = [];
+      for (const path of remaining) {
+        if (path.includes(cp)) withCut.push(path);
+        else withoutCut.push(path);
       }
-      if (!merged) combined = combined.concat(res);
+      if (withCut.length) withoutCut.push(stitchPaths(withCut, cp));
+      remaining = withoutCut;
     }
-    return combined;
+    return remaining;
   }
 
   const xs = new Int32Array(nodes.length);

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -78,3 +78,53 @@ const diamond = [A, B, C, D];
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
 }
+
+// Test stitching when a cut pixel lies in the middle of a path
+{
+  const Q0 = coordToIndex(0, 0);
+  const Q1 = coordToIndex(1, 1);
+  const Q2 = coordToIndex(2, 2);
+  const Q3 = coordToIndex(3, 3);
+  const Q4 = coordToIndex(1, 3);
+  const Q5 = coordToIndex(3, 1);
+  const star = [Q0, Q1, Q2, Q3, Q4, Q5];
+  const paths = solve(star);
+  assert.strictEqual(paths.length, 2);
+  const covered = new Set(paths.flat());
+  assert.strictEqual(covered.size, star.length);
+  const pathWithQ2 = paths.find((p) => p.includes(Q2));
+  const occurrences = pathWithQ2.filter((p) => p === Q2).length;
+  assert.strictEqual(occurrences, 2);
+  for (let i = 1; i < pathWithQ2.length; i++) {
+    const a = pathWithQ2[i - 1];
+    const b = pathWithQ2[i];
+    const ax = a % MAX_DIMENSION;
+    const ay = Math.floor(a / MAX_DIMENSION);
+    const bx = b % MAX_DIMENSION;
+    const by = Math.floor(b / MAX_DIMENSION);
+    assert(Math.abs(ax - bx) <= 1 && Math.abs(ay - by) <= 1);
+  }
+}
+
+// Regression: ensure paths touching multiple cut pixels merge correctly
+{
+  const R0 = coordToIndex(0, 0);
+  const R1 = coordToIndex(0, 1);
+  const R2 = coordToIndex(1, 0);
+  const R3 = coordToIndex(2, 0);
+  const pixels = [R0, R1, R2, R3];
+  const paths = solve(pixels);
+  assert.strictEqual(paths.length, 1);
+  const path = paths[0];
+  const set = new Set(path);
+  assert.strictEqual(set.size, pixels.length);
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1];
+    const b = path[i];
+    const ax = a % MAX_DIMENSION;
+    const ay = Math.floor(a / MAX_DIMENSION);
+    const bx = b % MAX_DIMENSION;
+    const by = Math.floor(b / MAX_DIMENSION);
+    assert(Math.abs(ax - bx) <= 1 && Math.abs(ay - by) <= 1);
+  }
+}


### PR DESCRIPTION
## Summary
- Correct `stitchPaths` to orient split segments around cut pixels consistently and avoid stray fragments
- Extend regression test to verify stitched paths remain contiguous
- Fix grouping to merge across all cut pixels and add regression test for multi-cut paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f1f5ab20832cb52103626bfdb394