### PR TITLE
feat: compress graph partitions with placeholders

### DIFF
--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -85,3 +85,23 @@ test('HamiltonianService.traverseFree covers all pixels in a 2x2 square', async 
   assert.strictEqual(covered.size, pixels.length);
 });
 
+test('solveFromPixels handles multiple cut edges by compressing non-base parts', async () => {
+  const pixels = [
+    coordToIndex(0, 0),
+    coordToIndex(0, 1),
+    coordToIndex(0, 2),
+    coordToIndex(1, 1),
+    coordToIndex(2, 0),
+    coordToIndex(2, 2),
+    coordToIndex(3, 0),
+    coordToIndex(3, 1),
+  ];
+  const neighbors = buildGraphFromPixels(pixels);
+  const partition = partitionAtEdgeCut(neighbors);
+  assert(partition);
+  assert.strictEqual(partition.edges.length, 2);
+  const paths = await solveFromPixels(pixels);
+  assert.strictEqual(paths.length, 1);
+  assert.strictEqual(paths[0].length, pixels.length);
+});
+


### PR DESCRIPTION
## Summary
- Handle multi-edge cuts by picking a base component and compressing others into placeholder nodes
- Expand compressed parts using anchors to recompute local paths
- Add regression test covering graphs with multiple cut edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc16718a0832c85c214c31e0178c1