### PR TITLE
Simplify cut-set search to pairs

### DIFF
--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -42,7 +42,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         if (tool.prepared !== 'draw' || nodeTree.selectedLayerCount !== 1) return;
         overlayService.setPixels(overlayId, pixels);
     });
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'draw' || nodeTree.selectedLayerCount !== 1) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
@@ -85,7 +85,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         const sourcePixels = new Set(pixelStore.get(sourceId));
         overlayService.setPixels(overlayId, pixels.filter(pixel => sourcePixels.has(pixel)));
     });
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'erase' || nodeTree.selectedLayerCount !== 1) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
@@ -217,7 +217,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
     });
 
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'path' || nodeTree.selectedLayerCount !== 1) return;
         if (pixels.length !== 1) return;
 
@@ -228,7 +228,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.WAIT, rect: CURSOR_STYLE.WAIT });
 
         const allPixels = pixelStore.get(layerId);
-        const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
+        const paths = await hamiltonian.traverseWithStart(allPixels, startPixel);
 
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
 

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,6 +4,7 @@ import {
   findDegree2CutSet,
   useHamiltonianService,
   solve,
+  stitchPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -66,4 +67,25 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Ensure cut pixel is excluded and neighbor becomes start
+{
+  const cut = coordToIndex(1, 1);
+  const left = coordToIndex(0, 1);
+  const right = coordToIndex(2, 1);
+  const path = solve([left, cut, right], { start: cut })[0];
+  assert.strictEqual(path.length, 3);
+  assert.strictEqual(path[1], cut);
+  assert.notStrictEqual(path[0], cut);
+  assert.notStrictEqual(path[2], cut);
+}
+
+// Verify stitching joins paths using neighbor endpoints
+{
+  const cut = 42;
+  const left = [[1]];
+  const right = [[3]];
+  const merged = stitchPaths(left, right, cut, 1, 3);
+  assert.deepStrictEqual(merged, [[1, cut, 3]]);
 }

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -28,7 +28,7 @@ const pixels = [A, B, C, D];
 // Test solver on the same graph
 {
   const service = useHamiltonianService();
-  const paths = service.traverseFree(pixels);
+  const paths = await service.traverseFree(pixels);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -36,7 +36,7 @@ const pixels = [A, B, C, D];
 
 // Test solver with descending degree order
 {
-  const paths = solve(pixels, { degreeOrder: 'descending' });
+  const paths = await solve(pixels, { degreeOrder: 'descending' });
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -74,11 +74,25 @@ const pixels = [A, B, C, D];
   const cut = coordToIndex(1, 1);
   const left = coordToIndex(0, 1);
   const right = coordToIndex(2, 1);
-  const path = solve([left, cut, right], { start: cut })[0];
+  const path = (await solve([left, cut, right], { start: cut }))[0];
   assert.strictEqual(path.length, 3);
   assert.strictEqual(path[1], cut);
   assert.notStrictEqual(path[0], cut);
   assert.notStrictEqual(path[2], cut);
+}
+
+// Separate component still yields minimal paths with anchors satisfied
+{
+  const s1 = coordToIndex(0, 0);
+  const s2 = coordToIndex(1, 0);
+  const e = coordToIndex(2, 0);
+  const o1 = coordToIndex(4, 0);
+  const o2 = coordToIndex(5, 0);
+  const paths = await solve([s1, s2, e, o1, o2], { start: s1, end: e });
+  assert.strictEqual(paths.length, 2);
+  const endpoints = paths.flatMap((p) => [p[0], p[p.length - 1]]);
+  assert(endpoints.includes(s1));
+  assert(endpoints.includes(e));
 }
 
 // Verify stitching joins paths using neighbor endpoints


### PR DESCRIPTION
## Summary
- exclude cut nodes from partitioned subgraphs and use their unique neighbors as endpoints
- stitch partitions by reconnecting neighbor endpoints through the cut pixel
- verify neighbor-based endpoints and updated stitching behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87de8ac68832c964d8a7146f2469a