### PR TITLE
feat: add usable getters for tools

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -1,18 +1,5 @@
 import stageIcons from '../image/stage_toolbar';
 
-export const SINGLE_SELECTION_TOOLS = [
-  { type: 'draw', name: 'Draw', icon: stageIcons.draw },
-  { type: 'erase', name: 'Erase', icon: stageIcons.erase },
-  { type: 'cut', name: 'Cut', icon: stageIcons.cut },
-  { type: 'top', name: 'To Top', icon: stageIcons.top },
-];
-
-export const MULTI_SELECTION_TOOLS = [
-  { type: 'select', name: 'Select', icon: stageIcons.select },
-  { type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase },
-  { type: 'direction', name: 'Direction', icon: stageIcons.direction },
-];
-
 export const WAND_TOOLS = [
   { type: 'path', name: 'Path', icon: stageIcons.path },
 ];

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -39,28 +39,41 @@ export {
     useClipboardService
 };
 
-export const useService = () => ({
-    layerPanel: useLayerPanelService(),
-    layerTool: useLayerToolService(),
-    overlay: useOverlayService(),
-    layerQuery: useLayerQueryService(),
-    nodeQuery: useNodeQueryService(),
-    select: useSelectService(),
-    tools: {
-        draw: useDrawToolService(),
-        erase: useEraseToolService(),
-        globalErase: useGlobalEraseToolService(),
-        direction: useDirectionToolService(),
-        cut: useCutToolService(),
-        top: useTopToolService(),
-        path: usePathToolService(),
-    },
-    toolSelection: useToolSelectionService(),
-    viewport: useViewportService(),
-    stageResize: useStageResizeService(),
-    hamiltonian: useHamiltonianService(),
-    imageLoad: useImageLoadService(),
-    settings: useSettingsService(),
-    shortcut: useShortcutService(),
-    clipboard: useClipboardService()
-});
+export const useService = () => {
+    // Register single-layer tools before multi-layer ones to ensure toolbar order
+    const draw = useDrawToolService();
+    const erase = useEraseToolService();
+    const cut = useCutToolService();
+    const top = useTopToolService();
+    const path = usePathToolService();
+
+    const select = useSelectService();
+    const direction = useDirectionToolService();
+    const globalErase = useGlobalEraseToolService();
+
+    return {
+        layerPanel: useLayerPanelService(),
+        layerTool: useLayerToolService(),
+        overlay: useOverlayService(),
+        layerQuery: useLayerQueryService(),
+        nodeQuery: useNodeQueryService(),
+        select,
+        tools: {
+            draw,
+            erase,
+            cut,
+            top,
+            path,
+            direction,
+            globalErase,
+        },
+        toolSelection: useToolSelectionService(),
+        viewport: useViewportService(),
+        stageResize: useStageResizeService(),
+        hamiltonian: useHamiltonianService(),
+        imageLoad: useImageLoadService(),
+        settings: useSettingsService(),
+        shortcut: useShortcutService(),
+        clipboard: useClipboardService(),
+    };
+};

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { watch } from 'vue';
+import { watch, computed } from 'vue';
 import { useToolSelectionService } from './toolSelection';
 import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
