### PR TITLE
Refactor Hamiltonian solver for async concurrency

### DIFF
--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -42,7 +42,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         if (tool.prepared !== 'draw' || nodeTree.selectedLayerCount !== 1) return;
         overlayService.setPixels(overlayId, pixels);
     });
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'draw' || nodeTree.selectedLayerCount !== 1) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
@@ -217,7 +217,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
     });
 
-    watch(() => tool.affectedPixels, (pixels) => {
+    watch(() => tool.affectedPixels, async (pixels) => {
         if (tool.prepared !== 'path' || nodeTree.selectedLayerCount !== 1) return;
         if (pixels.length !== 1) return;
 
@@ -228,7 +228,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.WAIT, rect: CURSOR_STYLE.WAIT });
 
         const allPixels = pixelStore.get(layerId);
-        const paths = hamiltonian.traverseWithStart(allPixels, startPixel);
+        const paths = await hamiltonian.traverseWithStart(allPixels, startPixel);
 
         tool.setCursor({ stroke: CURSOR_STYLE.PATH, rect: CURSOR_STYLE.PATH });
 

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -29,7 +29,7 @@ const pixels = [A, B, C, D];
 // Test solver on the same graph
 {
   const service = useHamiltonianService();
-  const paths = service.traverseFree(pixels);
+  const paths = await service.traverseFree(pixels);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);
@@ -37,7 +37,7 @@ const pixels = [A, B, C, D];
 
 // Test solver with descending degree order
 {
-  const paths = solve(pixels, { degreeOrder: 'descending' });
+  const paths = await solve(pixels, { degreeOrder: 'descending' });
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
   assert.strictEqual(covered.size, pixels.length);


### PR DESCRIPTION
## Summary
- Track best path continuously with priority comparison, time checks, and microtask yielding
- Solve partitions concurrently with `Promise.all` and async solver methods
- Await Hamiltonian path generation in tools and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95396e1ec832cb474eff30811e4a1