### PR TITLE
Ensure cut pixels are endpoints before stitching and optimize merging

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,6 +4,7 @@ import {
   findDegree2CutSet,
   useHamiltonianService,
   solve,
+  stitchPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -66,4 +67,28 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Test stitchPaths splitting when cut pixel is internal
+{
+  const left = [[1, 2, 3, 4]];
+  const right = [[3, 5]];
+  const merged = stitchPaths(left, right, 3);
+  assert.deepStrictEqual(merged, [
+    [3, 4],
+    [1, 2, 3, 5],
+  ]);
+}
+
+// Test merging three paths sharing a cut pixel
+{
+  const first = [[0, 1]];
+  const second = [[2, 0]];
+  const third = [[0, 3]];
+  let merged = stitchPaths(first, second, 0);
+  merged = stitchPaths(merged, third, 0);
+  assert.deepStrictEqual(merged, [
+    [0, 2],
+    [1, 0, 3],
+  ]);
 }


### PR DESCRIPTION
## Summary
- Split paths at cut pixels when stitching to avoid interior cut points
- Propagate cut pixels as start or end when solving partitions and group merges by cut pixel
- Add tests for interior cut pixel splitting and merging more than two paths around a cut

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7fcb79d6c832c9516c261e7f82f4d