### PR TITLE
feat: refine connect wand orientation and merging

### DIFF
--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -58,7 +58,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
 
 export const useConnectToolService = defineStore('connectToolService', () => {
     const tool = useToolSelectionService();
-    const { nodeTree, pixels: pixelStore } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount > 1);
 
     const averageOf = (id) => {
@@ -87,22 +87,57 @@ export const useConnectToolService = defineStore('connectToolService', () => {
             return cache.get(id);
         };
 
+        const orientationMap = new Map();
+
         for (let i = 0; i < len; i++) {
             const id = selected[i];
             let orientation = null;
-            for (let dist = 1; dist < len && !orientation; dist++) {
+            for (let dist = 1; dist < len; dist++) {
                 const topAvg = getAvg(selected[(i - dist + len) % len]);
                 const bottomAvg = getAvg(selected[(i + dist) % len]);
                 if (!topAvg || !bottomAvg) continue;
                 const dx = bottomAvg[0] - topAvg[0];
                 const dy = bottomAvg[1] - topAvg[1];
-                if (Math.abs(dx) > Math.abs(dy)) orientation = 'horizontal';
-                else if (Math.abs(dy) > Math.abs(dx)) orientation = 'vertical';
+                if (Math.abs(dx) === Math.abs(dy)) continue;
+                orientation = Math.abs(dx) > Math.abs(dy) ? 'horizontal' : 'vertical';
+                if (dist >= 2) orientation = orientation === 'horizontal' ? 'vertical' : 'horizontal';
+                break;
             }
             if (!orientation) continue;
             const pixels = pixelStore.get(id);
             if (pixels.length) pixelStore.set(id, pixels, orientation);
+            orientationMap.set(id, orientation);
         }
+
+        const mergedSelection = new Set(nodeTree.selectedLayerIds);
+        const visited = new Set();
+        for (let i = 0; i < len; i++) {
+            const startId = selected[i];
+            if (visited.has(startId)) continue;
+            const orient = orientationMap.get(startId);
+            if (!orient) continue;
+            const run = [startId];
+            visited.add(startId);
+            let j = (i + 1) % len;
+            while (j !== i && orientationMap.get(selected[j]) === orient && nodeTree.has(selected[j])) {
+                run.push(selected[j]);
+                visited.add(selected[j]);
+                j = (j + 1) % len;
+            }
+            if (run.length > 1) {
+                const base = run[0];
+                for (const rid of run.slice(1)) {
+                    const px = pixelStore.get(rid);
+                    if (px.length) pixelStore.addPixels(base, px, orient);
+                }
+                const removed = nodeTree.remove(run.slice(1));
+                nodes.remove(removed);
+                pixelStore.remove(removed);
+                for (const rid of run.slice(1)) mergedSelection.delete(rid);
+                mergedSelection.add(base);
+            }
+        }
+        nodeTree.replaceSelection([...mergedSelection]);
 
         tool.setShape('stroke');
         tool.useRecent();


### PR DESCRIPTION
## Summary
- improve connect wand orientation detection with diagonal check and distance-based inversion
- merge vertically adjacent layers sharing direction, with wrap-around

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4c2442a0832c81e985867224caf9