### PR TITLE
Compress partitions with multiple cut edges

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -45,6 +45,25 @@ test('partitionAtEdgeCut detects a bridge in a line of three pixels', () => {
   assert.strictEqual(res.parts.length, 2);
 });
 
+test('solveFromPixels handles multiple cut edges', async () => {
+  const pixels = [
+    coordToIndex(0, 0),
+    coordToIndex(2, 0),
+    coordToIndex(3, 0),
+    coordToIndex(0, 1),
+    coordToIndex(1, 1),
+    coordToIndex(3, 1),
+    coordToIndex(0, 2),
+    coordToIndex(2, 2),
+  ];
+  const neighbors = buildGraphFromPixels(pixels);
+  const part = partitionAtEdgeCut(neighbors);
+  assert(part && part.edges.length > 1);
+  const paths = await solveFromPixels(pixels);
+  assert.strictEqual(paths.length, 1);
+  assert.strictEqual(paths[0].length, pixels.length);
+});
+
 test('solveFromPixels respects start and end anchors', async () => {
   const p0 = coordToIndex(0, 0);
   const p1 = coordToIndex(1, 0);


### PR DESCRIPTION
## Summary
- Compress non-base partitions into placeholders when multiple cut edges exist
- Re-solve base graph and expand placeholders for final path
- Test handling of graphs requiring more than one cut edge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc0c81c98832c905f5949423ec2f4