### PR TITLE
Improve wand popup button layout

### DIFF
--- a/src/components/WandPopup.vue
+++ b/src/components/WandPopup.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="absolute left-0 top-full mt-1 flex flex-col rounded-md border border-white/15 bg-slate-800 p-1 z-10">
     <button v-for="tool in tools" :key="tool.type" @click="$emit('select', tool)"
-            class="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-white/10">
+            class="flex items-center gap-2 px-1 py-1 text-xs rounded hover:bg-white/10">
       <img v-if="tool.icon" :src="tool.icon" :alt="tool.name" class="w-4 h-4" />
-      <span>{{ tool.name }}</span>
+      <span class="flex-1 break-words">{{ tool.name }}</span>
     </button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Prevent wand popup tool names from overflowing buttons
- Increase spacing between icon and label while tightening button padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc498d9c94832ca7daead10d821018