### PR TITLE
feat: add border wand tool

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -3,6 +3,7 @@ import stageIcons from '../image/stage_toolbar';
 export const WAND_TOOLS = [
   { type: 'path', name: 'Path', icon: stageIcons.path },
   { type: 'connect', name: 'Connect', icon: stageIcons.connect },
+  { type: 'border', name: 'Border', icon: stageIcons.border },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -12,6 +12,7 @@ import redo from './redo.svg';
 import path from './path.svg';
 import direction from './direction.svg';
 import connect from './connect.svg';
+import border from './border.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -27,6 +28,7 @@ export default {
   path,
   direction,
   connect,
+  border,
   wand,
   resize,
   undo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService, useConnectToolService } from './wandTools';
+import { usePathToolService, useConnectToolService, useBorderToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -29,6 +29,7 @@ export {
     useDirectionToolService,
     usePathToolService,
     useConnectToolService,
+    useBorderToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -49,6 +50,7 @@ export const useService = () => {
     const top = useTopToolService();
     const path = usePathToolService();
     const connect = useConnectToolService();
+    const border = useBorderToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -73,6 +75,7 @@ export const useService = () => {
             top,
             path,
             connect,
+            border,
             select,
             globalErase,
             direction,

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -5,7 +5,7 @@ import { useHamiltonianService } from './hamiltonian';
 import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { CURSOR_STYLE } from '@/constants';
-import { indexToCoord, groupConnectedPixels } from '../utils';
+import { indexToCoord, groupConnectedPixels, coordToIndex, getPixelUnion } from '../utils';
 
 export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
@@ -135,6 +135,61 @@ export const useConnectToolService = defineStore('connectToolService', () => {
             }
         }
         nodeTree.replaceSelection([...mergedSelection]);
+
+        tool.setShape('stroke');
+        tool.useRecent();
+    });
+
+    return { usable };
+});
+
+export const useBorderToolService = defineStore('borderToolService', () => {
+    const tool = useToolSelectionService();
+    const layerQuery = useLayerQueryService();
+    const { nodeTree, nodes, pixels: pixelStore, input } = useStore();
+    const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount > 0);
+
+    watch(() => tool.current, (p) => {
+        if (p !== 'border') return;
+        if (!usable.value) return;
+
+        tool.setCursor({ wand: CURSOR_STYLE.WAIT });
+
+        const selectedProps = pixelStore.getProperties(nodeTree.selectedLayerIds);
+        const selectedSet = new Set(getPixelUnion(selectedProps));
+
+        const width = input.width;
+        const height = input.height;
+        const border = new Set();
+        const neighbors = [
+            [1, 0],
+            [-1, 0],
+            [0, 1],
+            [0, -1],
+        ];
+
+        for (const pixel of selectedSet) {
+            const [x, y] = indexToCoord(pixel);
+            for (const [dx, dy] of neighbors) {
+                const nx = x + dx;
+                const ny = y + dy;
+                if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+                const neighbor = coordToIndex(nx, ny);
+                if (!selectedSet.has(neighbor)) border.add(neighbor);
+            }
+        }
+
+        if (!border.size) {
+            tool.useRecent();
+            return;
+        }
+
+        const color = nodes.getProperty(nodeTree.selectedLayerIds[0], 'color');
+        const id = nodes.createLayer({ name: 'Border', color });
+        pixelStore.set(id, [...border]);
+        const target = layerQuery.lowermost(nodeTree.selectedLayerIds);
+        nodeTree.insert([id], target, false);
+        nodeTree.replaceSelection([id]);
 
         tool.setShape('stroke');
         tool.useRecent();


### PR DESCRIPTION
## Summary
- add border wand tool to generate 1px outline around selected pixels
- wire border tool into service registry and toolbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc50121770832c87898f365ab9dcb4