### PR TITLE
Rename border tool to expand tool

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -3,7 +3,7 @@ import stageIcons from '../image/stage_toolbar';
 export const WAND_TOOLS = [
     { type: 'path', name: 'Path', icon: stageIcons.path },
     { type: 'relay', name: 'Relay', icon: stageIcons.relay },
-    { type: 'border', name: 'Border', icon: stageIcons.border },
+    { type: 'expand', name: 'Expand', icon: stageIcons.expand },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -13,6 +13,7 @@ import path from './path.svg';
 import direction from './direction.svg';
 import relay from './relay.svg';
 import border from './border.svg';
+import expand from './expand.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -29,6 +30,7 @@ export default {
     direction,
     relay,
     border,
+    expand,
     wand,
   resize,
   undo,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useDirectionToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService, useRelayToolService, useBorderToolService } from './wandTools';
+import { usePathToolService, useRelayToolService, useExpandToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -29,7 +29,7 @@ export {
     useDirectionToolService,
     usePathToolService,
     useRelayToolService,
-    useBorderToolService,
+    useExpandToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -50,7 +50,7 @@ export const useService = () => {
     const top = useTopToolService();
     const path = usePathToolService();
     const relay = useRelayToolService();
-    const border = useBorderToolService();
+    const expand = useExpandToolService();
 
     const select = useSelectToolService();
     const globalErase = useGlobalEraseToolService();
@@ -75,7 +75,7 @@ export const useService = () => {
             top,
             path,
             relay,
-            border,
+            expand,
             select,
             globalErase,
             direction,

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -142,14 +142,14 @@ export const useRelayToolService = defineStore('relayToolService', () => {
     return { usable };
 });
 
-export const useBorderToolService = defineStore('borderToolService', () => {
+export const useExpandToolService = defineStore('expandToolService', () => {
     const tool = useToolSelectionService();
     const nodeQuery = useNodeQueryService();
     const { nodeTree, nodes, pixels: pixelStore, viewport: viewportStore } = useStore();
     const usable = computed(() => tool.shape === 'wand' && nodeTree.selectedLayerCount > 0);
 
     watch(() => tool.current, (p) => {
-        if (p !== 'border') return;
+        if (p !== 'expand') return;
         if (!usable.value) return;
 
         const width = viewportStore.stage.width;
@@ -160,7 +160,7 @@ export const useBorderToolService = defineStore('borderToolService', () => {
             pixelStore.get(id).forEach(px => selected.add(px));
         }
 
-        const border = new Set();
+        const expansion = new Set();
         for (const pixel of selected) {
             const [x, y] = indexToCoord(pixel);
             for (let dy = -1; dy <= 1; dy++) {
@@ -170,17 +170,17 @@ export const useBorderToolService = defineStore('borderToolService', () => {
                     const ny = y + dy;
                     if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
                     const ni = coordToIndex(nx, ny);
-                    if (!selected.has(ni)) border.add(ni);
+                    if (!selected.has(ni)) expansion.add(ni);
                 }
             }
         }
 
-        if (border.size) {
+        if (expansion.size) {
             const topId = nodeQuery.uppermost(nodeTree.selectedIds);
             const baseName = nodes.getProperty(topId, 'name');
-            const name = nodeTree.selectedLayerCount === 1 ? `Border of ${baseName}` : 'Border';
+            const name = nodeTree.selectedLayerCount === 1 ? `Expand of ${baseName}` : 'Expand';
             const id = nodes.createLayer({ name, color: 0xFFFFFFFF });
-            pixelStore.set(id, [...border]);
+            pixelStore.set(id, [...expansion]);
             nodeTree.insert([id], topId, false);
             nodeTree.replaceSelection([id]);
         }


### PR DESCRIPTION
## Summary
- rename border wand tool to expand and adjust variable names
- switch toolbar constants to new expand icon
- add expand icon to stage toolbar exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd11fd46ac832c9179eac1f07e694c