### PR TITLE
Add connect wand tool for aligning layer directions

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -2,6 +2,7 @@ import stageIcons from '../image/stage_toolbar';
 
 export const WAND_TOOLS = [
   { type: 'path', name: 'Path', icon: stageIcons.path },
+  { type: 'connect', name: 'Connect', icon: stageIcons.connect },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -11,6 +11,7 @@ import undo from './undo.svg';
 import redo from './redo.svg';
 import path from './path.svg';
 import direction from './direction.svg';
+import connect from './connect.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -25,6 +26,7 @@ export default {
   top,
   path,
   direction,
+  connect,
   wand,
   resize,
   undo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService } from './wandTools';
+import { usePathToolService, useConnectToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -28,6 +28,7 @@ export {
     useTopToolService,
     useDirectionToolService,
     usePathToolService,
+    useConnectToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -47,6 +48,7 @@ export const useService = () => {
     const cut = useCutToolService();
     const top = useTopToolService();
     const path = usePathToolService();
+    const connect = useConnectToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -70,6 +72,7 @@ export const useService = () => {
             cut,
             top,
             path,
+            connect,
             select,
             globalErase,
             direction,

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -5,6 +5,7 @@ import { useHamiltonianService } from './hamiltonian';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { CURSOR_STYLE } from '@/constants';
+import { indexToCoord } from '../utils';
 
 export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
@@ -52,6 +53,60 @@ export const usePathToolService = defineStore('pathToolService', () => {
         tool.useRecent();
     });
 
-    return { usable };
+  return { usable };
 });
 
+export const useConnectToolService = defineStore('connectToolService', () => {
+    const tool = useToolSelectionService();
+    const { nodeTree, pixels: pixelStore } = useStore();
+    const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount > 1);
+
+    const averageOf = (id) => {
+        const pixels = pixelStore.get(id);
+        if (!pixels.length) return null;
+        let sx = 0, sy = 0;
+        for (const p of pixels) {
+            const [x, y] = indexToCoord(p);
+            sx += x;
+            sy += y;
+        }
+        return [sx / pixels.length, sy / pixels.length];
+    };
+
+    watch(() => tool.current, (p) => {
+        if (p !== 'connect') return;
+        if (!usable.value) return;
+
+        tool.setCursor({ wand: CURSOR_STYLE.WAIT });
+
+        const selected = nodeTree.layerOrder.filter(id => nodeTree.selectedLayerIds.includes(id));
+        const len = selected.length;
+        const cache = new Map();
+        const getAvg = (id) => {
+            if (!cache.has(id)) cache.set(id, averageOf(id));
+            return cache.get(id);
+        };
+
+        for (let i = 0; i < len; i++) {
+            const id = selected[i];
+            let orientation = null;
+            for (let dist = 1; dist < len && !orientation; dist++) {
+                const topAvg = getAvg(selected[(i - dist + len) % len]);
+                const bottomAvg = getAvg(selected[(i + dist) % len]);
+                if (!topAvg || !bottomAvg) continue;
+                const dx = bottomAvg[0] - topAvg[0];
+                const dy = bottomAvg[1] - topAvg[1];
+                if (Math.abs(dx) > Math.abs(dy)) orientation = 'horizontal';
+                else if (Math.abs(dy) > Math.abs(dx)) orientation = 'vertical';
+            }
+            if (!orientation) continue;
+            const pixels = pixelStore.get(id);
+            if (pixels.length) pixelStore.set(id, pixels, orientation);
+        }
+
+        tool.setShape('stroke');
+        tool.useRecent();
+    });
+
+    return { usable };
+});


### PR DESCRIPTION
## Summary
- add connect wand tool that sets pixel directions based on neighboring layers
- expose connect tool and icon in toolbar
- register connect service in tooling services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc443c11a0832c8bf321f2264e0027