### PR TITLE
Restrict merge color to selected layers

### DIFF
--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -44,10 +44,12 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         return order[idx - 1] ?? null;
     }
 
-    function topVisibleAt(pixel) {
+    function topVisibleAt(pixel, ids = null) {
         const order = nodeTree.layerIdsBottomToTop;
+        const idSet = ids ? new Set(ids) : null;
         for (let i = order.length - 1; i >= 0; i--) {
             const id = order[i];
+            if (idSet && !idSet.has(id)) continue;
             if (!nodes._visibility[id]) continue;
             if (pixels.has(id, pixel)) return id;
         }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -13,8 +13,9 @@ export const useLayerToolService = defineStore('layerToolService', () => {
 
         const colors = [];
         if (pixelUnion.length) {
+            const selection = nodeTree.selectedLayerIds;
             for (const pixel of pixelUnion) {
-                const id = layerQuery.topVisibleAt(pixel);
+                const id = layerQuery.topVisibleAt(pixel, selection);
                 colors.push(id ? nodes.getProperty(id, 'color') : 0);
             }
         } else {


### PR DESCRIPTION
## Summary
- Allow `topVisibleAt` to filter by given layer IDs
- Merge tool now averages colors from selected layers only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd16cbb944832cb485ea7d5de3c53c