### PR TITLE
feat: introduce preview editing store for live updates

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -88,7 +88,7 @@ import blockIcons from '../image/layer_block';
 import { useService } from '../services';
 import { useContextMenuStore } from '../stores/contextMenu';
 
-const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output, preview } = useStore();
 const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc, clipboard } = useService();
 const contextMenu = useContextMenuStore();
 
@@ -247,10 +247,11 @@ function applyToSelection(id, fn, ids = nodeTree.selectedNodeIds) {
 
 function onColorInput(id, event) {
     const colorU32 = hexToRgbaU32(event.target.value);
-    applyToSelection(id, sid => nodes.setColor(sid, colorU32), nodeTree.selectedLayerIds);
+    applyToSelection(id, sid => preview.applyNodePreview(sid, { color: colorU32 }), nodeTree.selectedLayerIds);
 }
 
 function onColorChange() {
+    preview.commitPreview();
     output.commit();
 }
 

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -23,7 +23,7 @@
       <!-- 결과 레이어 -->
       <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOfLayer(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in layerPropsForRender" :key="'pix-'+props.id" :d="pathWithPreview(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 그리드 -->
@@ -69,14 +69,31 @@ import { useStore } from '../stores';
 import { useService } from '../services';
 import { OVERLAY_STYLES, GRID_STROKE_COLOR } from '@/constants';
 import { rgbaCssU32 } from '../utils';
-import { checkerboardPatternUrl } from '../utils/pixels.js';
+import { checkerboardPatternUrl, pixelsToUnionPath } from '../utils/pixels.js';
 
-const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, viewportEvent: viewportEvents } = useStore();
+const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, viewportEvent: viewportEvents, preview } = useStore();
 const { overlay, toolSelection: toolSelectionService, viewport } = useService();
 const viewportEl = useTemplateRef('viewportEl');
 const stage = viewportStore.stage;
 const image = viewportStore.imageRect;
 const dpr = window.devicePixelRatio || 1;
+
+const layerPropsForRender = computed(() => {
+    return nodeTree.layerIdsBottomToTop.map(id => {
+        const base = nodes.getProperties(id);
+        const edit = preview.nodeEdits[id];
+        return { ...base, ...(edit || {}) };
+    });
+});
+
+function pathWithPreview(id) {
+    const diff = preview.pixelEdits[id];
+    if (!diff) return pixelStore.pathOfLayer(id);
+    const base = new Set(pixelStore.get(id));
+    diff.add.forEach(p => base.add(p));
+    diff.remove.forEach(p => base.delete(p));
+    return pixelsToUnionPath([...base]);
+}
 
 const stageStyle = computed(() => {
     const width = stage.width / dpr;

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -221,7 +221,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
-    const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const usable = computed(() => tool.shape === 'stroke' || tool.shape === 'rect');
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'globalErase', name: 'Global Erase', icon: stageIcons.globalErase, usable });

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -115,7 +115,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
 });
 
 export const useOrientationToolService = defineStore('orientationToolService', () => {
-    const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const tool = useToolSelectionService();
     const layerQuery = useLayerQueryService();
     const overlayService = useOverlayService();
@@ -276,7 +276,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             for (const pixel of pixels) {
                 if (targetPixels.has(pixel)) pixelsToRemove.push(pixel);
             }
-            if (pixelsToRemove.length) pixelStore.removePixels(id, pixelsToRemove);
+            if (pixelsToRemove.length) preview.applyPixelPreview(id, { remove: pixelsToRemove });
         }
     });
     return { usable };

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -14,7 +14,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
-    const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'draw', name: 'Draw', icon: stageIcons.draw, usable });
@@ -49,7 +49,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         if (tool.current !== 'draw' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.locked(id)) return;
-        pixelStore.addPixels(id, pixels);
+        preview.applyPixelPreview(id, { add: pixels });
     });
     return { usable };
 });
@@ -59,7 +59,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
-    const { nodeTree, nodes, pixels: pixelStore } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'erase', name: 'Erase', icon: stageIcons.erase, usable });
@@ -96,7 +96,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         if (tool.current !== 'erase' || !usable.value) return;
         const id = nodeTree.selectedLayerIds[0];
        if (nodes.locked(id)) return;
-        pixelStore.removePixels(id, pixels);
+        preview.applyPixelPreview(id, { remove: pixels });
     });
     return { usable };
 });

