### PR TITLE
fix: adjust wand popup button layout

### DIFF
--- a/src/components/WandPopup.vue
+++ b/src/components/WandPopup.vue
@@ -1,9 +1,13 @@
 <template>
-  <div class="absolute left-0 top-full mt-1 flex flex-col rounded-md border border-white/15 bg-slate-800 p-1 z-10">
-    <button v-for="tool in tools" :key="tool.type" @click="$emit('select', tool)"
-            class="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-white/10">
+  <div class="absolute left-0 top-full mt-1 flex flex-col rounded-md border border-white/15 bg-slate-800 p-1 z-10 w-max">
+    <button
+      v-for="tool in tools"
+      :key="tool.type"
+      @click="$emit('select', tool)"
+      class="flex items-center gap-2 px-1 py-1 text-xs rounded hover:bg-white/10 w-full"
+    >
       <img v-if="tool.icon" :src="tool.icon" :alt="tool.name" class="w-4 h-4" />
-      <span>{{ tool.name }}</span>
+      <span class="whitespace-nowrap">{{ tool.name }}</span>
     </button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- widen wand popup buttons to fit long tool names
- tweak wand popup button spacing and padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4c910f40832cb752cf49c0ef4744