### PR TITLE
refactor: async best-path search

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -29,7 +29,7 @@ const pixels = [A, B, C, D];
 // Test solver on the same graph
 {
   const service = useHamiltonianService();
-  const paths = service.traverseFree(pixels);
+  const paths = await service.traverseFree(pixels);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -37,7 +37,7 @@ const pixels = [A, B, C, D];
 
 // Test solver with descending degree order
 {
-  const paths = solve(pixels, { degreeOrder: 'descending' });
+  const paths = await solve(pixels, { degreeOrder: 'descending' });
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);


### PR DESCRIPTION
## Summary
- track and update best path with anchor-aware priority and yield the event loop between comparisons
- move time-limit checks after comparisons and allow partitions to run asynchronously
- expose async traversal APIs for start/end/ free traversal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94e85608c832cb205602fd7eb2302