--- a/src/services/toolSelection.js
+++ b/src/services/toolSelection.js
@@ -4,7 +4,7 @@ import { useStore } from '../stores';
 import { coordToIndex, indexToCoord } from '../utils/pixels.js';
 
 export const useToolSelectionService = defineStore('toolSelectionService', () => {
-    const { viewport: viewportStore, viewportEvent: viewportEvents, output } = useStore();
+    const { viewport: viewportStore, viewportEvent: viewportEvents, output, preview } = useStore();
 
     const active = ref(false)
     const prepared = ref([]);
@@ -144,6 +144,7 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
             previewPixels.value = [];
         }
 
+        preview.commitPreview();
         output.commit();
         try { e.target.releasePointerCapture?.(pointer); } catch {}
 
@@ -159,6 +160,7 @@ export const useToolSelectionService = defineStore('toolSelectionService', () =>
     watch(() => [ viewportEvents.pinchIds, viewportEvents.recent.pointer.cancel ], ([pinches, cancels]) => {
         if (!pinches?.includes(pointer) || !cancels.includes(pointer)) return;
         output.rollbackPending();
+        preview.clearPreview();
         const startEvent = viewportEvents.get('pointerdown', pointer);
         try { startEvent?.target?.releasePointerCapture?.(pointer); } catch {}
         

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -8,6 +8,7 @@ import { useViewportEventStore } from './viewportEvent';
 import { useKeyboardEventStore } from './keyboardEvent';
 import { useContextMenuStore } from './contextMenu';
 import { useToolbarStore } from './toolbar';
+import { usePreviewStore } from './preview';
 
 export {
     useInputStore,
@@ -19,7 +20,8 @@ export {
     useViewportEventStore,
     useKeyboardEventStore,
     useContextMenuStore,
-    useToolbarStore
+    useToolbarStore,
+    usePreviewStore
 };
 
 export const useStore = () => ({
@@ -32,5 +34,6 @@ export const useStore = () => ({
     viewportEvent: useViewportEventStore(),
     keyboardEvent: useKeyboardEventStore(),
     contextMenu: useContextMenuStore(),
-    toolbar: useToolbarStore()
+    toolbar: useToolbarStore(),
+    preview: usePreviewStore()
 });

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -1,0 +1,104 @@
+import { defineStore } from 'pinia';
+import { useNodeStore } from './nodes';
+import { usePixelStore } from './pixels';
+
+// pending edits are staged until the next microtask so that if commitPreview()
+// is called within the same tick, the preview state is never touched
+let pendingNodeEdits = {};
+let pendingPixelEdits = {};
+let flushPromise = null;
+
+function scheduleFlush(store) {
+    if (flushPromise) return;
+    flushPromise = Promise.resolve().then(() => {
+        flushPromise = null;
+        for (const [idStr, props] of Object.entries(pendingNodeEdits)) {
+            const id = Number(idStr);
+            if (!store.nodeEdits[id]) store.nodeEdits[id] = {};
+            Object.assign(store.nodeEdits[id], props);
+        }
+        for (const [idStr, diff] of Object.entries(pendingPixelEdits)) {
+            const id = Number(idStr);
+            if (!store.pixelEdits[id]) store.pixelEdits[id] = { add: new Set(), remove: new Set() };
+            const entry = store.pixelEdits[id];
+            diff.add.forEach(p => {
+                entry.add.add(p);
+                entry.remove.delete(p);
+            });
+            diff.remove.forEach(p => {
+                entry.remove.add(p);
+                entry.add.delete(p);
+            });
+        }
+        pendingNodeEdits = {};
+        pendingPixelEdits = {};
+    });
+}
+
+export const usePreviewStore = defineStore('preview', {
+    state: () => ({
+        nodeEdits: {}, // { id: {prop:value} }
+        pixelEdits: {} // { id: { add:Set, remove:Set } }
+    }),
+    actions: {
+        applyNodePreview(id, props = {}) {
+            const prev = pendingNodeEdits[id] || {};
+            pendingNodeEdits[id] = { ...prev, ...props };
+            scheduleFlush(this);
+        },
+        applyPixelPreview(id, { add = [], remove = [] } = {}) {
+            if (!pendingPixelEdits[id]) pendingPixelEdits[id] = { add: new Set(), remove: new Set() };
+            const entry = pendingPixelEdits[id];
+            add.forEach(p => {
+                entry.add.add(p);
+                entry.remove.delete(p);
+            });
+            remove.forEach(p => {
+                entry.remove.add(p);
+                entry.add.delete(p);
+            });
+            scheduleFlush(this);
+        },
+        commitPreview() {
+            const nodeStore = useNodeStore();
+            const pixelStore = usePixelStore();
+
+            if (flushPromise) {
+                // commit pending edits directly without touching reactive preview state
+                for (const [idStr, props] of Object.entries(pendingNodeEdits)) {
+                    nodeStore.update(Number(idStr), props);
+                }
+                for (const [idStr, diff] of Object.entries(pendingPixelEdits)) {
+                    const id = Number(idStr);
+                    const base = new Set(pixelStore.get(id));
+                    diff.add.forEach(p => base.add(p));
+                    diff.remove.forEach(p => base.delete(p));
+                    pixelStore.set(id, [...base]);
+                }
+                pendingNodeEdits = {};
+                pendingPixelEdits = {};
+                flushPromise = null;
+            }
+
+            for (const [idStr, props] of Object.entries(this.nodeEdits)) {
+                nodeStore.update(Number(idStr), props);
+            }
+            for (const [idStr, diff] of Object.entries(this.pixelEdits)) {
+                const id = Number(idStr);
+                const base = new Set(pixelStore.get(id));
+                diff.add.forEach(p => base.add(p));
+                diff.remove.forEach(p => base.delete(p));
+                pixelStore.set(id, [...base]);
+            }
+
+            this.clearPreview();
+        },
+        clearPreview() {
+            this.nodeEdits = {};
+            this.pixelEdits = {};
+            pendingNodeEdits = {};
+            pendingPixelEdits = {};
+            flushPromise = null;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- stage preview edits in microtask to skip preview state when immediately committed
- keep layer panel thumbnails bound to canonical node/pixel stores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bff76988c0832c99ee1e502dffa54e