### PR TITLE
feat: compress partitions with multiple cut edges

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -85,3 +85,22 @@ test('HamiltonianService.traverseFree covers all pixels in a 2x2 square', async 
   assert.strictEqual(covered.size, pixels.length);
 });
 
+test('solveFromPixels handles multiple cut edges via compression', async () => {
+  const pixels = [
+    coordToIndex(0, 0),
+    coordToIndex(2, 0),
+    coordToIndex(3, 0),
+    coordToIndex(0, 1),
+    coordToIndex(1, 1),
+    coordToIndex(3, 1),
+    coordToIndex(0, 2),
+    coordToIndex(2, 2),
+  ];
+  const neighbors = buildGraphFromPixels(pixels);
+  const partition = partitionAtEdgeCut(neighbors);
+  assert(partition && partition.edges.length > 1);
+  const paths = await solveFromPixels(pixels);
+  assert.strictEqual(paths.length, 1);
+  assert.strictEqual(paths[0].length, pixels.length);
+});
+


### PR DESCRIPTION
## Summary
- compress non-base partitions into placeholders when multiple cut edges exist
- run solver on base part and expand placeholders for final path
- add regression test covering multiple cut edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc0c81c98832c905f5949423ec2f4