### PR TITLE
Remove limit on partitionAtEdgeCut edge combinations

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -123,15 +123,20 @@ function partitionAtEdgeCut(nodes, neighbors) {
     return { cutEdges: edges, parts };
   };
 
-  for (const edge of candidateEdges) {
-    const res = tryEdges([edge]);
-    if (res) return res;
-  }
-  for (let i = 0; i < candidateEdges.length; i++) {
-    for (let j = i + 1; j < candidateEdges.length; j++) {
-      const res = tryEdges([candidateEdges[i], candidateEdges[j]]);
+  const search = (k, start, combo) => {
+    if (combo.length === k) return tryEdges(combo);
+    for (let i = start; i < candidateEdges.length; i++) {
+      combo.push(candidateEdges[i]);
+      const res = search(k, i + 1, combo);
       if (res) return res;
+      combo.pop();
     }
+    return null;
+  };
+
+  for (let k = 1; k <= candidateEdges.length; k++) {
+    const res = search(k, 0, []);
+    if (res) return res;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- allow partitionAtEdgeCut to search through any number of candidate edge cuts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fec7db4832cb7dd56b27123845c