### PR TITLE
Exclude cut pixels from partitions and use neighbor endpoints

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,17 +4,17 @@ import {
   partitionAtDegree2Cut,
   useHamiltonianService,
   solve,
+  stitchPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
 const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 
-// Construct diamond graph: A(1,0), B(0,1), C(2,1), D(1,2)
-const A = coordToIndex(1, 0);
-const B = coordToIndex(0, 1);
-const C = coordToIndex(2, 1);
-const D = coordToIndex(1, 2);
-const pixels = [A, B, C, D];
+// Construct linear graph: A(0,0), B(1,0), C(2,0)
+const A = coordToIndex(0, 0);
+const B = coordToIndex(1, 0);
+const C = coordToIndex(2, 0);
+const pixels = [A, B, C];
 
 // Test cut detection and partitioning
 {
@@ -22,8 +22,11 @@ const pixels = [A, B, C, D];
   const res = partitionAtDegree2Cut(nodes, neighbors, degrees);
   assert(res);
   assert(Array.isArray(res.cut));
-  assert.strictEqual(res.cut.length, 2);
+  assert.strictEqual(res.cut.length, 1);
   assert(res.left && res.right);
+  const cutPixel = nodes[res.cut[0]];
+  assert(!res.left.nodes.includes(cutPixel));
+  assert(!res.right.nodes.includes(cutPixel));
 }
 
 // Test solver on the same graph
@@ -68,4 +71,20 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Test stitching when cut pixel lies in the middle of a path
+{
+  const left = [[1, 4, 2, 3]];
+  const right = [[4, 5]];
+  const res = stitchPaths([...left], [...right], 4);
+  assert.deepStrictEqual(res, [[2, 3], [1, 4, 5]]);
+}
+
+// Test stitching when cut pixel is excluded from subpaths
+{
+  const left = [[1, 2]];
+  const right = [[3, 4]];
+  const res = stitchPaths([...left], [...right], 5, 2, 3);
+  assert.deepStrictEqual(res, [[1, 2, 5, 3, 4]]);
 }


### PR DESCRIPTION
## Summary
- Skip cut nodes when partitioning and track their adjacent node per component
- Use the adjacent node as start or end for subproblems and join paths via the removed cut pixel
- Extend tests to verify partitions omit cut pixels and stitching works with excluded cut nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b92a13cf94832c8809b63f72eed2b9