### PR TITLE
Ensure cut pixel endpoints and robust stitching

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -131,10 +131,32 @@ function partitionAtDegree2Cut(nodes, neighbors, degrees) {
 function stitchPaths(left, right, cutPixel) {
   const li = left.findIndex((p) => p.includes(cutPixel));
   const ri = right.findIndex((p) => p.includes(cutPixel));
-  const lPath = left.splice(li, 1)[0];
-  const rPath = right.splice(ri, 1)[0];
-  if (lPath[lPath.length - 1] !== cutPixel) lPath.reverse();
-  if (rPath[0] !== cutPixel) rPath.reverse();
+  let lPath = left.splice(li, 1)[0];
+  let rPath = right.splice(ri, 1)[0];
+
+  let idx = lPath.indexOf(cutPixel);
+  if (idx !== lPath.length - 1) {
+    if (idx === 0) {
+      lPath.reverse();
+      idx = lPath.indexOf(cutPixel);
+    } else {
+      const tail = lPath.slice(idx + 1);
+      lPath = lPath.slice(0, idx + 1);
+      if (tail.length) left.push(tail);
+    }
+  }
+
+  idx = rPath.indexOf(cutPixel);
+  if (idx !== 0) {
+    if (idx === rPath.length - 1) {
+      rPath.reverse();
+    } else {
+      const head = rPath.slice(0, idx);
+      rPath = rPath.slice(idx);
+      if (head.length) right.push(head);
+    }
+  }
+
   const joined = lPath.concat(rPath.slice(1));
   return [...left, ...right, joined];
 }
@@ -337,6 +359,11 @@ function solve(input, opts = {}) {
       const partOpts = {};
       if (opts.start != null && part.nodes.includes(opts.start)) partOpts.start = opts.start;
       if (opts.end != null && part.nodes.includes(opts.end)) partOpts.end = opts.end;
+      for (const cp of cutPixels) {
+        if (!part.nodes.includes(cp)) continue;
+        if (partOpts.start == null) partOpts.start = cp;
+        else if (partOpts.end == null) partOpts.end = cp;
+      }
       if (opts.degreeOrder) partOpts.degreeOrder = opts.degreeOrder;
       results.push(solve(part, partOpts));
     }
@@ -414,4 +441,4 @@ class HamiltonianService {
 
 export const useHamiltonianService = () => new HamiltonianService();
 
-export { buildGraph, partitionAtDegree2Cut, solve };
+export { buildGraph, partitionAtDegree2Cut, solve, stitchPaths };

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -4,6 +4,7 @@ import {
   partitionAtDegree2Cut,
   useHamiltonianService,
   solve,
+  stitchPaths,
 } from '../src/services/hamiltonian.js';
 
 const MAX_DIMENSION = 65536;
@@ -68,4 +69,13 @@ const pixels = [A, B, C, D];
     coordToIndex(3, 1), // right-up
   ].sort((a, b) => a - b);
   assert.deepStrictEqual(neighborPixels, expected);
+}
+
+// Test stitching when cut pixel lies inside paths
+{
+  const cut = 0;
+  const left = [[1, cut, 2]];
+  const right = [[3, cut, 4]];
+  const stitched = stitchPaths(left, right, cut);
+  assert.deepStrictEqual(stitched, [[2], [3], [1, cut, 4]]);
 }


### PR DESCRIPTION
## Summary
- Guarantee cut pixels become path endpoints during recursive solving
- Improve `stitchPaths` to split paths when cut pixel occurs mid-path
- Add unit test covering internal cut pixel stitching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92a13cf94832c8809b63f72eed2b9