### PR TITLE
Optimize multi-edge Hamiltonian partitions with placeholders

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -88,3 +88,19 @@ const pixels = [A, B, C, D];
   assert(res);
   assert.strictEqual(res.cutEdges.length, 1);
 }
+
+// Test solving when multiple cut edges exist between two parts
+{
+  const E = coordToIndex(-1, 1);
+  const F = coordToIndex(-1, 0);
+  const extended = [A, B, C, D, E, F];
+  const neighbors = buildGraphFromPixels(extended);
+  const res = partitionAtEdgeCut(neighbors);
+  assert(res);
+  assert.strictEqual(res.cutEdges.length, 2);
+
+  const paths = await solveFromPixels(extended, { anchors: [B] });
+  assert.strictEqual(paths.length, 1);
+  const covered = new Set(paths.flat());
+  assert.strictEqual(covered.size, extended.length);
+}


### PR DESCRIPTION
## Summary
- Handle partitions with multiple cut edges by compressing the smaller side into a 1px placeholder and solving on the expanded base graph
- Expand placeholders with two anchors derived from the base path for accurate traversal
- Add regression test for graphs split by multiple cut edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd8dbd031c832c8b9d12c7efe4b279