### PR TITLE
Exclude group nodes from pixel getter use

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -113,8 +113,10 @@ const flatNodes = computed(() => {
   };
   walk(nodeTree.tree, 0);
   const propsList = nodes.getProperties(ids);
-  const pixelList = pixelStore.getProperties(ids);
-  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelList[i].pixels } }));
+  const layerIds = ids.filter(id => !nodes.isGroup(id));
+  const pixelProps = pixelStore.getProperties(layerIds);
+  const pixelMap = Object.fromEntries(pixelProps.map(p => [p.id, p.pixels]));
+  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelMap[id] || [] } }));
 });
 
 const ancestorsOfSelected = computed(() => {


### PR DESCRIPTION
## Summary
- Avoid calling pixel store getters for group nodes in the LayersPanel flat node computation
- Map pixel data only for layer nodes and default group pixel lists to empty arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe193766c832cbe4a562dacd98e73