### PR TITLE
Handle start-end solve fallback at tile level

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -126,14 +126,56 @@ function partitionAtCut(nodes, neighbors, cutSet) {
 
 // Merge two path covers using the shared cut pixel
 function stitchPaths(left, right, cutPixel) {
-  const li = left.findIndex((p) => p.includes(cutPixel));
-  const ri = right.findIndex((p) => p.includes(cutPixel));
-  const lPath = left.splice(li, 1)[0];
-  const rPath = right.splice(ri, 1)[0];
-  if (lPath[lPath.length - 1] !== cutPixel) lPath.reverse();
-  if (rPath[0] !== cutPixel) rPath.reverse();
+  function extract(paths, needEnd) {
+    const idx = paths.findIndex((p) => p.includes(cutPixel));
+    const path = paths.splice(idx, 1)[0];
+    const pos = path.indexOf(cutPixel);
+    if (needEnd) {
+      if (pos === path.length - 1) return path;
+      if (pos === 0) return path.reverse();
+      const before = path.slice(0, pos + 1); // ends with cutPixel
+      const after = path.slice(pos); // starts with cutPixel
+      paths.push(after);
+      return before;
+    }
+    // need cutPixel at start
+    if (pos === 0) return path;
+    if (pos === path.length - 1) return path.reverse();
+    const before = path.slice(0, pos + 1); // ends with cutPixel
+    const after = path.slice(pos); // starts with cutPixel
+    paths.push(before);
+    return after;
+  }
+
+  const lPath = extract(left, true); // ends with cutPixel
+  const rPath = extract(right, false); // starts with cutPixel
   const joined = lPath.concat(rPath.slice(1));
   return [...left, ...right, joined];
+}
+
+// Merge all paths sharing any cut pixel until none remain duplicated
+function mergeCutPaths(paths, cutPixels) {
+  let res = paths.slice();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const cp of cutPixels) {
+      const group = res.filter((p) => p.includes(cp));
+      if (group.length > 1) {
+        let merged = [group.shift()];
+        for (const p of group) {
+          merged = stitchPaths(merged, [p], cp);
+        }
+        res = res.filter((p) => !p.includes(cp));
+        res.push(...merged);
+        changed = true;
+      }
+    }
+  }
+  for (const p of res) {
+    if (p.length > 1 && p[0] === p[p.length - 1]) p.pop();
+  }
+  return res;
 }
 
 // Find connected components from an adjacency list
@@ -167,7 +209,7 @@ function getComponents(neighbors) {
 }
 
 // Core solver using backtracking to find minimum path cover
