### PR TITLE
Refactor tool selection to use registered tool objects

### DIFF
--- a/src/components/ViewportToolbar.vue
+++ b/src/components/ViewportToolbar.vue
@@ -37,7 +37,7 @@
       <!-- Tool Toggles -->
       <div class="inline-flex rounded-md overflow-hidden border border-white/15">
         <button v-for="tool in selectables" :key="tool.type"
-                @click="toolSelectionService.addPrepared(tool.type)"
+                @click="toolSelectionService.addPrepared(tool)"
                 :title="tool.name"
                 :disabled="toolSelectionService.isWand || !tool.usable"
                 :class="`p-1 ${toolSelectionService.current === tool.type ? 'bg-white/15' : 'bg-white/5 hover:bg-white/10'} ${toolSelectionService.isWand || !tool.usable ? 'opacity-50 cursor-not-allowed' : ''}`">
@@ -61,7 +61,7 @@
     </template>
 
 <script setup>
-import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
 import { WAND_TOOLS } from '@/constants';
@@ -69,7 +69,7 @@ import stageIcons from '../image/stage_toolbar';
 import WandPopup from './WandPopup.vue';
 
 const { viewport: viewportStore, input, output, toolbar: toolbarStore } = useStore();
-const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService, settings: settingsService } = useService();
+const { toolSelection: toolSelectionService, stageResize: stageResizeService, imageLoad: imageLoadService, settings: settingsService, tools } = useService();
 
 const fileInput = ref(null);
 function openFileDialog() {
@@ -96,9 +96,10 @@ function openWand() {
   toolSelectionService.setShape('wand');
 }
 
-function selectWandTool(type) {
+function selectWandTool(tool) {
   wandOpen.value = false;
-  toolSelectionService.addPrepared(type);
+  const serviceTool = tools[tool.type];
+  if (serviceTool) toolSelectionService.addPrepared({ ...tool, usable: serviceTool.usable });
 }
 
 function closeWand() {
@@ -118,9 +119,5 @@ function handleClickOutside(e) {
 
 onMounted(() => document.addEventListener('mousedown', handleClickOutside));
 onBeforeUnmount(() => document.removeEventListener('mousedown', handleClickOutside));
-
-watch(() => toolSelectionService.current, (val) => {
-  if (!toolSelectionService.isWand && val === 'waiting') toolSelectionService.tryOther();
-});
 
 </script>

--- a/src/components/WandPopup.vue
+++ b/src/components/WandPopup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="absolute left-0 top-full mt-1 flex flex-col rounded-md border border-white/15 bg-slate-800 p-1 z-10">
-    <button v-for="tool in tools" :key="tool.type" @click="$emit('select', tool.type)"
+    <button v-for="tool in tools" :key="tool.type" @click="$emit('select', tool)"
             class="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-white/10">
       <img v-if="tool.icon" :src="tool.icon" :alt="tool.name" class="w-4 h-4" />
       <span>{{ tool.name }}</span>

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -4,6 +4,7 @@ import { useOverlayService } from './overlay';
 import { useLayerQueryService } from './layerQuery';
 import { useNodeQueryService } from './nodeQuery';
 import { useToolSelectionService } from './toolSelection';
+import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
 import { usePathToolService } from './wandTools';
@@ -51,13 +52,18 @@ export const useService = () => {
     const globalErase = useGlobalEraseToolService();
     const direction = useDirectionToolService();
 
+    const toolSelection = useToolSelectionService();
+    const toolbar = useToolbarStore();
+    toolSelection.addPrepared(toolbar.tools.find(t => t.type === 'draw'));
+    toolSelection.addPrepared(toolbar.tools.find(t => t.type === 'select'));
+
     return {
         layerPanel: useLayerPanelService(),
         layerTool: useLayerToolService(),
         overlay: useOverlayService(),
         layerQuery: useLayerQueryService(),
         nodeQuery: useNodeQueryService(),
-        toolSelection: useToolSelectionService(),
+        toolSelection,
         tools: {
             draw,
             erase,

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -28,7 +28,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
@@ -168,7 +168,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
             overlays.forEach(id => overlayService.clear(id));
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         rebuild();
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
@@ -230,7 +230,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -5,6 +5,7 @@ import { useLayerPanelService } from './layerPanel';
 import { useLayerToolService } from './layerTool';
 import { useNodeQueryService } from './nodeQuery';
 import { useToolSelectionService } from './toolSelection';
+import { useToolbarStore } from '../stores/toolbar';
 import { useClipboardService } from './clipboard';
 import { TOOL_MODIFIERS } from '@/constants';
 
@@ -14,6 +15,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
     const layerSvc = useLayerToolService();
     const nodeQuery = useNodeQueryService();
     const toolSelectionService = useToolSelectionService();
+    const toolbar = useToolbarStore();
     const clipboard = useClipboardService();
 
     let modifierActive = false;
@@ -77,10 +79,11 @@ export const useShortcutService = defineStore('shortcutService', () => {
 
             const map = TOOL_MODIFIERS[key];
             if (map && !e.repeat) {
-                const change = map[toolSelectionService.current] ?? map.default;
-                if (change) {
+                const changeType = map[toolSelectionService.current] ?? map.default;
+                if (changeType) {
                     modifierActive = true;
-                    toolSelectionService.addPrepared(change);
+                    const tool = toolbar.tools.find(t => t.type === changeType);
+                    if (tool) toolSelectionService.addPrepared(tool);
                     break;
                 }
             }

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -23,7 +23,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.DRAW_STROKE, rect: CURSOR_STYLE.DRAW_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
@@ -68,7 +68,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
@@ -116,7 +116,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
     });
     watch(() => tool.hoverPixel, (pixel) => {
@@ -185,7 +185,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
         tool.setCursor({ stroke: CURSOR_STYLE.TOP, rect: CURSOR_STYLE.TOP });
     });
     watch(() => tool.hoverPixel, (pixel) => {

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -15,7 +15,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
 
     watch(() => tool.current, async (p) => {
         if (p !== 'path') return;
-        if (!usable.value) { tool.tryOther(); return; }
+        if (!usable.value) return;
 
         tool.setCursor({ wand: CURSOR_STYLE.WAIT });
 


### PR DESCRIPTION
## Summary
- Manage tool selection with full tool objects instead of name strings
- Centralize usable-tool resolution and remove per-tool fallbacks
- Update toolbar, wand popup, and shortcuts to pass tool objects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f96aa00832c81e7e5923628e275