### PR TITLE
feat: add border wand tool

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -3,6 +3,7 @@ import stageIcons from '../image/stage_toolbar';
 export const WAND_TOOLS = [
   { type: 'path', name: 'Path', icon: stageIcons.path },
   { type: 'connect', name: 'Connect', icon: stageIcons.connect },
+  { type: 'border', name: 'Border', icon: stageIcons.border },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -12,6 +12,7 @@ import redo from './redo.svg';
 import path from './path.svg';
 import direction from './direction.svg';
 import connect from './connect.svg';
+import border from './border.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -27,6 +28,7 @@ export default {
   path,
   direction,
   connect,
+  border,
   wand,
   resize,
   undo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService, useConnectToolService } from './wandTools';
+import { usePathToolService, useConnectToolService, useBorderToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -29,6 +29,7 @@ export {
     useDirectionToolService,
     usePathToolService,
     useConnectToolService,
+    useBorderToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -49,6 +50,7 @@ export const useService = () => {
     const top = useTopToolService();
     const path = usePathToolService();
     const connect = useConnectToolService();
+    const border = useBorderToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -73,6 +75,7 @@ export const useService = () => {
             top,
             path,
             connect,
+            border,
             select,
             globalErase,
             direction,

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -5,7 +5,7 @@ import { useHamiltonianService } from './hamiltonian';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { CURSOR_STYLE } from '@/constants';
-import { indexToCoord, groupConnectedPixels } from '../utils';
+import { indexToCoord, coordToIndex, groupConnectedPixels, getPixelUnion, averageColorU32 } from '../utils';
 
 export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
@@ -135,6 +135,60 @@ export const useConnectToolService = defineStore('connectToolService', () => {
             }
         }
         nodeTree.replaceSelection([...mergedSelection]);
+
+        tool.setShape('stroke');
+        tool.useRecent();
+    });
+
+    return { usable };
+});
+
+export const useBorderToolService = defineStore('borderToolService', () => {
+    const tool = useToolSelectionService();
+    const layerQuery = useLayerQueryService();
+    const { nodeTree, nodes, pixels: pixelStore, viewport } = useStore();
+    const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount >= 1);
+
+    watch(() => tool.current, (p) => {
+        if (p !== 'border') return;
+        if (!usable.value) return;
+
+        tool.setCursor({ wand: CURSOR_STYLE.WAIT });
+
+        const selectedIds = nodeTree.selectedLayerIds.slice();
+        const unionPixels = getPixelUnion(pixelStore.getProperties(selectedIds));
+        const pixelSet = new Set(unionPixels);
+        const width = viewport.stage.width;
+        const height = viewport.stage.height;
+        const borderSet = new Set();
+        const neighbors = [[1,0],[-1,0],[0,1],[0,-1]];
+
+        for (const pix of unionPixels) {
+            const [x, y] = indexToCoord(pix);
+            for (const [dx, dy] of neighbors) {
+                const nx = x + dx, ny = y + dy;
+                if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+                const nIdx = coordToIndex(nx, ny);
+                if (!pixelSet.has(nIdx)) borderSet.add(nIdx);
+            }
+        }
+
+        if (!borderSet.size) {
+            tool.useRecent();
+            return;
+        }
+
+        const components = groupConnectedPixels([...borderSet]);
+        const color = averageColorU32(selectedIds.map(id => nodes.getProperty(id, 'color')));
+        const newIds = components.map((pixels, idx) => {
+            const id = nodes.createLayer({ name: `Border ${idx + 1}`, color });
+            if (pixels.length) pixelStore.set(id, pixels);
+            return id;
+        });
+
+        const topId = layerQuery.uppermost(selectedIds);
+        nodeTree.insert(newIds, topId, false);
+        nodeTree.replaceSelection(newIds);
 
         tool.setShape('stroke');
         tool.useRecent();


### PR DESCRIPTION
## Summary
- add border wand tool to outline selections
- register tool and icon in toolbar constants and service registry
- expose border option in wand popup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc50121770832c87898f365ab9dcb4