-function solve(input, opts = {}) {
+function solveSequential(input, opts = {}) {
   let nodes, neighbors, degrees, indexMap;
   if (input && input.nodes && input.neighbors && input.degrees) {
     ({ nodes, neighbors, degrees } = input);
@@ -188,24 +230,16 @@ function solve(input, opts = {}) {
       if (opts.end != null && part.nodes.includes(opts.end))
         partOpts.end = opts.end;
       if (opts.degreeOrder) partOpts.degreeOrder = opts.degreeOrder;
-      results.push(solve(part, partOpts));
-    }
-    let combined = results.shift();
-    for (const res of results) {
-      let merged = false;
-      for (const cp of cutPixels) {
-        if (
-          combined.some((p) => p.includes(cp)) &&
-          res.some((p) => p.includes(cp))
-        ) {
-          combined = stitchPaths(combined, res, cp);
-          merged = true;
-          break;
-        }
+      const partCuts = cutPixels.filter((cp) => part.nodes.includes(cp));
+      for (const cp of partCuts) {
+        if (partOpts.start == null && cp !== partOpts.end) partOpts.start = cp;
+        else if (partOpts.end == null && cp !== partOpts.start)
+          partOpts.end = cp;
       }
-      if (!merged) combined = combined.concat(res);
+      results.push(solveSequential(part, partOpts));
     }
-    return combined;
+
+    return mergeCutPaths(results.flat(), cutPixels);
   }
 
   const xs = new Int32Array(nodes.length);
@@ -244,10 +278,11 @@ function solve(input, opts = {}) {
   const startTime = Date.now();
   let timeExceeded = false;
 
-  function checkTime(acc) {
+  function checkTime(acc, partial) {
     if (Date.now() - startTime > TIME_LIMIT) {
-      if (!best.paths || acc.length < best.paths.length)
-        best.paths = acc.map((p) => p.slice());
+      let candidate = acc.map((p) => p.slice());
+      if (partial && partial.length) candidate = candidate.concat([partial.slice()]);
+      if (!best.paths || candidate.length < best.paths.length) best.paths = candidate;
       timeExceeded = true;
       return true;
     }
@@ -303,7 +338,7 @@ function solve(input, opts = {}) {
 
   function extend(node, path, activeCount, acc, isFirst) {
     if (timeExceeded) return;
-    if (checkTime(acc)) return;
+    if (checkTime(acc, path)) return;
     if (best.paths && acc.length + 1 >= best.paths.length) return;
     const nbs = neighbors[node];
     nbs.sort((a, b) => {
@@ -343,8 +378,131 @@ function solve(input, opts = {}) {
   return paths;
 }
 
+async function runWorker(input, opts) {
+  if (typeof window === 'undefined' || typeof Worker === 'undefined') {
+    return Promise.resolve(solveSequential(input, opts));
+  }
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./hamiltonianWorker.js', import.meta.url), {
+      type: 'module',
+    });
+    worker.onmessage = (e) => resolve(e.data);
+    worker.onerror = reject;
+    worker.postMessage({ input, opts });
+  });
+}
+
+async function solveCore(input, opts = {}) {
+  let nodes, neighbors, degrees;
+  if (input && input.nodes && input.neighbors && input.degrees) {
+    ({ nodes, neighbors, degrees } = input);
+  } else {
+    ({ nodes, neighbors, degrees } = buildGraph(input));
+  }
+
+  const cutSet = findDegree2CutSet(neighbors, degrees);
+  let paths;
+  if (cutSet && cutSet.length) {
+    const parts = partitionAtCut(nodes, neighbors, cutSet);
+    const cutPixels = cutSet.map((i) => nodes[i]);
+    if (
+      typeof window !== 'undefined' &&
+      typeof Worker !== 'undefined' &&
+      !opts.worker
+    ) {
+      const promises = parts.map((part) => {
+        const partOpts = {};
+        if (opts.start != null && part.nodes.includes(opts.start))
+          partOpts.start = opts.start;
+        if (opts.end != null && part.nodes.includes(opts.end))
+          partOpts.end = opts.end;
+        if (opts.degreeOrder) partOpts.degreeOrder = opts.degreeOrder;
+        const partCuts = cutPixels.filter((cp) => part.nodes.includes(cp));
+        for (const cp of partCuts) {
+          if (partOpts.start == null && cp !== partOpts.end) partOpts.start = cp;
+          else if (partOpts.end == null && cp !== partOpts.start)
+            partOpts.end = cp;
+        }
+        return runWorker(part, partOpts);
+      });
+      const results = await Promise.all(promises);
+      paths = mergeCutPaths(results.flat(), cutPixels);
+    } else {
+      const results = [];
+      const batch = opts.yieldEvery || 1;
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        const partOpts = {};
+        if (opts.start != null && part.nodes.includes(opts.start))
+          partOpts.start = opts.start;
+        if (opts.end != null && part.nodes.includes(opts.end))
+          partOpts.end = opts.end;
+        if (opts.degreeOrder) partOpts.degreeOrder = opts.degreeOrder;
+        const partCuts = cutPixels.filter((cp) => part.nodes.includes(cp));
+        for (const cp of partCuts) {
+          if (partOpts.start == null && cp !== partOpts.end) partOpts.start = cp;
+          else if (partOpts.end == null && cp !== partOpts.start)
+            partOpts.end = cp;
+        }
+        results.push(solveSequential(part, partOpts));
+        if ((i + 1) % batch === 0) await new Promise((r) => setTimeout(r));
+      }
+      paths = mergeCutPaths(results.flat(), cutPixels);
+    }
+  } else {
+    paths = solveSequential(input, opts);
+  }
+
+  return paths;
+}
+
+export async function solve(input, opts = {}) {
+  if (opts.start != null && opts.end != null) {
+    const base = {
+      degreeOrder: opts.degreeOrder,
+      worker: opts.worker,
+      yieldEvery: opts.yieldEvery,
+    };
+    let graph = input;
+    if (!(graph && graph.nodes && graph.neighbors && graph.degrees)) {
+      graph = buildGraph(input);
+    }
+    const startOnly = await solveCore(
+      { ...graph, degrees: graph.degrees.slice() },
+      { ...base, start: opts.start }
+    );
+    const startPath = startOnly.find((p) => p[0] === opts.start);
+    if (
+      startOnly.length === 1 &&
+      startPath &&
+      startPath[startPath.length - 1] === opts.end
+    ) {
+      return startOnly;
+    }
+
+    const startEnd = await solveCore(
+      { ...graph, degrees: graph.degrees.slice() },
+      { ...base, start: opts.start, end: opts.end }
+    );
+    const sePath = startEnd.find(
+      (p) => p[0] === opts.start && p[p.length - 1] === opts.end
+    );
+    if (startEnd.length === 1 && sePath) {
+      return startEnd;
+    }
+
+    const endOnly = await solveCore(
+      { ...graph, degrees: graph.degrees.slice() },
+      { ...base, start: opts.end }
+    );
+    return startOnly.length <= endOnly.length ? startOnly : endOnly;
+  }
+
+  return solveCore(input, opts);
+}
+
 export const useHamiltonianService = () => {
-  function traverseWithStart(pixels, start) {
+  async function traverseWithStart(pixels, start) {
     const { nodes, neighbors, indexMap } = buildGraph(pixels);
     const { components, compIndex } = getComponents(neighbors);
     const startIdx = indexMap.get(start);
@@ -354,43 +512,52 @@ export const useHamiltonianService = () => {
     for (let i = 0; i < components.length; i++) {
       const compPixels = components[i].map((idx) => nodes[idx]);
       if (compIndex[startIdx] === i) {
-        result.push(...solve(compPixels, { start }));
+        const paths = await solve(compPixels, { start });
+        result.push(...paths);
       } else {
-        result.push(...solve(compPixels));
+        const paths = await solve(compPixels);
+        result.push(...paths);
       }
     }
     return result;
   }
 
-  function traverseWithStartEnd(pixels, start, end) {
+  async function traverseWithStartEnd(pixels, start, end) {
     const { nodes, neighbors, indexMap } = buildGraph(pixels);
     const { components, compIndex } = getComponents(neighbors);
     const startIdx = indexMap.get(start);
     const endIdx = indexMap.get(end);
     if (startIdx === undefined) throw new Error('Start pixel missing');
     if (endIdx === undefined) throw new Error('End pixel missing');
-    if (compIndex[startIdx] !== compIndex[endIdx])
-      throw new Error('Start and end pixels are disconnected');
 
     const result = [];
     for (let i = 0; i < components.length; i++) {
       const compPixels = components[i].map((idx) => nodes[idx]);
-      if (compIndex[startIdx] === i) {
-        result.push(...solve(compPixels, { start, end }));
+      if (compIndex[startIdx] === i && compIndex[endIdx] === i) {
+        const paths = await solve(compPixels, { start, end });
+        result.push(...paths);
+      } else if (compIndex[startIdx] === i) {
+        const paths = await solve(compPixels, { start });
+        result.push(...paths);
+      } else if (compIndex[endIdx] === i) {
+        const paths = await solve(compPixels, { start: end });
+        result.push(...paths);
       } else {
-        result.push(...solve(compPixels));
+        const paths = await solve(compPixels);
+        result.push(...paths);
       }
     }
     return result;
   }
 
-  function traverseFree(pixels) {
+  async function traverseFree(pixels) {
     const { nodes, neighbors } = buildGraph(pixels);
     const { components } = getComponents(neighbors);
     const result = [];
     for (const comp of components) {
       const compPixels = comp.map((idx) => nodes[idx]);
-      result.push(...solve(compPixels));
+      const paths = await solve(compPixels);
+      result.push(...paths);
     }
     return result;
   }
@@ -402,4 +569,4 @@ export const useHamiltonianService = () => {
   };
 };
 
-export { buildGraph, findDegree2CutSet, solve };
+export { buildGraph, findDegree2CutSet, stitchPaths, mergeCutPaths };

--- a/src/services/hamiltonianWorker.js
+++ b/src/services/hamiltonianWorker.js
@@ -1,0 +1,7 @@
+import { solve } from './hamiltonian.js';
+
+self.onmessage = async (e) => {
+  const { input, opts } = e.data;
+  const result = await solve(input, { ...opts, worker: true });
+  self.postMessage(result);
+};

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -217,7 +217,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
     });
 
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'path' || nodeTree.selectedLayerCount !== 1) return;
         if (pixels.length !== 1) return;
 
@@ -228,9 +228,12 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.WAIT, rect: CURSOR_STYLE.WAIT });
 
         const allPixels = pixelStore.get(layerId);
-        const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
-
-        tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
+        let paths = [];
+        try {
+            paths = await hamiltonian.traverseWithStart(allPixels, startPixel);
+        } finally {
+            tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
+        }
 
         if (!paths.length) return;
 

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,6 +4,8 @@ import {
   findDegree2CutSet,
   useHamiltonianService,
   solve,
+  stitchPaths,
+  mergeCutPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -27,7 +29,7 @@ const pixels = [A, B, C, D];
 // Test solver on the same graph
 {
   const service = useHamiltonianService();
-  const paths = service.traverseFree(pixels);
+  const paths = await service.traverseFree(pixels);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -35,7 +37,7 @@ const pixels = [A, B, C, D];
 
 // Test solver with descending degree order
 {
-  const paths = solve(pixels, { degreeOrder: 'descending' });
+  const paths = await solve(pixels, { degreeOrder: 'descending' });
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -66,4 +68,92 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Test stitchPaths splitting when cut pixel is internal
+{
+  const left = [[1, 2, 3, 4]];
+  const right = [[3, 5]];
+  const merged = stitchPaths(left, right, 3);
+  assert.deepStrictEqual(merged, [
+    [3, 4],
+    [1, 2, 3, 5],
+  ]);
+}
+
+// Test merging two paths sharing the same start tile
+{
+  const first = [[0, 1]];
+  const second = [[0, 2]];
+  const merged = stitchPaths(first, second, 0);
+  assert.deepStrictEqual(merged, [[1, 0, 2]]);
+}
+
+// Test merging three paths sharing a cut pixel
+{
+  const first = [[0, 1]];
+  const second = [[2, 0]];
+  const third = [[0, 3]];
+  let merged = stitchPaths(first, second, 0);
+  merged = stitchPaths(merged, third, 0);
+  assert.deepStrictEqual(merged, [
+    [0, 2],
+    [1, 0, 3],
+  ]);
+}
+
+// Test merging paths across multiple cut pixels to avoid duplication
+{
+  const paths = [
+    [1, 10, 2],
+    [2, 20],
+    [1, 30],
+  ];
+  const merged = mergeCutPaths(paths, [1, 2]);
+  assert.deepStrictEqual(merged, [[20, 2, 10, 1, 30]]);
+}
+
+// Test removing duplicate endpoints in a circular path
+{
+  const paths = [
+    [1, 2],
+    [2, 3],
+    [3, 1],
+  ];
+  const merged = mergeCutPaths(paths, [1, 2, 3]);
+  assert.deepStrictEqual(merged, [[3, 2, 1]]);
+}
+
+// Test solver-level fallback when start-end path cannot cover all pixels
+{
+  const coords = [
+    [1, 1], // center
+    [0, 2], // left arm
+    [2, 2], // right arm
+    [1, 0], // top arm
+  ];
+  const pixels = coords.map(([x, y]) => coordToIndex(x, y));
+  const start = coordToIndex(0, 2);
+  const end = coordToIndex(2, 2);
+  const result = await solve(pixels, { start, end });
+  const startOnly = await solve(pixels, { start });
+  const endOnly = await solve(pixels, { start: end });
+const eqStart = JSON.stringify(result) === JSON.stringify(startOnly);
+const eqEnd = JSON.stringify(result) === JSON.stringify(endOnly);
+assert(eqStart || eqEnd);
+}
+
+// Test time limit fallback preserves partial anchor path
+{
+  const origNow = Date.now;
+  let call = 0;
+  Date.now = () => (call++ % 4 === 3 ? 8000 : 0);
+  try {
+    const idx = (x, y) => x + MAX_DIMENSION * y;
+    const pixels = [idx(0, 0), idx(1, 0), idx(0, 1)];
+    const result = await solve(pixels, { start: pixels[0], end: pixels[1] });
+    assert(result.some((p) => p.length > 1));
+  } finally {
+    Date.now = origNow;
+  }
 }


### PR DESCRIPTION
## Summary
- Capture in-progress path when Hamiltonian search times out so fallback stitching uses single-anchor results instead of fragmented pixels
- Test timeout handling by stubbing `Date.now` and verifying a partial anchored path is returned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fcb79d6c832c9516c261e7f82f4d