### PR TITLE
feat: add undo support for wand tools

### DIFF
--- a/src/services/toolSelection.js
+++ b/src/services/toolSelection.js
@@ -26,8 +26,10 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
     const current = computed(() => currentTool.value?.type);
     const waitingTool = { type: 'waiting', name: 'Waiting', usable: computed(() => shape.value === 'wand') };
 
-    function addPrepared(t) {
+    function addPrepared(t, recordRollback = true) {
         prepared.value.push(t);
+        if (recordRollback && shape.value === 'wand' && t !== waitingTool)
+            output.setRollbackPoint();
         findUsable();
     }
     function findUsable() {
@@ -44,7 +46,8 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
     }
     function useRecent() {
         if (current.value === recent.value) findUsable();
-        else addPrepared(recent.value);
+        else addPrepared(recent.value, false);
+        if (output.hasPendingRollback) output.commit();
     }
     function setShape(s) {
         if (active.value) nextShape = s;


### PR DESCRIPTION
## Summary
- ensure wand tools capture rollback snapshots and commit changes
- commit wand operations when returning to previous tool

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc522af018832c87ad3a5d6b052cee