### PR TITLE
Respect selected layers when averaging merge color

### DIFF
--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -44,10 +44,12 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         return order[idx - 1] ?? null;
     }
 
-    function topVisibleAt(pixel) {
+    function topVisibleAt(pixel, ids = null) {
         const order = nodeTree.layerIdsBottomToTop;
+        const idSet = ids ? new Set(ids) : null;
         for (let i = order.length - 1; i >= 0; i--) {
             const id = order[i];
+            if (idSet && !idSet.has(id)) continue;
             if (!nodes._visibility[id]) continue;
             if (pixels.has(id, pixel)) return id;
         }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -14,7 +14,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         const colors = [];
         if (pixelUnion.length) {
             for (const pixel of pixelUnion) {
-                const id = layerQuery.topVisibleAt(pixel);
+                const id = layerQuery.topVisibleAt(pixel, nodeTree.selectedLayerIds);
                 colors.push(id ? nodes.getProperty(id, 'color') : 0);
             }
         } else {


### PR DESCRIPTION
## Summary
- allow `topVisibleAt` to filter by a provided layer set
- use filtered lookup in merge so average color ignores unselected layers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd16cbb944832cb485ea7d5de3c53c