### PR TITLE
Add wand operation menu to stage toolbar

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -23,6 +23,19 @@
         </button>
       </div>
 
+      <!-- Wand tools -->
+      <div class="relative">
+        <button @click="wandOpen = !wandOpen" title="Wand" class="p-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
+          <img :src="stageIcons.wand" alt="Wand" class="w-4 h-4">
+        </button>
+        <div v-if="wandOpen" class="absolute z-10 mt-1 flex flex-col rounded-md border border-white/15 bg-white/5">
+          <button v-for="tool in wandTools" :key="tool.type" @click="runWand(tool.type)" class="flex items-center gap-1 px-2 py-1 text-xs hover:bg-white/10">
+            <img :src="tool.icon" :alt="tool.name" class="w-4 h-4">
+            <span>{{ tool.name }}</span>
+          </button>
+        </div>
+      </div>
+
       <!-- Tool Toggles -->
       <div class="inline-flex rounded-md overflow-hidden border border-white/15">
         <button v-for="tool in selectables" :key="tool.type"
@@ -52,11 +65,11 @@
 import { ref, watch } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
-import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS } from '@/constants';
+import { SINGLE_SELECTION_TOOLS, MULTI_SELECTION_TOOLS, WAND_TOOLS } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
 
 const { viewport: viewportStore, nodeTree, input, output } = useStore();
-const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService, settings: settingsService } = useService();
+const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService, settings: settingsService, wand: wandService } = useService();
 
 const fileInput = ref(null);
 function openFileDialog() {
@@ -89,5 +102,12 @@ watch(() => nodeTree.selectedLayerCount, (size, prev) => {
         toolSelectionService.setPrepared(tool);
     }
 });
+
+const wandOpen = ref(false);
+const wandTools = WAND_TOOLS;
+async function runWand(type) {
+  wandOpen.value = false;
+  await wandService.run(type);
+}
 
 </script>

--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -5,13 +5,16 @@ export const SINGLE_SELECTION_TOOLS = [
   { type: 'erase', name: 'Erase', icon: stageIcons.erase },
   { type: 'cut', name: 'Cut', icon: stageIcons.cut },
   { type: 'top', name: 'To Top', icon: stageIcons.top },
-  { type: 'path', name: 'Path', icon: stageIcons.path },
 ];
 
 export const MULTI_SELECTION_TOOLS = [
   { type: 'select', name: 'Select', icon: stageIcons.select },
   { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
   { type: 'direction', name: 'Direction', icon: stageIcons.direction },
+];
+
+export const WAND_TOOLS = [
+  { type: 'path', name: 'Path', icon: stageIcons.path },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -12,6 +12,7 @@ import redo from './redo.svg';
 import path from './path.svg';
 import direction from './direction.svg';
 import settings from './settings.svg';
+import wand from './wand.svg';
 
 export default {
   stroke,
@@ -28,4 +29,5 @@ export default {
   undo,
   redo,
   settings,
+  wand,
 };

--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -121,7 +121,7 @@ function partitionAtEdgeCut(nodes, neighbors) {
       parts.push(buildGraph(comp));
     }
     const singleCount = parts.reduce((acc, p) => acc + (p.nodes.length === 1), 0);
-    if (edges.length > 1 && singleCount >= parts.length - 1) return null;
+    if (singleCount >= parts.length - 1) return null;
     return { cutEdges: edges, parts };
   };
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -3,7 +3,8 @@ import { useLayerToolService } from './layerTool';
 import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
 import { useNodeQueryService } from './nodeQuery';
-import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, useDirectionToolService, usePathToolService } from './tools';
+import { useDrawToolService, useEraseToolService, useTopToolService, useGlobalEraseToolService, useCutToolService, useSelectService, useDirectionToolService } from './tools';
+import { useWandService } from './wand';
 import { useToolSelectionService } from './toolSelection';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
@@ -24,7 +25,6 @@ export {
     useEraseToolService,
     useTopToolService,
     useDirectionToolService,
-    usePathToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -51,8 +51,8 @@ export const useService = () => ({
         direction: useDirectionToolService(),
         cut: useCutToolService(),
         top: useTopToolService(),
-        path: usePathToolService(),
     },
+    wand: useWandService(),
     toolSelection: useToolSelectionService(),
     viewport: useViewportService(),
     stageResize: useStageResizeService(),


### PR DESCRIPTION
## Summary
- add a wand button to the stage toolbar that opens a menu of one-click operations
- move the path action into the wand menu and run it with `traverseFree`
- tighten Hamiltonian partitioning to avoid trivial single-pixel partitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab4a74b78832caf2a62e865b968e1