### PR TITLE
feat: add tool history actions and dynamic fallback

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -37,10 +37,10 @@
       <!-- Tool Toggles -->
       <div class="inline-flex rounded-md overflow-hidden border border-white/15">
         <button v-for="tool in selectables" :key="tool.type"
-                @click="toolSelectionService.setPrepared(tool.type)"
+                @click="toolSelectionService.addPrepared(tool.type)"
                 :title="tool.name"
                 :disabled="toolSelectionService.isWand || !tool.usable"
-                :class="`p-1 ${toolSelectionService.prepared === tool.type ? 'bg-white/15' : 'bg-white/5 hover:bg-white/10'} ${toolSelectionService.isWand || !tool.usable ? 'opacity-50 cursor-not-allowed' : ''}`">
+                :class="`p-1 ${toolSelectionService.current === tool.type ? 'bg-white/15' : 'bg-white/5 hover:bg-white/10'} ${toolSelectionService.isWand || !tool.usable ? 'opacity-50 cursor-not-allowed' : ''}`">
           <img v-if="tool.icon" :src="tool.icon" :alt="tool.name" class="w-4 h-4">
           <span v-else class="text-xs">{{ tool.label || tool.name }}</span>
         </button>
@@ -83,33 +83,30 @@ async function onFileChange(e) {
   e.target.value = '';
 }
 
-toolSelectionService.setPrepared('select');
 toolSelectionService.setShape('stroke');
 
 const selectables = computed(() => toolbarStore.tools);
 
 const wandOpen = ref(false);
 let previousShape = 'stroke';
-let previousTool = 'select';
 const wandToolTypes = new Set(WAND_TOOLS.map(t => t.type));
