### PR TITLE
Limit canvas size to 128x128

### DIFF
--- a/src/components/ImageLoadPopup.vue
+++ b/src/components/ImageLoadPopup.vue
@@ -17,11 +17,21 @@
         </label>
         <label class="block">
           <span>Canvas Width</span>
-          <input type="number" v-model.number="imageLoadService.canvasWidth" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          <input
+            type="number"
+            v-model.number="imageLoadService.canvasWidth"
+            :max="MAX_DIMENSION"
+            class="mt-1 w-full rounded bg-slate-700 px-2 py-1"
+          />
         </label>
         <label class="block">
           <span>Canvas Height</span>
-          <input type="number" v-model.number="imageLoadService.canvasHeight" class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          <input
+            type="number"
+            v-model.number="imageLoadService.canvasHeight"
+            :max="MAX_DIMENSION"
+            class="mt-1 w-full rounded bg-slate-700 px-2 py-1"
+          />
         </label>
       </div>
       <div class="flex justify-end gap-2">
@@ -34,6 +44,7 @@
 
 <script setup>
 import { useService } from '../services';
+import { MAX_DIMENSION } from '../utils';
 
 const { imageLoad: imageLoadService } = useService();
 

--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -1,4 +1,4 @@
-const MAX_DIMENSION = 65536;
+const MAX_DIMENSION = 128;
 const TIME_LIMIT = 5000;
 
 // Return a direction priority for a given offset.

--- a/src/services/imageLoad.js
+++ b/src/services/imageLoad.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref, watch } from 'vue';
 import { useStore } from '../stores';
+import { MAX_DIMENSION } from '../utils';
 
 export const useImageLoadService = defineStore('imageLoadService', () => {
   const show = ref(false);
@@ -16,8 +17,8 @@ export const useImageLoadService = defineStore('imageLoadService', () => {
   watch(canvasHeight, v => localStorage.setItem('imageLoad.canvasHeight', v));
 
   function open() {
-    canvasWidth.value = input.width + 2;
-    canvasHeight.value = input.height + 2;
+    canvasWidth.value = Math.min(input.width + 2, MAX_DIMENSION);
+    canvasHeight.value = Math.min(input.height + 2, MAX_DIMENSION);
     show.value = true;
   }
 
@@ -31,7 +32,9 @@ export const useImageLoadService = defineStore('imageLoadService', () => {
   }
 
   function apply() {
-    input.initialize({ initializeLayers: initialize.value, segmentTolerance: tolerance.value, canvasWidth: canvasWidth.value, canvasHeight: canvasHeight.value });
+    const width = Math.min(canvasWidth.value, MAX_DIMENSION);
+    const height = Math.min(canvasHeight.value, MAX_DIMENSION);
+    input.initialize({ initializeLayers: initialize.value, segmentTolerance: tolerance.value, canvasWidth: width, canvasHeight: height });
     close();
   }
 

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
-import { packRGBA, averageColorU32, coordToIndex, indexToCoord } from '../utils';
+import { packRGBA, averageColorU32, coordToIndex, indexToCoord, MAX_DIMENSION } from '../utils';
 
 export const useInputStore = defineStore('input', {
     state: () => ({
@@ -20,8 +20,8 @@ export const useInputStore = defineStore('input', {
     actions: {
         createImage({ src = '', width = 0, height = 0, buffer = null } = {}) {
             this._src = src;
-            this._width = width;
-            this._height = height;
+            this._width = Math.min(width, MAX_DIMENSION);
+            this._height = Math.min(height, MAX_DIMENSION);
             this._buffer = buffer;
         },
         async load(src) {
@@ -33,8 +33,8 @@ export const useInputStore = defineStore('input', {
                 img.onerror = rej;
                 img.src = src;
             });
-            const w = img.naturalWidth,
-                h = img.naturalHeight;
+            const w = Math.min(img.naturalWidth, MAX_DIMENSION),
+                h = Math.min(img.naturalHeight, MAX_DIMENSION);
             const canvas = document.createElement('canvas');
             canvas.width = w;
             canvas.height = h;
@@ -42,7 +42,7 @@ export const useInputStore = defineStore('input', {
                 willReadFrequently: true
             });
             context.imageSmoothingEnabled = false;
-            context.drawImage(img, 0, 0);
+            context.drawImage(img, 0, 0, w, h);
             const data = context.getImageData(0, 0, w, h).data;
             this.createImage({ src, width: w, height: h, buffer: data });
         },
@@ -62,8 +62,8 @@ export const useInputStore = defineStore('input', {
         initialize({ initializeLayers = true, segmentTolerance = 40, canvasWidth, canvasHeight } = {}) {
             const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore } = useStore();
             const layerPanel = useLayerPanelService();
-            const width = canvasWidth ?? this.width;
-            const height = canvasHeight ?? this.height;
+            const width = Math.min(canvasWidth ?? this.width, MAX_DIMENSION);
+            const height = Math.min(canvasHeight ?? this.height, MAX_DIMENSION);
             const ox = Math.floor((width - this.width) / 2);
             const oy = Math.floor((height - this.height) / 2);
             viewportStore.setSize(width, height);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 import { SVG_NAMESPACE, CHECKERBOARD_CONFIG } from '@/constants';
 
 export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
-export const MAX_DIMENSION = 65536;
+export const MAX_DIMENSION = 128;
 export const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 export const indexToCoord = (index) => [index % MAX_DIMENSION, Math.floor(index / MAX_DIMENSION)];
 

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -6,8 +6,7 @@ import {
   useHamiltonianService,
   solveFromPixels,
 } from '../src/services/hamiltonian.js';
-
-const MAX_DIMENSION = 65536;
+const MAX_DIMENSION = 128;
 const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 
 test('buildGraphFromPixels orders neighbors around a center pixel', () => {


### PR DESCRIPTION
## Summary
- restrict MAX_DIMENSION to 128 and update coordinate helpers
- clamp image dimensions to 128 when loading and initializing the canvas
- bound canvas width/height inputs and Hamiltonian service to the new limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf787f0bb8832ca510cdb98d286b7d