### PR TITLE
Track node store hashes

### DIFF
--- a/src/components/ViewportInfo.vue
+++ b/src/components/ViewportInfo.vue
@@ -31,7 +31,7 @@ const pixelInfo = computed(() => {
       return `[${px},${py}] ${rgbaCssObj(colorObject)}`;
     } else {
       const id = layerQuery.topVisibleAt(pixel);
-      const colorU32 = id ? nodes.getProperty(id, 'color') : 0;
+      const colorU32 = id ? nodes.color(id) : 0;
       return `[${px},${py}] ${rgbaCssU32(colorU32)}`;
     }
   });

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -12,14 +12,14 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
         locked: props.locked,
         attributes: props.attributes,
     };
-    if (props.type === 'layer') {
+    if (!props.isGroup) {
         return {
             type: 'layer',
             ...base,
             pixels: pixelStore.getDirectional(id),
         };
     }
-    if (props.type === 'group') {
+    if (props.isGroup) {
         const info = nodeTree._findNode(id);
         const children = info?.node.children || [];
         return {

--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -66,7 +66,7 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
 
     function byColor(color) {
         return nodeTree.layerOrder.filter(
-            layerId => nodes.getProperty(layerId, 'color') === color
+            layerId => nodes.color(layerId) === color
         );
     }
 

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -55,7 +55,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         if (!id)
             overlayService.setPixels(overlayId, [pixel]);
         else {
-            if (nodes.getProperty(id, 'locked'))
+            if (nodes.locked(id))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
                 overlayService.setLayers(overlayId, [id]);
@@ -66,7 +66,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         if (tool.current !== 'select') return;
         if (pixel) {
             const id = layerQuery.topVisibleAt(pixel);
-            if (id && nodes.getProperty(id, 'locked')) {
+            if (id && nodes.locked(id)) {
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                 return;
             }
@@ -79,7 +79,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         for (const pixel of pixels) {
             const id = layerQuery.topVisibleAt(pixel);
             if (id === null) continue;
-            if (!nodes.getProperty(id, 'locked')) intersectedIds.push(id);
+            if (!nodes.locked(id)) intersectedIds.push(id);
         }
         const highlightIds = [];
         intersectedIds.forEach(id => {
@@ -95,7 +95,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
             const intersectedIds = new Set();
             for (const pixel of pixels) {
                 const id = layerQuery.topVisibleAt(pixel);
-                if (id !== null && !nodes.getProperty(id, 'locked')) intersectedIds.add(id);
+                if (id !== null && !nodes.locked(id)) intersectedIds.add(id);
             }
             const currentSelection = new Set(mode === 'select' ? [] : nodeTree.selectedLayerIds);
             if (mode === 'add') {
@@ -143,7 +143,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
                 const add = new Set();
                 for (let i = nodeTree.layerOrder.length - 1; i >= 0; i--) {
                     const id = nodeTree.layerOrder[i];
-                    if (!nodes.getProperty(id, 'visibility')) continue;
+                    if (!nodes.visibility(id)) continue;
                     const pixels = pixelStore.getDirectionPixels(direction, id);
                     if (!pixels.length) continue;
                     for (const pixel of pixels) {
@@ -181,7 +181,7 @@ export const useDirectionToolService = defineStore('directionToolService', () =>
         const target = layerQuery.topVisibleAt(pixel);
         const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
         if (target != null && editable) {
-            if (nodes.getProperty(target, 'locked')) {
+            if (nodes.locked(target)) {
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                 return;
             }
@@ -240,7 +240,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'globalErase') return;
         if (pixel){
-            const lockedIds = nodeTree.layerOrder.filter(id => nodes.getProperty(id, 'locked'));
+            const lockedIds = nodeTree.layerOrder.filter(id => nodes.locked(id));
             for (const id of lockedIds) {
             const lockedPixels = new Set(pixelStore.get(id));
             if (lockedPixels.has(pixel)) {
@@ -255,7 +255,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         if (tool.current !== 'globalErase') return;
         const erasablePixels = [];
         if (pixels.length) {
-            const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.getProperty(id, 'locked'));
+            const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.locked(id));
             const unlockedPixels = new Set();
             for (const id of unlockedIds) {
                 pixelStore.get(id).forEach(pixel => unlockedPixels.add(pixel));
@@ -269,7 +269,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'globalErase' || !pixels.length) return;
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
-            .filter(id => !nodes.getProperty(id, 'locked'));
+            .filter(id => !nodes.locked(id));
         for (const id of targetIds) {
             const targetPixels = new Set(pixelStore.get(id));
             const pixelsToRemove = [];

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -33,7 +33,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'draw' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(sourceId, 'locked')) {
+        if (nodes.locked(sourceId)) {
             if (pixel)
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
@@ -48,7 +48,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'draw' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(id, 'locked')) return;
+        if (nodes.locked(id)) return;
         pixelStore.addPixels(id, pixels);
     });
     return { usable };
@@ -78,7 +78,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'erase' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(sourceId, 'locked')) {
+        if (nodes.locked(sourceId)) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
             if (pixel != null && sourcePixels.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
@@ -95,7 +95,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'erase' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
-       if (nodes.getProperty(id, 'locked')) return;
+       if (nodes.locked(id)) return;
         pixelStore.removePixels(id, pixels);
     });
     return { usable };
@@ -126,7 +126,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'cut' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(sourceId, 'locked')) {
+        if (nodes.locked(sourceId)) {
             const sourcePixels = new Set(pixelStore.get(sourceId));
             if (pixel != null && sourcePixels.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
@@ -141,7 +141,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'cut' || !usable.value) return;
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.getProperty(sourceId, 'locked')) return;
+        if (nodes.locked(sourceId)) return;
         const sourcePixels = new Set(pixelStore.get(sourceId));
 
         const cutPixels = [];
@@ -155,10 +155,10 @@ export const useCutToolService = defineStore('cutToolService', () => {
 
         pixelStore.removePixels(sourceId, cutPixels);
         const id = nodes.createLayer({
-            name: `Cut of ${nodes.getProperty(sourceId, 'name')}`,
-            color: nodes.getProperty(sourceId, 'color'),
-            visibility: nodes.getProperty(sourceId, 'visibility'),
-            attributes: nodes.getProperty(sourceId, 'attributes'),
+            name: `Cut of ${nodes.name(sourceId)}`,
+            color: nodes.color(sourceId),
+            visibility: nodes.visibility(sourceId),
+            attributes: nodes.attributes(sourceId),
         });
         if (cutPixels.length) pixelStore.set(id, cutPixels);
         nodeTree.insert([id], sourceId, false);
@@ -195,7 +195,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             return;
         }
         const id = layerQuery.topVisibleAt(pixel);
-        if (id && nodes.getProperty(id, 'locked')) {
+        if (id && nodes.locked(id)) {
             overlayService.setLayers(overlayId, [id]);
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
         }
@@ -208,7 +208,7 @@ export const useTopToolService = defineStore('topToolService', () => {
         if (tool.current !== 'top' || !usable.value || !pixel) return;
         const id = layerQuery.topVisibleAt(pixel);
         if (!id) return;
-        if (nodes.getProperty(id, 'locked')) {
+        if (nodes.locked(id)) {
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
         }
         else {

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -25,8 +25,8 @@ export const usePathToolService = defineStore('pathToolService', () => {
         const allPixels = pixelStore.get(layerId);
         const paths = await hamiltonian.traverseFree(allPixels);
 
-        const color = nodes.getProperty(layerId, 'color');
-        const name = nodes.getProperty(layerId, 'name');
+        const color = nodes.color(layerId);
+        const name = nodes.name(layerId);
         const groupId = nodes.createGroup({ name: `${name} Paths` });
 
         nodeTree.insert([groupId], layerQuery.lowermost([layerId]), true);
@@ -206,8 +206,8 @@ export const useExpandToolService = defineStore('expandToolService', () => {
                     }
                 }
                 if (!layerId) continue;
-                const color = nodes.getProperty(layerId, 'color');
-                const name = nodes.getProperty(layerId, 'name');
+                const color = nodes.color(layerId);
+                const name = nodes.name(layerId);
                 let group = colorGroups.get(color);
                 if (!group) {
                     group = { name, color, pixels: [] };

--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -5,7 +5,7 @@ import { useNodeStore } from './nodes';
 function flattenLayers(nodes, result = [], nodeStore = useNodeStore()) {
     for (const node of nodes) {
         if (node.children) flattenLayers(node.children, result, nodeStore);
-        else if (nodeStore.getProperty(node.id, 'type') === 'layer') result.push(node.id);
+        else if (!nodeStore.isGroup(node.id)) result.push(node.id);
     }
     return result;
 }
@@ -57,7 +57,7 @@ function pathTo(nodes, id, stack = []) {
 
 function collectLayerIds(node, result = [], nodeStore = useNodeStore()) {
     if (!node) return result;
-    if (nodeStore.getProperty(node.id, 'type') === 'group') {
+    if (nodeStore.isGroup(node.id)) {
         if (node.children) {
             for (const child of node.children) collectLayerIds(child, result, nodeStore);
         }
@@ -118,7 +118,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
         selectedNodeCount(state) { return this._selectedNodeIds.length },
         selectedGroupIds(state) {
             const nodeStore = useNodeStore();
-            return [...state._selection].filter(id => nodeStore.getProperty(id, 'type') === 'group');
+            return [...state._selection].filter(id => nodeStore.isGroup(id));
         },
         selectedGroupCount(state) { return this.selectedGroupIds.length },
         descendantLayerIds(state) { return (id) => {
@@ -158,7 +158,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             const nodes = ids.map(id => {
                 const existing = this._removeFromTree(id);
                 if (existing) return existing;
-                return nodeStore.getProperty(id, 'type') === 'group'
+                return nodeStore.isGroup(id)
                     ? { id, children: reactive([]) }
                     : { id };
             });
@@ -170,7 +170,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             const nodes = ids.map(id => {
                 const existing = this._removeFromTree(id);
                 if (existing) return existing;
-                return nodeStore.getProperty(id, 'type') === 'group'
+                return nodeStore.isGroup(id)
                     ? { id, children: reactive([]) }
                     : { id };
             });

--- a/src/stores/nodes.js
+++ b/src/stores/nodes.js
@@ -1,6 +1,76 @@
 import { defineStore } from 'pinia';
 import { reactive } from 'vue';
-import { randColorU32 } from '../utils';
+import { murmurHash32 } from '../utils/hash.js';
+
+// ---------------------------------------------------------------------------
+// hash helpers
+// ---------------------------------------------------------------------------
+
+function randColorU32() {
+    const r = Math.floor(150 + Math.random() * 105);
+    const g = Math.floor(50 + Math.random() * 180);
+    const b = Math.floor(50 + Math.random() * 180);
+    return ((r & 255) | ((g & 255) << 8) | ((b & 255) << 16) | (255 << 24)) >>> 0;
+}
+
+function hashAttributes(attrs = []) {
+    const str = attrs.map(a => `${a.name}:${a.value}`).sort().join('|');
+    return murmurHash32(str);
+}
+
+function nodePartHash(id, value) {
+    let h = id ^ value;
+    h = Math.imul(h ^ (h >>> 16), 0x85ebca6b);
+    h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35);
+    return (h ^ (h >>> 16)) >>> 0;
+}
+
+function initNodeHash(store, id) {
+    const node = {
+        id: id >>> 0,
+        name: nodePartHash(id, store._hash.name[id]),
+        attributes: nodePartHash(id, store._hash.attributes[id]),
+        color: nodePartHash(id, store._color[id] >>> 0),
+        visibility: nodePartHash(id, store._visibility[id] ? 1 : 0),
+        locked: nodePartHash(id, store._locked[id] ? 2 : 0),
+        isGroup: nodePartHash(id, store._isGroup[id] ? 1 : 0),
+        hash: 0
+    };
+    node.hash = (node.id ^ node.name ^ node.attributes ^ node.color ^ node.visibility ^ node.locked ^ node.isGroup) >>> 0;
+    store._hash.node[id] = node;
+    store._hash.all = (store._hash.all ^ node.hash) >>> 0;
+}
+
+function updateHashPart(store, id, part, newValue) {
+    const node = store._hash.node[id];
+    if (!node) return;
+    const oldNodeHash = node.hash;
+    const oldPart = node[part] || 0;
+    node[part] = newValue >>> 0;
+    node.hash = (node.hash ^ oldPart ^ node[part]) >>> 0;
+    store._hash.all = (store._hash.all ^ oldNodeHash ^ node.hash) >>> 0;
+}
+
+function rehashAttributes(store, id) {
+    const attrHash = hashAttributes(store._attributes[id] || []);
+    store._hash.attributes[id] = attrHash;
+    updateHashPart(store, id, 'attributes', nodePartHash(id, attrHash));
+}
+
+function prepareNode(store, id, { name, visibility, locked, color, isGroup, attributes }) {
+    store._name[id] = name;
+    store._visibility[id] = visibility;
+    store._locked[id] = locked;
+    store._color[id] = color >>> 0;
+    store._isGroup[id] = isGroup;
+
+    const attrs = attributes.map(a => ({ ...a }));
+    store._attributes[id] = reactive(attrs);
+
+    store._hash.name[id] = murmurHash32(name);
+    store._hash.attributes[id] = hashAttributes(attrs);
+    initNodeHash(store, id);
+}
 
 export const useNodeStore = defineStore('nodes', {
     state: () => ({
@@ -9,28 +79,17 @@ export const useNodeStore = defineStore('nodes', {
         _visibility: {},
         _locked: {},
         _attributes: {},
-        _type: {}
+        _isGroup: {},
+        _hash: { name: {}, attributes: {}, node: {}, all: 0 }
     }),
     getters: {
         has: (state) => (id) => state._name[id] != null,
-        getProperty: (state) => (id, prop) => {
-            switch (prop) {
-                case 'name':
-                    return state._name[id];
-                case 'color':
-                    return (state._color[id] >>> 0);
-                case 'visibility':
-                    return !!state._visibility[id];
-                case 'locked':
-                    return !!state._locked[id];
-                case 'type':
-                    return state._type[id];
-                case 'attributes':
-                    return state._attributes[id]?.map(a => ({ ...a })) || [];
-                default:
-                    return undefined;
-            }
-        },
+        name: (state) => (id) => state._name[id],
+        color: (state) => (id) => (state._color[id] >>> 0),
+        visibility: (state) => (id) => !!state._visibility[id],
+        locked: (state) => (id) => !!state._locked[id],
+        isGroup: (state) => (id) => !!state._isGroup[id],
+        attributes: (state) => (id) => state._attributes[id]?.map(a => ({ ...a })) || [],
         getProperties: (state) => {
             const propsOf = (id) => ({
                 id,
@@ -38,7 +97,7 @@ export const useNodeStore = defineStore('nodes', {
                 color: (state._color[id] >>> 0),
                 visibility: !!state._visibility[id],
                 locked: !!state._locked[id],
-                type: state._type[id],
+                isGroup: !!state._isGroup[id],
                 attributes: state._attributes[id]?.map(a => ({ ...a })) || []
             });
             return (ids = []) => {
@@ -48,71 +107,104 @@ export const useNodeStore = defineStore('nodes', {
         }
     },
     actions: {
-        createLayer(layerProperties = {}) {
+        _createNode(props = {}, isGroup) {
             const id = crypto.getRandomValues(new Uint32Array(1))[0];
-            this._name[id] = layerProperties.name || 'Layer';
-            this._visibility[id] = layerProperties.visibility ?? true;
-            this._locked[id] = layerProperties.locked ?? false;
-            this._color[id] = (layerProperties.color ?? randColorU32()) >>> 0;
-            const attrs = layerProperties.attributes ? layerProperties.attributes.map(a => ({ ...a })) : [];
-            this._attributes[id] = reactive(attrs);
-            this._type[id] = 'layer';
+            const defaults = {
+                name: isGroup ? 'Group' : 'Layer',
+                visibility: true,
+                locked: false,
+                color: randColorU32(),
+                attributes: []
+            };
+            prepareNode(this, id, { ...defaults, ...props, isGroup });
             return id;
         },
-        createGroup(groupProperties = {}) {
-            const id = crypto.getRandomValues(new Uint32Array(1))[0];
-            this._name[id] = groupProperties.name || 'Group';
-            this._visibility[id] = groupProperties.visibility ?? true;
-            this._locked[id] = groupProperties.locked ?? false;
-            this._color[id] = (groupProperties.color ?? randColorU32()) >>> 0;
-            this._attributes[id] = reactive([]);
-             this._type[id] = 'group';
-            return id;
+        createLayer(props = {}) {
+            return this._createNode(props, false);
         },
-        update(id, props) {
-            if (this._name[id] == null) return;
-            if (props.name !== undefined) this._name[id] = props.name;
-            if (props.visibility !== undefined) this._visibility[id] = !!props.visibility;
-            if (props.locked !== undefined) this._locked[id] = !!props.locked;
-            if (!this._locked[id] && props.color !== undefined) this._color[id] = (props.color >>> 0);
-            if (props.attributes !== undefined) {
-                const attrs = Array.isArray(props.attributes) ? props.attributes.map(a => ({ ...a })) : [];
-                this._attributes[id] = reactive(attrs);
-            }
+        createGroup(props = {}) {
+            return this._createNode(props, true);
+        },
+        setName(id, name) {
+            if (!this.has(id)) return;
+            this._name[id] = name;
+            const h = murmurHash32(name);
+            this._hash.name[id] = h;
+            updateHashPart(this, id, 'name', nodePartHash(id, h));
+        },
+        setVisibility(id, value) {
+            if (!this.has(id)) return;
+            this._visibility[id] = !!value;
+            updateHashPart(this, id, 'visibility', nodePartHash(id, this._visibility[id] ? 1 : 0));
+        },
+        setLocked(id, value) {
+            if (!this.has(id)) return;
+            this._locked[id] = !!value;
+            updateHashPart(this, id, 'locked', nodePartHash(id, this._locked[id] ? 2 : 0));
+        },
+        setColor(id, color) {
+            if (!this.has(id) || this._locked[id]) return;
+            this._color[id] = (color >>> 0);
+            updateHashPart(this, id, 'color', nodePartHash(id, this._color[id]));
+        },
+        setIsGroup(id, value) {
+            if (!this.has(id)) return;
+            this._isGroup[id] = !!value;
+            updateHashPart(this, id, 'isGroup', nodePartHash(id, this._isGroup[id] ? 1 : 0));
+        },
+        setAttributes(id, attrs = []) {
+            if (!this.has(id)) return;
+            this._attributes[id] = reactive(Array.isArray(attrs) ? attrs.map(a => ({ ...a })) : []);
+            rehashAttributes(this, id);
+        },
+        update(id, props = {}) {
+            if (!this.has(id)) return;
+            if (props.name !== undefined) this.setName(id, props.name);
+            if (props.visibility !== undefined) this.setVisibility(id, props.visibility);
+            if (props.locked !== undefined) this.setLocked(id, props.locked);
+            if (props.color !== undefined) this.setColor(id, props.color);
+            if (props.isGroup !== undefined) this.setIsGroup(id, props.isGroup);
+            if (props.attributes !== undefined) this.setAttributes(id, props.attributes);
         },
         toggleVisibility(id) {
-            if (this._name[id] == null) return;
-            this._visibility[id] = !this._visibility[id];
+            this.setVisibility(id, !this._visibility[id]);
         },
         toggleLock(id) {
-            if (this._name[id] == null) return;
-            this._locked[id] = !this._locked[id];
+            this.setLocked(id, !this._locked[id]);
         },
         setAttribute(id, name, value) {
-            if (this._name[id] == null) return;
+            if (!this.has(id)) return;
             if (!this._attributes[id]) this._attributes[id] = reactive([]);
             const attrs = this._attributes[id];
             const found = attrs.find(a => a.name === name);
             if (found) found.value = value;
             else attrs.push({ name, value });
+            rehashAttributes(this, id);
         },
         removeAttribute(id, name) {
+            if (!this.has(id)) return;
             const attrs = this._attributes[id];
             if (!attrs) return;
             const index = attrs.findIndex(a => a.name === name);
             if (index >= 0) attrs.splice(index, 1);
+            rehashAttributes(this, id);
         },
         remove(ids = []) {
             const removed = [];
             for (const id of ids) {
-                if (this._name[id] == null) continue;
+                if (!this.has(id)) continue;
+                const nodeHash = this._hash.node[id]?.hash ?? 0;
                 removed.push(id);
                 delete this._name[id];
                 delete this._color[id];
                 delete this._visibility[id];
                 delete this._locked[id];
                 delete this._attributes[id];
-                delete this._type[id];
+                delete this._isGroup[id];
+                delete this._hash.name[id];
+                delete this._hash.attributes[id];
+                delete this._hash.node[id];
+                this._hash.all = (this._hash.all ^ nodeHash) >>> 0;
             }
             return removed;
         },
@@ -123,7 +215,7 @@ export const useNodeStore = defineStore('nodes', {
                 visibility: !!this._visibility[id],
                 locked: !!this._locked[id],
                 color: (this._color[id] >>> 0),
-                type: this._type[id],
+                isGroup: !!this._isGroup[id],
                 attributes: this._attributes[id]?.map(a => ({ ...a })) || []
             }]));
         },
@@ -133,17 +225,19 @@ export const useNodeStore = defineStore('nodes', {
             this._visibility = {};
             this._locked = {};
             this._attributes = {};
-            this._type = {};
-            for (const id of Object.keys(byId)) {
-                const info = byId[id];
-                const numId = Number(id);
-                this._name[numId] = info.name || 'Layer';
-                this._visibility[numId] = !!info.visibility;
-                this._locked[numId] = !!info.locked;
-                this._color[numId] = (info.color ?? randColorU32()) >>> 0;
-                this._type[numId] = info.type || 'layer';
-                const attrs = info.attributes ? info.attributes.map(a => ({ ...a })) : [];
-                this._attributes[numId] = reactive(attrs);
+            this._isGroup = {};
+            this._hash = { name: {}, attributes: {}, node: {}, all: 0 };
+            for (const [idStr, info] of Object.entries(byId)) {
+                const id = Number(idStr);
+                const defaults = {
+                    name: 'Layer',
+                    visibility: true,
+                    locked: false,
+                    color: randColorU32(),
+                    isGroup: false,
+                    attributes: []
+                };
+                prepareNode(this, id, { ...defaults, ...info });
             }
         }
     }

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,0 +1,42 @@
+export function murmurHash32(str, seed = 0) {
+  let remainder = str.length & 3;
+  let bytes = str.length - remainder;
+  let h1 = seed >>> 0;
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
+  let i = 0;
+  while (i < bytes) {
+    let k1 = (str.charCodeAt(i) & 0xff) |
+      ((str.charCodeAt(++i) & 0xff) << 8) |
+      ((str.charCodeAt(++i) & 0xff) << 16) |
+      ((str.charCodeAt(++i) & 0xff) << 24);
+    ++i;
+    k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) >>> 0;
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) >>> 0;
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+    const h1b = (((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16)) >>> 0;
+    h1 = ((h1b & 0xffff) + 0x6b64 + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16)) >>> 0;
+  }
+  let k1 = 0;
+  switch (remainder) {
+    case 3:
+      k1 ^= (str.charCodeAt(i + 2) & 0xff) << 16;
+    case 2:
+      k1 ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+    case 1:
+      k1 ^= (str.charCodeAt(i) & 0xff);
+      k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) >>> 0;
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) >>> 0;
+      h1 ^= k1;
+  }
+  h1 ^= str.length;
+  h1 ^= h1 >>> 16;
+  h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) >>> 0;
+  h1 ^= h1 >>> 13;
+  h1 = (((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16)) >>> 0;
+  h1 ^= h1 >>> 16;
+  return h1 >>> 0;
+}

--- a/test/nodeHash.test.js
+++ b/test/nodeHash.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createPinia, setActivePinia } from 'pinia';
+import { useNodeStore } from '../src/stores/nodes.js';
+
+test('store hash differs when swapping names vs colors', () => {
+  setActivePinia(createPinia());
+  const nodes = useNodeStore();
+  const idA = nodes.createLayer({ name: 'A', color: 0x11223344 });
+  const idB = nodes.createLayer({ name: 'B', color: 0x55667788 });
+  const baseline = nodes.serialize();
+  const baselineHash = nodes._hash.all;
+
+  nodes.setName(idA, 'B');
+  nodes.setName(idB, 'A');
+  const nameHash = nodes._hash.all;
+  assert.notStrictEqual(nameHash, baselineHash);
+
+  nodes.applySerialized(baseline);
+  assert.strictEqual(nodes._hash.all, baselineHash);
+  const colorA = nodes.color(idA);
+  const colorB = nodes.color(idB);
+  nodes.setColor(idA, colorB);
+  nodes.setColor(idB, colorA);
+  const colorHash = nodes._hash.all;
+  assert.notStrictEqual(colorHash, baselineHash);
+  assert.notStrictEqual(nameHash, colorHash);
+});


### PR DESCRIPTION
## Summary
- hash each node property separately and fold into per-node hash map
- incrementally update store hash using per-property XOR updates
- use bit-mixed nodePartHash and replace `_type` string with boolean `_isGroup` across nodes and consumers
- refactor node store with shared node creation and dedicated setters for clearer hash maintenance
- replace remaining `nodes.update` calls with explicit setter functions for names, colors, visibility, and locking
- split generic `getProperty` into dedicated getters like `color(id)` and `visibility(id)`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf628b27f4832ca4b85245ca82714d