### PR TITLE
Optimize pixel hash updates and enforce typed array set

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -339,7 +339,7 @@ function deleteNode(id) {
     const belowId = nodeQuery.below(lowermostTarget);
     const removed = nodeTree.remove(targets);
     nodes.remove(removed);
-    pixelStore.remove(removed);
+    pixelStore.removeLayer(removed);
     let newSelectId = null;
     if (nodeTree.has(belowId)) {
         newSelectId = belowId;

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -38,7 +38,6 @@ const onAdd = () => {
     const above = nodeTree.selectedLayerCount ? layerQuery.uppermost(nodeTree.selectedLayerIds) : null;
     const id = nodes.addLayer({color: 0xFFFFFFFF});
     pixelStore.addLayer(id);
-    pixelStore.set(id);
     nodeTree.insert([id], above, false);
     nodeTree.replaceSelection([id]);
     layerPanel.setScrollRule({ type: 'follow', target: id });

--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -37,6 +37,7 @@ const onAdd = () => {
     output.setRollbackPoint();
     const above = nodeTree.selectedLayerCount ? layerQuery.uppermost(nodeTree.selectedLayerIds) : null;
     const id = nodes.addLayer({color: 0xFFFFFFFF});
+    pixelStore.addLayer(id);
     pixelStore.set(id);
     nodeTree.insert([id], above, false);
     nodeTree.replaceSelection([id]);

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -12,13 +12,6 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
         locked: props.locked,
         attributes: props.attributes,
     };
-    if (!props.isGroup) {
-        return {
-            type: 'layer',
-            ...base,
-            pixels: Array.from(pixelStore.get(id)),
-        };
-    }
     if (props.isGroup) {
         const info = nodeTree._findNode(id);
         const children = info?.node.children || [];
@@ -28,7 +21,13 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
             children: children.map(child => serializeNode(child.id, nodeTree, nodes, pixelStore)),
         };
     }
-    return null;
+    else {
+        return {
+            type: 'layer',
+            ...base,
+            pixels: pixelStore.get(id),
+        };
+    }
 }
 
 export const useClipboardService = defineStore('clipboardService', () => {
@@ -36,7 +35,7 @@ export const useClipboardService = defineStore('clipboardService', () => {
     const nodeQuery = useNodeQueryService();
     const layerPanel = useLayerPanelService();
 
-    let clipboardData = null;
+    let clipboardData = [];
 
     function copySelection() {
         const ordered = nodeTree.orderedSelection;
@@ -52,29 +51,24 @@ export const useClipboardService = defineStore('clipboardService', () => {
             locked: data.locked,
             attributes: data.attributes,
         };
-        if (data.type === 'layer') {
-            const id = nodes.addLayer(base);
-            pixelStore.addLayer(id);
-            pixelStore.set(id, data.pixels ? Uint8Array.from(data.pixels) : undefined);
-            return { id, children: [] };
-        }
         if (data.type === 'group') {
             const id = nodes.addGroup(base);
             const children = (data.children || []).map(c => createFrom(c));
             return { id, children };
         }
-        return { id: null, children: [] };
+        if (data.type === 'layer') {
+            const id = nodes.addLayer(base);
+            pixelStore.addLayer(id);
+            pixelStore.set(id, data.pixels);
+            return { id, children: [] };
+        }
     }
 
     function paste() {
-        if (!clipboardData || !clipboardData.length) return [];
+        if (!clipboardData.length) return [];
 
         output.setRollbackPoint();
         const infos = clipboardData.map(createFrom);
-        if (!infos.length) {
-            output.rollbackPending?.();
-            return [];
-        }
         const topIds = infos.map(info => info.id);
         const uppermost = nodeQuery.uppermost(nodeTree.selectedIds);
         nodeTree.insert(topIds, uppermost, false);

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -54,6 +54,7 @@ export const useClipboardService = defineStore('clipboardService', () => {
         };
         if (data.type === 'layer') {
             const id = nodes.addLayer(base);
+            pixelStore.addLayer(id);
             pixelStore.set(id, data.pixels ? Uint8Array.from(data.pixels) : undefined);
             return { id, children: [] };
         }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 import { useLayerQueryService } from './layerQuery';
 import { averageColorU32 } from '../utils';
-import { findPixelComponents, getPixelUnion } from '../utils/pixels.js';
+import { groupConnectedPixels, getPixelUnion } from '../utils/pixels.js';
 
 export const useLayerToolService = defineStore('layerToolService', () => {
     const { nodeTree, nodes, pixels } = useStore();
@@ -33,9 +33,8 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             color: colorU32,
             attributes: maintainedAttrs,
         });
-        const newPixels = pixelUnion;
         pixels.addLayer(newLayerId);
-        pixels.set(newLayerId, newPixels);
+        pixels.add(newLayerId, pixelUnion);
         nodeTree.insert([newLayerId], nodeTree.orderedSelection[0], true);
         const removed = nodeTree.remove(nodeTree.selectedNodeIds);
         nodes.remove(removed);
@@ -70,9 +69,8 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     visibility: props.visibility,
                     attributes: props.attributes,
                 });
-                const px = pixels.get(srcId);
                 pixels.addLayer(newId);
-                pixels.set(newId, px);
+                pixels.set(newId, pixels.get(srcId));
                 if (parentId == null) nodeTree.insert([newId], srcId, false);
                 else nodeTree.append([newId], parentId, false);
             }
@@ -95,7 +93,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
         const splitedLayers = [];
 
         for (const layerId of selected) {
-            const components = findPixelComponents(pixels.get(layerId));
+            const components = groupConnectedPixels(pixels.get(layerId));
             if (components.length <= 1) {
                 newSelection.push(layerId)
                 continue;
@@ -110,7 +108,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     attributes: original.attributes,
                 });
                 pixels.addLayer(newId);
-                pixels.set(newId, componentPixels);
+                pixels.add(newId, componentPixels);
                 return newId;
             });
 

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -34,11 +34,12 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             attributes: maintainedAttrs,
         });
         const newPixels = pixelUnion;
+        pixels.addLayer(newLayerId);
         pixels.set(newLayerId, newPixels);
         nodeTree.insert([newLayerId], nodeTree.orderedSelection[0], true);
         const removed = nodeTree.remove(nodeTree.selectedNodeIds);
         nodes.remove(removed);
-        pixels.remove(removed);
+        pixels.removeLayer(removed);
         return newLayerId;
     }
 
