### PR TITLE
Implement tool history and usability fallback

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -90,13 +90,11 @@ const selectables = computed(() => toolbarStore.tools);
 
 const wandOpen = ref(false);
 let previousShape = 'stroke';
-let previousTool = 'select';
 const wandToolTypes = new Set(WAND_TOOLS.map(t => t.type));
 const wandWorking = computed(() => wandToolTypes.has(toolSelectionService.prepared));
 
 function openWand() {
   previousShape = toolSelectionService.shape;
-  previousTool = toolSelectionService.prepared;
   wandOpen.value = true;
   toolSelectionService.setShape('wand');
 }
@@ -109,7 +107,7 @@ function selectWandTool(type) {
 function closeWand() {
   wandOpen.value = false;
   toolSelectionService.setShape(previousShape);
-  toolSelectionService.setPrepared(previousTool);
+  toolSelectionService.findUsable();
 }
 
 function setShape(shape) {

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -28,10 +28,12 @@ export const useSelectService = defineStore('selectService', () => {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'select') return;
+        if (!usable.value) { tool.tryOther(); return; }
         if (!pixel) {
             overlayService.clear(overlayId);
             return;
@@ -63,6 +65,7 @@ export const useSelectService = defineStore('selectService', () => {
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'select') return;
+        if (!usable.value) { tool.tryOther(); return; }
         if (pixel) {
             const id = layerQuery.topVisibleAt(pixel);
             if (id && nodes.getProperty(id, 'locked')) {
@@ -74,6 +77,7 @@ export const useSelectService = defineStore('selectService', () => {
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.prepared !== 'select') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const intersectedIds = [];
         for (const pixel of pixels) {
             const id = layerQuery.topVisibleAt(pixel);
@@ -90,6 +94,7 @@ export const useSelectService = defineStore('selectService', () => {
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.prepared !== 'select') return;
+        if (!usable.value) { tool.tryOther(); return; }
         if (pixels.length > 0) {
             const intersectedIds = new Set();
             for (const pixel of pixels) {
@@ -167,15 +172,19 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
             overlays.forEach(id => overlayService.clear(id));
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         rebuild();
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'direction' || !pixel) return;
+        if (tool.prepared !== 'direction') return;
+        if (!usable.value) { tool.tryOther(); return; }
+        if (!pixel) return;
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.dragPixel, (pixel, prevPixel) => {
-        if (tool.prepared !== 'direction' || pixel == null) return;
+        if (tool.prepared !== 'direction') return;
+        if (!usable.value || pixel == null) { if (!usable.value) tool.tryOther(); return; }
         const target = layerQuery.topVisibleAt(pixel);
         const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
         if (target != null && editable) {
@@ -228,14 +237,17 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'globalErase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.prepared !== 'globalErase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         if (pixel){
             const lockedIds = nodeTree.layerOrder.filter(id => nodes.getProperty(id, 'locked'));
             for (const id of lockedIds) {
@@ -250,6 +262,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.prepared !== 'globalErase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const erasablePixels = [];
         if (pixels.length) {
             const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.getProperty(id, 'locked'));
@@ -264,7 +277,8 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         overlayService.setPixels(overlayId, erasablePixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'globalErase' || !pixels.length) return;
+        if (tool.prepared !== 'globalErase') return;
+        if (!usable.value || !pixels.length) { if (!usable.value) tool.tryOther(); return; }
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
             .filter(id => !nodes.getProperty(id, 'locked'));
         for (const id of targetIds) {

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -16,8 +16,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
     const toolSelectionService = useToolSelectionService();
     const clipboard = useClipboardService();
 
-    let previousTool = toolSelectionService.prepared;
-    let modifierActive = false;
+    let modifierKey = null;
 
     function deleteSelection() {
         if (!nodeTree.selectedNodeCount) return;
@@ -80,8 +79,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
             if (map && !e.repeat) {
                 const change = map[toolSelectionService.prepared] ?? map.default;
                 if (change) {
-                    previousTool = toolSelectionService.prepared;
-                    modifierActive = true;
+                    modifierKey = key;
                     toolSelectionService.setPrepared(change);
                     break;
                 }
@@ -142,27 +140,12 @@ export const useShortcutService = defineStore('shortcutService', () => {
 
     watch(() => keyboardEvents.recent.up, (ups) => {
         for (const e of ups) {
-            if (e.key === 'Shift') {
-                if (toolSelectionService.prepared !== previousTool) {
-                    toolSelectionService.setPrepared(previousTool);
-                }
-                modifierActive = false;
-                break;
-            }
-            if (e.key === 'Control' || e.key === 'Meta') {
-                const down = keyboardEvents.get('keydown', e.key);
-                if (!down || !down.repeat) continue;
-                if (toolSelectionService.prepared !== previousTool) {
-                    toolSelectionService.setPrepared(previousTool);
-                }
-                modifierActive = false;
+            if (e.key === modifierKey) {
+                toolSelectionService.findUsable();
+                modifierKey = null;
                 break;
             }
         }
-    });
-
-    watch(() => toolSelectionService.prepared, (tool) => {
-        if (!modifierActive) previousTool = tool;
     });
 
     return {};

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -23,14 +23,17 @@ export const useDrawToolService = defineStore('drawToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.DRAW_STROKE, rect: CURSOR_STYLE.DRAW_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'draw') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.prepared !== 'draw') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             if (pixel)
@@ -41,11 +44,13 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.prepared !== 'draw') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.prepared !== 'draw') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
         pixelStore.addPixels(id, pixels);
@@ -67,14 +72,17 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'erase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.prepared !== 'erase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -85,13 +93,15 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.prepared !== 'erase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const sourceId = nodeTree.selectedLayerIds[0];
         const sourcePixels = new Set(pixelStore.get(sourceId));
         overlayService.setPixels(overlayId, pixels.filter(pixel => sourcePixels.has(pixel)));
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.prepared !== 'erase') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
         pixelStore.removePixels(id, pixels);
@@ -114,14 +124,17 @@ export const useCutToolService = defineStore('cutToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
         if (tool.prepared !== 'cut') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.prepared !== 'cut') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -132,11 +145,13 @@ export const useCutToolService = defineStore('cutToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.prepared !== 'cut') return;
+        if (!usable.value) { tool.tryOther(); return; }
         overlayService.setPixels(overlayId, pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.prepared !== 'cut') return;
+        if (!usable.value) { tool.tryOther(); return; }
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) return;
         const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -182,10 +197,12 @@ export const useTopToolService = defineStore('topToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.TOP, rect: CURSOR_STYLE.TOP });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'top' || !usable.value) return;
+        if (tool.prepared !== 'top') return;
+        if (!usable.value) { tool.tryOther(); return; }
         if (!pixel) {
             overlayService.clear(overlayId);
             return;
@@ -201,7 +218,8 @@ export const useTopToolService = defineStore('topToolService', () => {
         }
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'top' || !usable.value || !pixel) return;
+        if (tool.prepared !== 'top') return;
+        if (!usable.value || !pixel) { if (!usable.value) tool.tryOther(); return; }
         const id = layerQuery.topVisibleAt(pixel);
         if (!id) return;
         if (nodes.getProperty(id, 'locked')) {

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -14,7 +14,8 @@ export const usePathToolService = defineStore('pathToolService', () => {
     const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount === 1);
 
     watch(() => tool.prepared, async (p) => {
-        if (p !== 'path' || !usable.value) return;
+        if (p !== 'path') return;
+        if (!usable.value) { tool.tryOther(); return; }
 
         tool.setCursor({ wand: CURSOR_STYLE.WAIT });
 


### PR DESCRIPTION
## Summary
- Track recent tools in a stack with fallback helpers
- Switch tools only when usable and trim history after pointer up
- Allow tool services to step back to usable tools automatically
- Replace manual previous-tool restoration with `findUsable`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe61dfcb4832c961e7b731e1a7d96