### PR TITLE
Add border wand tool for pixel outlines

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -1,8 +1,9 @@
 import stageIcons from '../image/stage_toolbar';
 
 export const WAND_TOOLS = [
-  { type: 'path', name: 'Path', icon: stageIcons.path },
-  { type: 'connect', name: 'Connect', icon: stageIcons.connect },
+    { type: 'path', name: 'Path', icon: stageIcons.path },
+    { type: 'connect', name: 'Connect', icon: stageIcons.connect },
+    { type: 'border', name: 'Border', icon: stageIcons.border },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -12,6 +12,7 @@ import redo from './redo.svg';
 import path from './path.svg';
 import direction from './direction.svg';
 import connect from './connect.svg';
+import border from './border.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -25,9 +26,10 @@ export default {
   globalErase,
   top,
   path,
-  direction,
-  connect,
-  wand,
+    direction,
+    connect,
+    border,
+    wand,
   resize,
   undo,
   redo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService, useConnectToolService } from './wandTools';
+import { usePathToolService, useConnectToolService, useBorderToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -29,6 +29,7 @@ export {
     useDirectionToolService,
     usePathToolService,
     useConnectToolService,
+    useBorderToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -49,6 +50,7 @@ export const useService = () => {
     const top = useTopToolService();
     const path = usePathToolService();
     const connect = useConnectToolService();
+    const border = useBorderToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -73,6 +75,7 @@ export const useService = () => {
             top,
             path,
             connect,
+            border,
             select,
             globalErase,
             direction,


### PR DESCRIPTION
## Summary
- add border wand tool to generate 1px outlines around selected layers
- register border tool and icon in toolbar and service registry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc50121770832c87898f365ab9dcb4