-const wandWorking = computed(() => wandToolTypes.has(toolSelectionService.prepared));
+const wandWorking = computed(() => wandToolTypes.has(toolSelectionService.current));
 
 function openWand() {
   previousShape = toolSelectionService.shape;
-  previousTool = toolSelectionService.prepared;
   wandOpen.value = true;
   toolSelectionService.setShape('wand');
 }
 
 function selectWandTool(type) {
   wandOpen.value = false;
-  toolSelectionService.setPrepared(type);
+  toolSelectionService.addPrepared(type);
 }
 
 function closeWand() {
   wandOpen.value = false;
   toolSelectionService.setShape(previousShape);
-  toolSelectionService.setPrepared(previousTool);
+  toolSelectionService.useRecent();
 }
 
 function setShape(shape) {
@@ -125,7 +122,7 @@ function handleClickOutside(e) {
 onMounted(() => document.addEventListener('mousedown', handleClickOutside));
 onBeforeUnmount(() => document.removeEventListener('mousedown', handleClickOutside));
 
-watch(() => toolSelectionService.prepared, (val) => {
+watch(() => toolSelectionService.current, (val) => {
   if (val === 'done') closeWand();
 });
 

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -23,15 +23,16 @@ export const useSelectService = defineStore('selectService', () => {
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'select', name: 'Select', icon: stageIcons.select, usable });
     let mode = 'select';
-    watch(() => tool.prepared === 'select', (isSelect) => {
+    watch(() => tool.current === 'select', (isSelect) => {
         if (!isSelect) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'select') return;
+        if (tool.current !== 'select') return;
         if (!pixel) {
             overlayService.clear(overlayId);
             return;
@@ -62,7 +63,7 @@ export const useSelectService = defineStore('selectService', () => {
 
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'select') return;
+        if (tool.current !== 'select') return;
         if (pixel) {
             const id = layerQuery.topVisibleAt(pixel);
             if (id && nodes.getProperty(id, 'locked')) {
@@ -73,7 +74,7 @@ export const useSelectService = defineStore('selectService', () => {
         tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'select') return;
+        if (tool.current !== 'select') return;
         const intersectedIds = [];
         for (const pixel of pixels) {
             const id = layerQuery.topVisibleAt(pixel);
@@ -89,7 +90,7 @@ export const useSelectService = defineStore('selectService', () => {
         overlayService.setLayers(overlayId, highlightIds);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'select') return;
+        if (tool.current !== 'select') return;
         if (pixels.length > 0) {
             const intersectedIds = new Set();
             for (const pixel of pixels) {
@@ -132,7 +133,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
         return id;
     });
     function rebuild() {
-        if (tool.prepared !== 'direction') return;
+        if (tool.current !== 'direction') return;
         const layerIds = nodeTree.selectedLayerIds;
         const showAll = layerIds.length === 0;
         PIXEL_DIRECTIONS.forEach((direction, idx) => {
@@ -162,20 +163,21 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
             }
         });
     }
-    watch(() => tool.prepared === 'direction', (isDirection) => {
+    watch(() => tool.current === 'direction', (isDirection) => {
         if (!isDirection) {
             overlays.forEach(id => overlayService.clear(id));
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         rebuild();
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'direction' || !pixel) return;
+        if (tool.current !== 'direction' || !pixel) return;
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
     watch(() => tool.dragPixel, (pixel, prevPixel) => {
-        if (tool.prepared !== 'direction' || pixel == null) return;
+        if (tool.current !== 'direction' || pixel == null) return;
         const target = layerQuery.topVisibleAt(pixel);
         const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
         if (target != null && editable) {
@@ -223,19 +225,20 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     const usable = computed(() => true);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase, usable });
-    watch(() => tool.prepared === 'globalErase', (isGlobalErase) => {
+    watch(() => tool.current === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'globalErase') return;
+        if (tool.current !== 'globalErase') return;
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'globalErase') return;
+        if (tool.current !== 'globalErase') return;
         if (pixel){
             const lockedIds = nodeTree.layerOrder.filter(id => nodes.getProperty(id, 'locked'));
             for (const id of lockedIds) {
@@ -249,7 +252,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'globalErase') return;
+        if (tool.current !== 'globalErase') return;
         const erasablePixels = [];
         if (pixels.length) {
             const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.getProperty(id, 'locked'));
@@ -264,7 +267,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         overlayService.setPixels(overlayId, erasablePixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'globalErase' || !pixels.length) return;
+        if (tool.current !== 'globalErase' || !pixels.length) return;
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
             .filter(id => !nodes.getProperty(id, 'locked'));
         for (const id of targetIds) {

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -16,7 +16,6 @@ export const useShortcutService = defineStore('shortcutService', () => {
     const toolSelectionService = useToolSelectionService();
     const clipboard = useClipboardService();
 
-    let previousTool = toolSelectionService.prepared;
     let modifierActive = false;
 
     function deleteSelection() {
@@ -78,11 +77,10 @@ export const useShortcutService = defineStore('shortcutService', () => {
 
             const map = TOOL_MODIFIERS[key];
             if (map && !e.repeat) {
-                const change = map[toolSelectionService.prepared] ?? map.default;
+                const change = map[toolSelectionService.current] ?? map.default;
                 if (change) {
-                    previousTool = toolSelectionService.prepared;
                     modifierActive = true;
-                    toolSelectionService.setPrepared(change);
+                    toolSelectionService.addPrepared(change);
                     break;
                 }
             }
@@ -143,26 +141,18 @@ export const useShortcutService = defineStore('shortcutService', () => {
     watch(() => keyboardEvents.recent.up, (ups) => {
         for (const e of ups) {
             if (e.key === 'Shift') {
-                if (toolSelectionService.prepared !== previousTool) {
-                    toolSelectionService.setPrepared(previousTool);
-                }
+                toolSelectionService.useRecent();
                 modifierActive = false;
                 break;
             }
             if (e.key === 'Control' || e.key === 'Meta') {
                 const down = keyboardEvents.get('keydown', e.key);
                 if (!down || !down.repeat) continue;
-                if (toolSelectionService.prepared !== previousTool) {
-                    toolSelectionService.setPrepared(previousTool);
-                }
+                toolSelectionService.useRecent();
                 modifierActive = false;
                 break;
             }
         }
-    });
-
-    watch(() => toolSelectionService.prepared, (tool) => {
-        if (!modifierActive) previousTool = tool;
     });
 
     return {};

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -18,19 +18,20 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'draw', name: 'Draw', icon: stageIcons.draw, usable });
-    watch(() => tool.prepared === 'draw', (isDraw) => {
+    watch(() => tool.current === 'draw', (isDraw) => {
         if (!isDraw) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.DRAW_STROKE, rect: CURSOR_STYLE.DRAW_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'draw') return;
+        if (tool.current !== 'draw') return;
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.current !== 'draw' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             if (pixel)
@@ -41,11 +42,11 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.current !== 'draw' || !usable.value) return;
         overlayService.setPixels(overlayId, pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'draw' || !usable.value) return;
+        if (tool.current !== 'draw' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(id, 'locked')) return;
         pixelStore.addPixels(id, pixels);
@@ -62,19 +63,20 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'erase', name: 'Erase', icon: stageIcons.erase, usable });
-    watch(() => tool.prepared === 'erase', (isErase) => {
+    watch(() => tool.current === 'erase', (isErase) => {
         if (!isErase) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'erase') return;
+        if (tool.current !== 'erase') return;
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.current !== 'erase' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -85,15 +87,15 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.current !== 'erase' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         const sourcePixels = new Set(pixelStore.get(sourceId));
         overlayService.setPixels(overlayId, pixels.filter(pixel => sourcePixels.has(pixel)));
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'erase' || !usable.value) return;
+        if (tool.current !== 'erase' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(id, 'locked')) return;
+       if (nodes.getProperty(id, 'locked')) return;
         pixelStore.removePixels(id, pixels);
     });
     return { usable };
@@ -109,19 +111,20 @@ export const useCutToolService = defineStore('cutToolService', () => {
     const usable = computed(() => nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'cut', name: 'Cut', icon: stageIcons.cut, usable });
-    watch(() => tool.prepared === 'cut', (isCut) => {
+    watch(() => tool.current === 'cut', (isCut) => {
         if (!isCut) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'cut') return;
+        if (tool.current !== 'cut') return;
         overlayService.setPixels(overlayId, pixel ? [pixel] : []);
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.current !== 'cut' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -132,11 +135,11 @@ export const useCutToolService = defineStore('cutToolService', () => {
         }
     });
     watch(() => tool.previewPixels, (pixels) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.current !== 'cut' || !usable.value) return;
         overlayService.setPixels(overlayId, pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
-        if (tool.prepared !== 'cut' || !usable.value) return;
+        if (tool.current !== 'cut' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.getProperty(sourceId, 'locked')) return;
         const sourcePixels = new Set(pixelStore.get(sourceId));
@@ -177,15 +180,16 @@ export const useTopToolService = defineStore('topToolService', () => {
     const usable = computed(() => nodeTree.selectedIds.length === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'top', name: 'To Top', icon: stageIcons.top, usable });
-    watch(() => tool.prepared === 'top', (isTop) => {
+    watch(() => tool.current === 'top', (isTop) => {
         if (!isTop) {
             overlayService.clear(overlayId);
             return;
         }
+        if (!usable.value) { tool.tryOther(); return; }
         tool.setCursor({ stroke: CURSOR_STYLE.TOP, rect: CURSOR_STYLE.TOP });
     });
     watch(() => tool.hoverPixel, (pixel) => {
-        if (tool.prepared !== 'top' || !usable.value) return;
+        if (tool.current !== 'top' || !usable.value) return;
         if (!pixel) {
             overlayService.clear(overlayId);
             return;
@@ -201,7 +205,7 @@ export const useTopToolService = defineStore('topToolService', () => {
         }
     });
     watch(() => tool.dragPixel, (pixel) => {
-        if (tool.prepared !== 'top' || !usable.value || !pixel) return;
+        if (tool.current !== 'top' || !usable.value || !pixel) return;
         const id = layerQuery.topVisibleAt(pixel);
         if (!id) return;
         if (nodes.getProperty(id, 'locked')) {

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -13,8 +13,9 @@ export const usePathToolService = defineStore('pathToolService', () => {
     const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount === 1);
 
-    watch(() => tool.prepared, async (p) => {
-        if (p !== 'path' || !usable.value) return;
+    watch(() => tool.current, async (p) => {
+        if (p !== 'path') return;
+        if (!usable.value) { tool.tryOther(); return; }
 
         tool.setCursor({ wand: CURSOR_STYLE.WAIT });
 
@@ -25,7 +26,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.setCursor({ wand: CURSOR_STYLE.PATH });
 
         if (!paths.length) {
-            tool.setPrepared('done');
+            tool.addPrepared('done');
             return;
         }
 
@@ -54,7 +55,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
 
         nodeTree.replaceSelection([groupId]);
 
-        tool.setPrepared('done');
+        tool.addPrepared('done');
     });
 
     return { usable };


### PR DESCRIPTION
## Summary
- replace single prepared tool with stack and recent-use helpers
- auto switch to usable tools and fall back when shortcuts or toolbar change selection
- simplify external tool reversion to use new helper actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc02db1e28832cbd05ca3999ecd830