@@ -17,6 +17,7 @@ export const useSelectService = defineStore('selectService', () => {
     const layerPanel = useLayerPanelService();
     const { nodeTree, nodes, keyboardEvent: keyboardEvents } = useStore();
     const layerQuery = useLayerQueryService();
+    const usable = computed(() => true);
     let mode = 'select';
     watch(() => tool.prepared === 'select', (isSelect) => {
         if (!isSelect) {
@@ -105,7 +106,7 @@ export const useSelectService = defineStore('selectService', () => {
             nodeTree.clearSelection();
         }
     });
-    return {};
+    return { usable };
 });
 
 export const useDirectionToolService = defineStore('directionToolService', () => {
@@ -113,6 +114,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
     const tool = useToolSelectionService();
     const layerQuery = useLayerQueryService();
     const overlayService = useOverlayService();
+    const usable = computed(() => true);
     const overlays = PIXEL_DIRECTIONS.map(direction => {
         const id = overlayService.createOverlay();
         overlayService.setStyles(id, {
@@ -203,7 +205,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
         rebuild();
     });
     watch(() => nodeTree.selectedIds, rebuild);
-    return {};
+    return { usable };
 });
 
 export const useGlobalEraseToolService = defineStore('globalEraseToolService', () => {
@@ -212,6 +214,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const usable = computed(() => true);
     watch(() => tool.prepared === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) {
             overlayService.clear(overlayId);
@@ -265,6 +268,6 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             if (pixelsToRemove.length) pixelStore.removePixels(id, pixelsToRemove);
         }
     });
-    return {};
+    return { usable };
 });
 

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -5,9 +5,11 @@ import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
+import { useToolbarStore } from '../stores/toolbar';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
 import { indexToCoord, ensureDirectionPattern } from '../utils';
 import { PIXEL_DIRECTIONS } from '../stores/pixels';
+import stageIcons from '../image/stage_toolbar';
 
 export const useSelectService = defineStore('selectService', () => {
     const tool = useToolSelectionService();
@@ -18,6 +20,8 @@ export const useSelectService = defineStore('selectService', () => {
     const { nodeTree, nodes, keyboardEvent: keyboardEvents } = useStore();
     const layerQuery = useLayerQueryService();
     const usable = computed(() => true);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'select', name: 'Select', icon: stageIcons.select, usable });
     let mode = 'select';
     watch(() => tool.prepared === 'select', (isSelect) => {
         if (!isSelect) {
@@ -115,6 +119,8 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
     const layerQuery = useLayerQueryService();
     const overlayService = useOverlayService();
     const usable = computed(() => true);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'direction', name: 'Direction', icon: stageIcons.direction, usable });
     const overlays = PIXEL_DIRECTIONS.map(direction => {
         const id = overlayService.createOverlay();
         overlayService.setStyles(id, {
@@ -215,6 +221,8 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => true);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase, usable });
     watch(() => tool.prepared === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) {
             overlayService.clear(overlayId);

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -5,7 +5,9 @@ import { useOverlayService } from './overlay';
 import { useLayerPanelService } from './layerPanel';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
+import { useToolbarStore } from '../stores/toolbar';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
+import stageIcons from '../image/stage_toolbar';
 
 export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
@@ -14,6 +16,8 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'draw', name: 'Draw', icon: stageIcons.draw, usable });
     watch(() => tool.prepared === 'draw', (isDraw) => {
         if (!isDraw) {
             overlayService.clear(overlayId);
@@ -56,6 +60,8 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'erase', name: 'Erase', icon: stageIcons.erase, usable });
     watch(() => tool.prepared === 'erase', (isErase) => {
         if (!isErase) {
             overlayService.clear(overlayId);
@@ -101,6 +107,8 @@ export const useCutToolService = defineStore('cutToolService', () => {
     const layerPanel = useLayerPanelService();
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'cut', name: 'Cut', icon: stageIcons.cut, usable });
     watch(() => tool.prepared === 'cut', (isCut) => {
         if (!isCut) {
             overlayService.clear(overlayId);
@@ -167,6 +175,8 @@ export const useTopToolService = defineStore('topToolService', () => {
     const layerQuery = useLayerQueryService();
     const { nodeTree, nodes } = useStore();
     const usable = computed(() => nodeTree.selectedIds.length === 1);
+    const toolbar = useToolbarStore();
+    toolbar.register({ type: 'top', name: 'To Top', icon: stageIcons.top, usable });
     watch(() => tool.prepared === 'top', (isTop) => {
         if (!isTop) {
             overlayService.clear(overlayId);

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { watch } from 'vue';
+import { watch, computed } from 'vue';
 import { useToolSelectionService } from './toolSelection';
 import { useHamiltonianService } from './hamiltonian';
 import { useLayerQueryService } from './layerQuery';
@@ -11,9 +11,10 @@ export const usePathToolService = defineStore('pathToolService', () => {
     const hamiltonian = useHamiltonianService();
     const layerQuery = useLayerQueryService();
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount === 1);
 
     watch(() => tool.prepared, async (p) => {
-        if (p !== 'path' || tool.shape !== 'wand' || nodeTree.selectedLayerCount !== 1) return;
+        if (p !== 'path' || !usable.value) return;
 
         tool.setCursor({ wand: CURSOR_STYLE.WAIT });
 
@@ -56,6 +57,6 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setPrepared('done');
     });
 
-    return {};
+    return { usable };
 });
 

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -7,6 +7,7 @@ import { useViewportStore } from './viewport';
 import { useViewportEventStore } from './viewportEvent';
 import { useKeyboardEventStore } from './keyboardEvent';
 import { useContextMenuStore } from './contextMenu';
+import { useToolbarStore } from './toolbar';
 
 export {
     useInputStore,
@@ -17,7 +18,8 @@ export {
     useViewportStore,
     useViewportEventStore,
     useKeyboardEventStore,
-    useContextMenuStore
+    useContextMenuStore,
+    useToolbarStore
 };
 
 export const useStore = () => ({
@@ -29,5 +31,6 @@ export const useStore = () => ({
     viewport: useViewportStore(),
     viewportEvent: useViewportEventStore(),
     keyboardEvent: useKeyboardEventStore(),
-    contextMenu: useContextMenuStore()
+    contextMenu: useContextMenuStore(),
+    toolbar: useToolbarStore()
 });

--- a/src/stores/toolbar.js
+++ b/src/stores/toolbar.js
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useToolbarStore = defineStore('toolbar', () => {
+    const tools = ref([]);
+
+    function register(tool) {
+        if (!tools.value.find(t => t.type === tool.type)) {
+            tools.value.push(tool);
+        }
+    }
+
+    return { tools, register };
+});


### PR DESCRIPTION
## Summary
- add `usable` getter to every tool service
- refactor tool actions to use `usable` instead of repeating selection checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ca978ec832ca1155415e2868b96