### PR TITLE
Initialize pixel sets for newly created layers

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -37,6 +37,7 @@ const onAdd = () => {
     output.setRollbackPoint();
     const above = nodeTree.selectedLayerCount ? layerQuery.uppermost(nodeTree.selectedLayerIds) : null;
     const id = nodes.addLayer({color: 0xFFFFFFFF});
+    pixelStore.set(id);
     nodeTree.insert([id], above, false);
     nodeTree.replaceSelection([id]);
     layerPanel.setScrollRule({ type: 'follow', target: id });

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -54,7 +54,7 @@ export const useClipboardService = defineStore('clipboardService', () => {
         };
         if (data.type === 'layer') {
             const id = nodes.addLayer(base);
-            if (data.pixels) pixelStore.set(id, data.pixels);
+            pixelStore.set(id, data.pixels || []);
             return { id, children: [] };
         }
         if (data.type === 'group') {

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -34,7 +34,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             attributes: maintainedAttrs,
         });
         const newPixels = pixelUnion;
-        if (newPixels.length) pixels.addPixels(newLayerId, newPixels);
+        pixels.set(newLayerId, newPixels);
         nodeTree.insert([newLayerId], nodeTree.orderedSelection[0], true);
         const removed = nodeTree.remove(nodeTree.selectedNodeIds);
         nodes.remove(removed);
@@ -70,7 +70,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     attributes: props.attributes,
                 });
                 const px = pixels.get(srcId);
-                if (px.length) pixels.set(newId, px);
+                pixels.set(newId, px);
                 if (parentId == null) nodeTree.insert([newId], srcId, false);
                 else nodeTree.append([newId], parentId, false);
             }

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -160,7 +160,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
             visibility: nodes.visibility(sourceId),
             attributes: nodes.attributes(sourceId),
         });
-        if (cutPixels.length) pixelStore.set(id, cutPixels);
+        pixelStore.set(id, cutPixels);
         nodeTree.insert([id], sourceId, false);
 
         nodeTree.replaceSelection([sourceId]);

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -100,7 +100,7 @@ export const useInputStore = defineStore('input', {
                                     color: segment.colorU32,
                                     visibility: true
                                 });
-                                if (segment.pixels?.length) pixelStore.set(layerId, segment.pixels);
+                                pixelStore.set(layerId, segment.pixels || []);
                                 layerIds.push(layerId);
                             }
                             groupLayerMap.push({ groupId, layerIds });
@@ -111,7 +111,7 @@ export const useInputStore = defineStore('input', {
                                 color: segment.colorU32,
                                 visibility: true
                             });
-                            if (segment.pixels?.length) pixelStore.set(id, segment.pixels);
+                            pixelStore.set(id, segment.pixels || []);
                             topIds.push(id);
                         }
                     }
@@ -119,10 +119,12 @@ export const useInputStore = defineStore('input', {
                     for (const { groupId, layerIds } of groupLayerMap) nodeTree.append(layerIds, groupId, false);
                 } else {
                     const ids = [nodes.addLayer({}), nodes.addLayer({})];
+                    ids.forEach(id => pixelStore.set(id));
                     nodeTree.insert(ids);
                 }
             } else {
                 const ids = [nodes.addLayer({}), nodes.addLayer({})];
+                ids.forEach(id => pixelStore.set(id));
                 nodeTree.insert(ids);
             }
             layerPanel.setScrollRule({ type: 'follow', target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });

--- a/test/nodeHash.test.js
+++ b/test/nodeHash.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import { webcrypto as crypto } from 'node:crypto';
-globalThis.crypto = crypto;
+if (!globalThis.crypto) globalThis.crypto = crypto;
 
 import assert from 'node:assert';
 import { createPinia, setActivePinia } from 'pinia';

--- a/test/nodeTreeHash.test.js
+++ b/test/nodeTreeHash.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import { webcrypto as crypto } from 'node:crypto';
-globalThis.crypto = crypto;
+if (!globalThis.crypto) globalThis.crypto = crypto;
 
 import assert from 'node:assert';
 import { createPinia, setActivePinia } from 'pinia';

--- a/test/pixelHash.test.js
+++ b/test/pixelHash.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import { webcrypto as crypto } from 'node:crypto';
-globalThis.crypto = crypto;
+if (!globalThis.crypto) globalThis.crypto = crypto;
 
 import assert from 'node:assert';
 import { createPinia, setActivePinia } from 'pinia';


### PR DESCRIPTION
## Summary
- Initialize pixel store entries whenever layers are created or duplicated to avoid missing set errors
- Handle layer creation in clipboard and single-layer tools without safeguards
- Update tests to conditionally stub Web Crypto for Node 20+

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfd9e53ca8832ca104576a036afc35