### PR TITLE
refactor: replace recursion in partitionAtEdgeCut

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -125,20 +125,22 @@ function partitionAtEdgeCut(nodes, neighbors) {
     return { cutEdges: edges, parts };
   };
 
-  const search = (k, start, combo) => {
-    if (combo.length === k) return tryEdges(combo);
-    for (let i = start; i < candidateEdges.length; i++) {
-      combo.push(candidateEdges[i]);
-      const res = search(k, i + 1, combo);
-      if (res) return res;
-      combo.pop();
-    }
-    return null;
-  };
-
+  // Iteratively try combinations of candidate edges without recursion
   for (let k = 1; k <= candidateEdges.length; k++) {
-    const res = search(k, 0, []);
-    if (res) return res;
+    const indices = Array.from({ length: k }, (_, i) => i);
+    while (indices.length) {
+      const combo = indices.map((i) => candidateEdges[i]);
+      const res = tryEdges(combo);
+      if (res) return res;
+
+      let pos = k - 1;
+      while (pos >= 0 && indices[pos] === pos + candidateEdges.length - k) pos--;
+      if (pos < 0) break;
+      indices[pos]++;
+      for (let j = pos + 1; j < k; j++) {
+        indices[j] = indices[j - 1] + 1;
+      }
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Replace recursive edge combination search in `partitionAtEdgeCut` with iterative loop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8b82d308832c8f57f044c53b8ee0