### PR TITLE
Ensure cut pixels are endpoints before stitching and optimize merging

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -172,6 +172,9 @@ function mergeCutPaths(paths, cutPixels) {
       }
     }
   }
+  for (const p of res) {
+    if (p.length > 1 && p[0] === p[p.length - 1]) p.pop();
+  }
   return res;
 }
 

--- a/src/services/hamiltonianWorker.js
+++ b/src/services/hamiltonianWorker.js
@@ -1,13 +1,7 @@
 import { solve } from './hamiltonian.js';
 
-try {
-  const { parentPort, workerData } = await import('node:worker_threads');
-  const result = await solve(workerData.input, { ...workerData.opts, worker: true });
-  parentPort.postMessage(result);
-} catch {
-  self.onmessage = async (e) => {
-    const { input, opts } = e.data;
-    const result = await solve(input, { ...opts, worker: true });
-    self.postMessage(result);
-  };
-}
+self.onmessage = async (e) => {
+  const { input, opts } = e.data;
+  const result = await solve(input, { ...opts, worker: true });
+  self.postMessage(result);
+};

--- a/src/services/hamiltonianWorker.js
+++ b/src/services/hamiltonianWorker.js
@@ -1,0 +1,13 @@
+import { solve } from './hamiltonian.js';
+
+try {
+  const { parentPort, workerData } = await import('node:worker_threads');
+  const result = await solve(workerData.input, { ...workerData.opts, worker: true });
+  parentPort.postMessage(result);
+} catch {
+  self.onmessage = async (e) => {
+    const { input, opts } = e.data;
+    const result = await solve(input, { ...opts, worker: true });
+    self.postMessage(result);
+  };
+}

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -217,7 +217,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
     });
 
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'path' || nodeTree.selectedLayerCount !== 1) return;
         if (pixels.length !== 1) return;
 
@@ -228,9 +228,12 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.WAIT, rect: CURSOR_STYLE.WAIT });
 
         const allPixels = pixelStore.get(layerId);
-        const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
-
-        tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
+        let paths = [];
+        try {
+            paths = await hamiltonian.traverseWithStart(allPixels, startPixel);
+        } finally {
+            tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
+        }
 
         if (!paths.length) return;
 

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,6 +4,7 @@ import {
   findDegree2CutSet,
   useHamiltonianService,
   solve,
+  stitchPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -27,7 +28,7 @@ const pixels = [A, B, C, D];
 // Test solver on the same graph
 {
   const service = useHamiltonianService();
-  const paths = service.traverseFree(pixels);
+  const paths = await service.traverseFree(pixels);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -35,7 +36,7 @@ const pixels = [A, B, C, D];
 
 // Test solver with descending degree order
 {
-  const paths = solve(pixels, { degreeOrder: 'descending' });
+  const paths = await solve(pixels, { degreeOrder: 'descending' });
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -66,4 +67,36 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Test stitchPaths splitting when cut pixel is internal
+{
+  const left = [[1, 2, 3, 4]];
+  const right = [[3, 5]];
+  const merged = stitchPaths(left, right, 3);
+  assert.deepStrictEqual(merged, [
+    [3, 4],
+    [1, 2, 3, 5],
+  ]);
+}
+
+// Test merging two paths sharing the same start tile
+{
+  const first = [[0, 1]];
+  const second = [[0, 2]];
+  const merged = stitchPaths(first, second, 0);
+  assert.deepStrictEqual(merged, [[1, 0, 2]]);
+}
+
+// Test merging three paths sharing a cut pixel
+{
+  const first = [[0, 1]];
+  const second = [[2, 0]];
+  const third = [[0, 3]];
+  let merged = stitchPaths(first, second, 0);
+  merged = stitchPaths(merged, third, 0);
+  assert.deepStrictEqual(merged, [
+    [0, 2],
+    [1, 0, 3],
+  ]);
 }

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -112,3 +112,14 @@ const pixels = [A, B, C, D];
   const merged = mergeCutPaths(paths, [1, 2]);
   assert.deepStrictEqual(merged, [[20, 2, 10, 1, 30]]);
 }
+
+// Test removing duplicate endpoints in a circular path
+{
+  const paths = [
+    [1, 2],
+    [2, 3],
+    [3, 1],
+  ];
+  const merged = mergeCutPaths(paths, [1, 2, 3]);
+  assert.deepStrictEqual(merged, [[3, 2, 1]]);
+}

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -5,6 +5,7 @@ import {
   useHamiltonianService,
   solve,
   stitchPaths,
+  mergeCutPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -99,4 +100,15 @@ const pixels = [A, B, C, D];
     [0, 2],
     [1, 0, 3],
   ]);
+}
+
+// Test merging paths across multiple cut pixels to avoid duplication
+{
+  const paths = [
+    [1, 10, 2],
+    [2, 20],
+    [1, 30],
+  ];
+  const merged = mergeCutPaths(paths, [1, 2]);
+  assert.deepStrictEqual(merged, [[20, 2, 10, 1, 30]]);
 }


### PR DESCRIPTION
## Summary
- Split paths at cut pixels during stitching to avoid interior cut points
- Propagate cut pixels as start or end when solving partitions and group merges by cut pixel
- Parallelize solving by running each partition in a worker and expose async traversal APIs
- Add tests using the asynchronous solver

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fcb79d6c832c9516c261e7f82f4d