### PR TITLE
Add incremental hashing for node tree store

### DIFF
--- a/src/stores/nodeTree.js
+++ b/src/stores/nodeTree.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { readonly, reactive } from 'vue';
-import { useNodeStore } from './nodes';
+import { useNodeStore } from './nodes.js';
+import { mixHash } from '../utils/hash.js';
 
 function flattenLayers(nodes, result = [], nodeStore = useNodeStore()) {
     for (const node of nodes) {
@@ -86,10 +87,67 @@ function flattenSelectedLayers(tree, selection) {
     return [...result];
 }
 
+function createHashNode(store, node) {
+    let hashNode;
+    if (node.children && node.children.length) {
+        const children = node.children.map(child => createHashNode(store, child));
+        let h = node.id;
+        for (const c of children) h = mixHash(h, c.hash);
+        hashNode = { hash: h, children };
+    } else {
+        hashNode = { hash: node.id };
+    }
+    store._hashNodes[node.id] = hashNode;
+    return hashNode;
+}
+
+function deleteHashNode(store, node) {
+    delete store._hashNodes[node.id];
+    if (node.children) {
+        for (const child of node.children) deleteHashNode(store, child);
+    }
+}
+
+function rehashUpFrom(store, id) {
+    if (id != null) {
+        const path = pathTo(store._tree, id);
+        if (path) {
+            for (let i = path.length - 1; i >= 0; i--) {
+                const tNode = path[i];
+                const hNode = store._hashNodes[tNode.id];
+                if (tNode.children && tNode.children.length) {
+                    hNode.children = tNode.children.map(ch => store._hashNodes[ch.id]);
+                    let h = tNode.id;
+                    for (const ch of hNode.children) h = mixHash(h, ch.hash);
+                    hNode.hash = h;
+                } else {
+                    delete hNode.children;
+                    hNode.hash = tNode.id;
+                }
+            }
+        }
+    }
+    const rootChildren = store._tree.map(n => store._hashNodes[n.id]);
+    store._hash.tree.children = rootChildren;
+    let rootHash = 0;
+    for (const child of rootChildren) rootHash = mixHash(rootHash, child.hash);
+    store._hash.tree.hash = rootHash;
+}
+
+function rebuildHashTree(store) {
+    store._hashNodes = {};
+    const children = store._tree.map(node => createHashNode(store, node));
+    let rootHash = 0;
+    for (const child of children) rootHash = mixHash(rootHash, child.hash);
+    store._hash.tree = { hash: rootHash, children };
+}
+
 export const useNodeTreeStore = defineStore('nodeTree', {
     state: () => ({
         _tree: [],
-        _selection: new Set()
+        _selection: new Set(),
+        _hash: { tree: { hash: 0, children: [] }, selection: 0 },
+        _hashNodes: {}
     }),
     getters: {
         _layerIds: (state) => flattenLayers(state._tree),
@@ -134,20 +192,34 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             const info = findNode(this._tree, id);
             if (!info) return null;
             const parentArr = info.parent ? info.parent.children : this._tree;
-            return parentArr.splice(info.index, 1)[0];
+            const parentHashArr = info.parent ? this._hashNodes[info.parent.id].children : this._hash.tree.children;
+            const removed = parentArr.splice(info.index, 1)[0];
+            parentHashArr.splice(info.index, 1);
+            deleteHashNode(this, removed);
+            rehashUpFrom(this, info.parent ? info.parent.id : null);
+            return removed;
         },
         insert(ids, targetId, placeBelow = true) {
             const nodeStore = useNodeStore();
             const targetInfo = targetId != null ? this._findNode(targetId) : null;
             let parentArr = this._tree;
+            let parentHashArr = this._hash.tree.children;
             let index = parentArr.length;
             if (targetInfo) {
                 parentArr = targetInfo.parent ? targetInfo.parent.children : this._tree;
+                if (targetInfo.parent) {
+                    parentHashArr = this._hashNodes[targetInfo.parent.id].children;
+                    if (!parentHashArr) {
+                        this._hashNodes[targetInfo.parent.id].children = [];
+                        parentHashArr = this._hashNodes[targetInfo.parent.id].children;
+                    }
+                } else {
+                    parentHashArr = this._hash.tree.children;
+                }
                 index = targetInfo.index;
                 if (!placeBelow) index++;
             }
 
-            // adjust index to account for nodes that will be removed before insertion
             const idsSet = new Set(ids);
             let removedBefore = 0;
             for (let i = 0; i < index; i++) {
@@ -163,7 +235,10 @@ export const useNodeTreeStore = defineStore('nodeTree', {
                     : { id };
             });
 
+            const hashNodes = nodes.map(n => createHashNode(this, n));
             parentArr.splice(index, 0, ...nodes);
+            parentHashArr.splice(index, 0, ...hashNodes);
+            rehashUpFrom(this, targetInfo ? (targetInfo.parent ? targetInfo.parent.id : null) : null);
         },
         append(ids, groupId, placeTop = true) {
             const nodeStore = useNodeStore();
@@ -174,13 +249,22 @@ export const useNodeTreeStore = defineStore('nodeTree', {
                     ? { id, children: reactive([]) }
                     : { id };
             });
+            const hashNodes = nodes.map(n => createHashNode(this, n));
             let targetArr = this._tree;
+            let targetHashArr = this._hash.tree.children;
             if (groupId != null) {
                 const info = this._findNode(groupId);
                 if (info && info.node.children) targetArr = info.node.children;
+                targetHashArr = this._hashNodes[groupId].children;
+                if (!targetHashArr) {
+                    this._hashNodes[groupId].children = [];
+                    targetHashArr = this._hashNodes[groupId].children;
+                }
             }
             const index = placeTop ? 0 : targetArr.length;
             targetArr.splice(index, 0, ...nodes);
+            targetHashArr.splice(index, 0, ...hashNodes);
+            rehashUpFrom(this, groupId != null ? groupId : null);
         },
         _selectedAncestor(id) {
             let info = this._findNode(id);
@@ -195,14 +279,17 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             const traverse = (nodes, ancestorSelected) => {
                 for (const node of nodes) {
                     const selected = this._selection.has(node.id);
-                    if (ancestorSelected && selected) this._selection.delete(node.id);
+                    if (ancestorSelected && selected) {
+                        this._selection.delete(node.id);
+                        this._hash.selection ^= node.id;
+                    }
                     if (node.children) traverse(node.children, ancestorSelected || selected);
                 }
             };
             traverse(this._tree, false);
         },
         _deselect(id) {
-            if (this._selection.delete(id)) return;
+            if (this._selection.delete(id)) { this._hash.selection ^= id; return; }
             const ancestor = this._selectedAncestor(id);
             if (!ancestor) return;
             const path = pathTo(this._tree, id);
@@ -211,19 +298,29 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             if (start === -1) return;
             for (const node of path.slice(start, -1)) {
                 if (node.children) {
-                    for (const child of node.children) this._selection.add(child.id);
+                    for (const child of node.children) {
+                        if (!this._selection.has(child.id)) {
+                            this._selection.add(child.id);
+                            this._hash.selection ^= child.id;
+                        }
+                    }
                 }
             }
-            this._selection.delete(ancestor.id);
-            this._selection.delete(id);
+            if (this._selection.delete(ancestor.id)) this._hash.selection ^= ancestor.id;
+            if (this._selection.delete(id)) this._hash.selection ^= id;
         },
         replaceSelection(ids = []) {
             this._selection = new Set(ids);
+            this._hash.selection = 0;
+            for (const id of this._selection) this._hash.selection ^= id;
             this._collapseSelection();
         },
         addToSelection(ids = []) {
             for (const id of ids) {
-                if (!this._selectedAncestor(id)) this._selection.add(id);
+                if (!this._selectedAncestor(id) && !this._selection.has(id)) {
+                    this._selection.add(id);
+                    this._hash.selection ^= id;
+                }
             }
             this._collapseSelection();
         },
@@ -238,6 +335,7 @@ export const useNodeTreeStore = defineStore('nodeTree', {
         },
         clearSelection() {
             this._selection.clear();
+            this._hash.selection = 0;
         },
         remove(ids) {
             const removed = [];
@@ -251,7 +349,9 @@ export const useNodeTreeStore = defineStore('nodeTree', {
                 const node = this._removeFromTree(id);
                 if (node) collectIds(node);
             }
-            for (const id of removed) this._selection.delete(id);
+            for (const id of removed) {
+                if (this._selection.delete(id)) this._hash.selection ^= id;
+            }
             return removed;
         },
         serialize() {
@@ -264,9 +364,13 @@ export const useNodeTreeStore = defineStore('nodeTree', {
             const treePayload = payload?.tree;
             const orderPayload = payload?.order;
             if (Array.isArray(treePayload)) this._tree = reactive(buildTree(treePayload));
-            else if (Array.isArray(orderPayload)) this._tree = reactive(orderPayload.map(id => ({ id }))); 
+            else if (Array.isArray(orderPayload)) this._tree = reactive(orderPayload.map(id => ({ id })));
             else this._tree = reactive([]);
+            rebuildHashTree(this);
             this._selection = new Set(payload?.selection || []);
+            this._hash.selection = 0;
+            for (const id of this._selection) this._hash.selection ^= id;
+            this._collapseSelection();
         }
     }
 });

--- a/test/nodeTreeHash.test.js
+++ b/test/nodeTreeHash.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createPinia, setActivePinia } from 'pinia';
+import { useNodeStore } from '../src/stores/nodes.js';
+import { useNodeTreeStore } from '../src/stores/nodeTree.js';
+
+test('nodeTree hashing for tree and selection', () => {
+  setActivePinia(createPinia());
+  const nodes = useNodeStore();
+  const tree = useNodeTreeStore();
+  const l1 = nodes.addLayer({ name: 'L1' });
+  const l2 = nodes.addLayer({ name: 'L2' });
+  const g = nodes.addGroup({ name: 'G' });
+  tree.append([g]);
+  tree.append([l1, l2], g, false);
+
+  const baseHash = tree._hash.tree.hash;
+
+  tree.insert([l1], l2, false);
+  const swappedHash = tree._hash.tree.hash;
+  assert.notStrictEqual(swappedHash, baseHash);
+
+  tree.insert([l1], l2, true);
+  assert.strictEqual(tree._hash.tree.hash, baseHash);
+
+  tree.replaceSelection([l1]);
+  assert.strictEqual(tree._hash.selection, l1);
+  tree.addToSelection([l2]);
+  assert.strictEqual(tree._hash.selection, l1 ^ l2);
+  tree.removeFromSelection([l1]);
+  assert.strictEqual(tree._hash.selection, l2);
+  tree.clearSelection();
+  assert.strictEqual(tree._hash.selection, 0);
+});


### PR DESCRIPTION
## Summary
- track node tree structure with mixHash-based incremental hashing
- maintain selection hash using XOR for efficient updates
- add tests validating tree and selection hashing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfc7be287c832c977f485b35b990fe