### PR TITLE
Store pixel preview as deltas

### DIFF
--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -143,7 +143,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         return res;
     }
     function orientationOfWithPreview(id, pixel) {
-        const previewMap = preview.pixels[id];
+        const previewMap = preview.pixels[id]?.orientationMap;
         if (previewMap) {
             for (const o of PIXEL_ORIENTATIONS) {
                 const arr = previewMap[o];
@@ -171,7 +171,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                 for (let i = nodeTree.layerOrder.length - 1; i >= 0; i--) {
                     const id = nodeTree.layerOrder[i];
                     if (!nodes.visibility(id)) continue;
-                    let pixels = preview.pixels[id]?.[orientation];
+                    let pixels = preview.pixels[id]?.orientationMap?.[orientation];
                     if (!pixels) pixels = orientationPixels(id, orientation);
                     if (!pixels.length) continue;
                     for (const pixel of pixels) {
@@ -184,7 +184,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
             }
             else {
                 for (const id of layerIds) {
-                    let pixels = preview.pixels[id]?.[orientation];
+                    let pixels = preview.pixels[id]?.orientationMap?.[orientation];
                     if (!pixels) pixels = orientationPixels(id, orientation);
                     if (!pixels.length) continue;
                     overlayService.addPixels(overlayId, pixels);


### PR DESCRIPTION
## Summary
- Track pixel preview changes as deltas instead of full orientation maps
- Apply queued add/remove/orientation deltas when committing previews
- Update orientation tool to read pixel preview deltas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0598bd6a8832cb910845f7fe07924