### PR TITLE
feat: add connect wand tool

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -2,6 +2,7 @@ import stageIcons from '../image/stage_toolbar';
 
 export const WAND_TOOLS = [
   { type: 'path', name: 'Path', icon: stageIcons.path },
+  { type: 'connect', name: 'Connect', icon: stageIcons.connect },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -10,6 +10,7 @@ import resize from './resize.svg';
 import undo from './undo.svg';
 import redo from './redo.svg';
 import path from './path.svg';
+import connect from './connect.svg';
 import direction from './direction.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
@@ -24,6 +25,7 @@ export default {
   globalErase,
   top,
   path,
+  connect,
   direction,
   wand,
   resize,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService } from './wandTools';
+import { usePathToolService, useConnectToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -28,6 +28,7 @@ export {
     useTopToolService,
     useDirectionToolService,
     usePathToolService,
+    useConnectToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -47,6 +48,7 @@ export const useService = () => {
     const cut = useCutToolService();
     const top = useTopToolService();
     const path = usePathToolService();
+    const connect = useConnectToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -70,6 +72,7 @@ export const useService = () => {
             cut,
             top,
             path,
+            connect,
             select,
             globalErase,
             direction,

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -5,6 +5,7 @@ import { useHamiltonianService } from './hamiltonian';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { CURSOR_STYLE } from '@/constants';
+import { indexToCoord } from '../utils';
 
 export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
@@ -49,6 +50,70 @@ export const usePathToolService = defineStore('pathToolService', () => {
         nodeTree.replaceSelection([groupId]);
 
         tool.setShape("stroke");
+        tool.useRecent();
+    });
+
+    return { usable };
+});
+
+export const useConnectToolService = defineStore('connectToolService', () => {
+    const tool = useToolSelectionService();
+    const { nodeTree, pixels: pixelStore } = useStore();
+    const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount > 2);
+
+    function average(id) {
+        const pixels = pixelStore.get(id);
+        if (!pixels.length) return null;
+        let sx = 0, sy = 0;
+        for (const p of pixels) {
+            const [x, y] = indexToCoord(p);
+            sx += x;
+            sy += y;
+        }
+        return { x: sx / pixels.length, y: sy / pixels.length };
+    }
+
+    watch(() => tool.current, (p) => {
+        if (p !== 'connect') return;
+        if (!usable.value) return;
+
+        tool.setCursor({ wand: CURSOR_STYLE.WAIT });
+
+        const ids = nodeTree.selectedLayerIds.slice();
+        const n = ids.length;
+        const averages = new Map();
+        ids.forEach(id => averages.set(id, average(id)));
+
+        for (let i = 0; i < n; i++) {
+            const id = ids[i];
+            const pixels = pixelStore.get(id);
+            if (!pixels.length) continue;
+            let range = 1;
+            let direction = null;
+            while (range <= Math.floor(n / 2)) {
+                const upperId = ids[(i - range + n) % n];
+                const lowerId = ids[(i + range) % n];
+                const upAvg = averages.get(upperId);
+                const lowAvg = averages.get(lowerId);
+                if (!upAvg || !lowAvg) {
+                    range++;
+                    continue;
+                }
+                const dx = Math.abs(upAvg.x - lowAvg.x);
+                const dy = Math.abs(upAvg.y - lowAvg.y);
+                if (dx === dy) {
+                    range++;
+                    continue;
+                }
+                direction = dx > dy ? 'horizontal' : 'vertical';
+                break;
+            }
+            if (direction) {
+                pixelStore.addPixels(id, pixels, direction);
+            }
+        }
+
+        tool.setShape('stroke');
         tool.useRecent();
     });
 


### PR DESCRIPTION
## Summary
- add connect wand tool to align pixel directions using neighboring layer averages
- expose connect in wand toolbar and stage icons
- register new connect tool service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc443c11a0832c8bf321f2264e0027