@@ -70,6 +71,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     attributes: props.attributes,
                 });
                 const px = pixels.get(srcId);
+                pixels.addLayer(newId);
                 pixels.set(newId, px);
                 if (parentId == null) nodeTree.insert([newId], srcId, false);
                 else nodeTree.append([newId], parentId, false);
@@ -107,6 +109,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     visibility: original.visibility,
                     attributes: original.attributes,
                 });
+                pixels.addLayer(newId);
                 pixels.set(newId, componentPixels);
                 return newId;
             });
@@ -115,7 +118,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             
             const removed = nodeTree.remove([layerId]);
             nodes.remove(removed);
-            pixels.remove(removed);
+            pixels.removeLayer(removed);
 
             newSelection.push(...newIds);
             splitedLayers.push(...newIds);

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -29,7 +29,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
         const belowId = nodeQuery.below(lowermostTarget);
         const removed = nodeTree.remove(ids);
         nodes.remove(removed);
-        pixelStore.remove(removed);
+        pixelStore.removeLayer(removed);
         let newSelect = null;
         if (nodeTree.has(belowId)) {
             newSelect = belowId;

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -171,7 +171,8 @@ export const useCutToolService = defineStore('cutToolService', () => {
             visibility: nodes.visibility(sourceId),
             attributes: nodes.attributes(sourceId),
         });
-        pixelStore.set(id, cutPixels);
+        pixelStore.addLayer(id);
+        pixelStore.add(id, cutPixels);
         nodeTree.insert([id], sourceId, false);
 
         nodeTree.replaceSelection([sourceId]);

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -33,7 +33,7 @@ export const usePathToolService = defineStore('pathToolService', () => {
 
         nodeTree.remove([layerId]);
         nodes.remove([layerId]);
-        pixelStore.remove([layerId]);
+        pixelStore.removeLayer([layerId]);
 
         paths.forEach((path, idx) => {
             const subGroupId = nodes.addGroup({ name: `Path ${idx + 1}` });
@@ -42,7 +42,8 @@ export const usePathToolService = defineStore('pathToolService', () => {
             const ids = [];
             path.forEach((pixel, j) => {
                 const lid = nodes.addLayer({ name: `Pixel ${j + 1}`, color });
-                pixelStore.addPixels(lid, [pixel]);
+                pixelStore.addLayer(lid);
+                pixelStore.add(lid, [pixel]);
                 ids.push(lid);
             });
             nodeTree.append(ids, subGroupId, false);
@@ -103,7 +104,7 @@ export const useRelayToolService = defineStore('relayToolService', () => {
             }
             if (!orientation) continue;
             const pixels = pixelsOf(id);
-            if (pixels.length) pixelStore.set(id, pixels, orientation);
+            if (pixels.length) pixelStore.add(id, pixels, orientation);
             orientationMap.set(id, orientation);
         }
 
@@ -122,10 +123,10 @@ export const useRelayToolService = defineStore('relayToolService', () => {
                 const union = [...new Set([...pixelsOf(baseId), ...pixelsOf(nextId)])];
                 if (groupConnectedPixels(union).length > 1) continue;
                 const px = pixelsOf(nextId);
-                if (px.length) pixelStore.addPixels(baseId, px, orient);
+                if (px.length) pixelStore.add(baseId, px, orient);
                 const removed = nodeTree.remove([nextId]);
                 nodes.remove(removed);
-                pixelStore.remove(removed);
+                pixelStore.removeLayer(removed);
                 orientationMap.delete(nextId);
                 mergedSelection.delete(nextId);
                 changed = true;
@@ -220,7 +221,8 @@ export const useExpandToolService = defineStore('expandToolService', () => {
                 const components = groupConnectedPixels(pixels);
                 for (const comp of components) {
                     const id = nodes.addLayer({ name, color });
-                    pixelStore.set(id, comp);
+                    pixelStore.addLayer(id);
+                    pixelStore.add(id, comp);
                     newLayerIds.push(id);
                 }
             }

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -104,7 +104,7 @@ export const useRelayToolService = defineStore('relayToolService', () => {
             }
             if (!orientation) continue;
             const pixels = pixelsOf(id);
-            if (pixels.length) pixelStore.add(id, pixels, orientation);
+            pixelStore.add(id, pixels, orientation);
             orientationMap.set(id, orientation);
         }
 
@@ -122,8 +122,7 @@ export const useRelayToolService = defineStore('relayToolService', () => {
                 if (!orient || orientationMap.get(nextId) !== orient) continue;
                 const union = [...new Set([...pixelsOf(baseId), ...pixelsOf(nextId)])];
                 if (groupConnectedPixels(union).length > 1) continue;
-                const px = pixelsOf(nextId);
-                if (px.length) pixelStore.add(baseId, px, orient);
+                pixelStore.add(baseId, pixelsOf(nextId), orient);
                 const removed = nodeTree.remove([nextId]);
                 nodes.remove(removed);
                 pixelStore.removeLayer(removed);

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -101,7 +101,7 @@ export const useInputStore = defineStore('input', {
                                     visibility: true
                                 });
                                 pixelStore.addLayer(layerId);
-                                pixelStore.add(layerId, segment.pixels || []);
+                                pixelStore.add(layerId, segment.pixels);
                                 layerIds.push(layerId);
                             }
                             groupLayerMap.push({ groupId, layerIds });
@@ -113,7 +113,7 @@ export const useInputStore = defineStore('input', {
                                 visibility: true
                             });
                             pixelStore.addLayer(id);
-                            pixelStore.add(id, segment.pixels || []);
+                            pixelStore.add(id, segment.pixels);
                             topIds.push(id);
                         }
                     }
@@ -121,15 +121,13 @@ export const useInputStore = defineStore('input', {
                     for (const { groupId, layerIds } of groupLayerMap) nodeTree.append(layerIds, groupId, false);
                 } else {
                     const ids = [nodes.addLayer({}), nodes.addLayer({})];
-                    pixelStore.addLayer(ids);
-                    ids.forEach(id => pixelStore.set(id));
                     nodeTree.insert(ids);
+                    pixelStore.addLayer(ids);
                 }
             } else {
                 const ids = [nodes.addLayer({}), nodes.addLayer({})];
-                pixelStore.addLayer(ids);
-                ids.forEach(id => pixelStore.set(id));
                 nodeTree.insert(ids);
+                pixelStore.addLayer(ids);
             }
             layerPanel.setScrollRule({ type: 'follow', target: nodeTree.layerOrder[nodeTree.layerOrder.length - 1] });
             if (ox || oy) {

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -100,7 +100,8 @@ export const useInputStore = defineStore('input', {
                                     color: segment.colorU32,
                                     visibility: true
                                 });
-                                pixelStore.set(layerId, segment.pixels || []);
+                                pixelStore.addLayer(layerId);
+                                pixelStore.add(layerId, segment.pixels || []);
                                 layerIds.push(layerId);
                             }
                             groupLayerMap.push({ groupId, layerIds });
@@ -111,7 +112,8 @@ export const useInputStore = defineStore('input', {
                                 color: segment.colorU32,
                                 visibility: true
                             });
-                            pixelStore.set(id, segment.pixels || []);
+                            pixelStore.addLayer(id);
+                            pixelStore.add(id, segment.pixels || []);
                             topIds.push(id);
                         }
                     }
@@ -119,11 +121,13 @@ export const useInputStore = defineStore('input', {
                     for (const { groupId, layerIds } of groupLayerMap) nodeTree.append(layerIds, groupId, false);
                 } else {
                     const ids = [nodes.addLayer({}), nodes.addLayer({})];
+                    pixelStore.addLayer(ids);
                     ids.forEach(id => pixelStore.set(id));
                     nodeTree.insert(ids);
                 }
             } else {
                 const ids = [nodes.addLayer({}), nodes.addLayer({})];
+                pixelStore.addLayer(ids);
                 ids.forEach(id => pixelStore.set(id));
                 nodeTree.insert(ids);
             }

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -80,7 +80,7 @@ export const useViewportStore = defineStore('viewport', {
                         toRemove.push(i);
                     }
                 }
-                if (toRemove.length) pixelStore.remove(id, toRemove);
+                pixelStore.remove(id, toRemove);
             }
             this._stage.width = newWidth;
             this._stage.height = newHeight;

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -80,7 +80,7 @@ export const useViewportStore = defineStore('viewport', {
                         toRemove.push(i);
                     }
                 }
-                if (toRemove.length) pixelStore.removePixels(id, toRemove);
+                if (toRemove.length) pixelStore.remove(id, toRemove);
             }
             this._stage.width = newWidth;
             this._stage.height = newHeight;

--- a/test/pixelHash.test.js
+++ b/test/pixelHash.test.js
@@ -19,18 +19,20 @@ test('swapping layer pixels changes hash', () => {
   setActivePinia(createPinia());
   const storeA = usePixelStore();
   const l1 = 1, l2 = 2;
+  storeA.addLayer([l1, l2]);
   const p1 = coordToIndex(0, 0);
   const p2 = coordToIndex(1, 0);
   const p3 = coordToIndex(0, 1);
   const p4 = coordToIndex(1, 1);
-  storeA.set(l1, [p1, p2], 'horizontal');
-  storeA.set(l2, [p3, p4], 'vertical');
+  storeA.add(l1, [p1, p2], 'horizontal');
+  storeA.add(l2, [p3, p4], 'vertical');
   const hashA = storeA._hash.all;
 
   setActivePinia(createPinia());
   const storeB = usePixelStore();
-  storeB.set(l1, [p3, p4], 'horizontal');
-  storeB.set(l2, [p1, p2], 'vertical');
+  storeB.addLayer([l1, l2]);
+  storeB.add(l1, [p3, p4], 'horizontal');
+  storeB.add(l2, [p1, p2], 'vertical');
   const hashB = storeB._hash.all;
 
   assert.notStrictEqual(hashA, hashB);
@@ -40,10 +42,11 @@ test('changing pixel orientation updates hash', () => {
   setActivePinia(createPinia());
   const store = usePixelStore();
   const layer = 1;
+  store.addLayer(layer);
   const px = coordToIndex(0, 0);
-  store.set(layer, [px], 'horizontal');
+  store.add(layer, [px], 'horizontal');
   const hash1 = store._hash.all;
-  store.setOrientation(layer, px, 'vertical');
+  store.add(layer, [px], 'vertical');
   const hash2 = store._hash.all;
   assert.notStrictEqual(hash1, hash2);
 });


### PR DESCRIPTION
## Summary
- Introduce explicit `addLayer`/`removeLayer` actions and remove implicit layer creation
- Rename pixel mutations to `add`/`remove` and drop `setOrientation`
- Require layer creators to register layers via `addLayer`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0360a44f0832cb8fbbbcf5a5d6cb1