### PR TITLE
refactor pixel storage to Map

### DIFF
--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -9,25 +9,26 @@ const ORIENTATION_IDS = Object.fromEntries(PIXEL_ORIENTATIONS.map((o, i) => [o, 
 const ID_TO_ORIENTATION = Object.fromEntries(PIXEL_ORIENTATIONS.map((o, i) => [i + 1, o]));
 const PIXEL_HASHES = crypto.getRandomValues(new Uint32Array(MAX_DIMENSION * MAX_DIMENSION));
 
-function hashLayer(arr) {
+function hashLayer(map) {
     let h = 0;
-    for (let i = 0; i < arr.length; i++) {
-        const v = arr[i];
-        if (v) h ^= mixHash(v, PIXEL_HASHES[i]);
+    if (map instanceof Map) {
+        for (const [i, v] of map) {
+            if (v) h ^= mixHash(v, PIXEL_HASHES[i]);
+        }
     }
     return h;
 }
 
 function rehashLayer(store, id) {
-    const arr = store._pixels[id] || new Uint8Array(MAX_DIMENSION * MAX_DIMENSION);
+    const map = store._pixels[id] || new Map();
     const oldHash = store._hash.layers[id] || 0;
-    const layerHash = hashLayer(arr);
+    const layerHash = hashLayer(map);
     store._hash.layers[id] = layerHash;
     store._hash.all ^= mixHash(id, oldHash) ^ mixHash(id, layerHash);
 }
 
 function updatePixelHash(store, id, index, oldVal, newVal) {
-    const oldLayerHash = store._hash.layers[id];
+    const oldLayerHash = store._hash.layers[id] || 0;
     const oldMix = oldVal ? mixHash(oldVal, PIXEL_HASHES[index]) : 0;
     const newMix = newVal ? mixHash(newVal, PIXEL_HASHES[index]) : 0;
     const newLayerHash = oldLayerHash ^ oldMix ^ newMix;
@@ -50,24 +51,22 @@ export const usePixelStore = defineStore('pixels', {
             return s._pixels[id];
         },
         sizeOf: (s) => (id) => {
-            const arr = s._pixels[id];
-            let c = 0;
-            for (let i = 0; i < arr.length; i++) if (arr[i]) c++;
-            return c;
+            const map = s._pixels[id];
+            return map ? map.size : 0;
         },
         orientationOf: (s) => (id, pixel) => {
-            const v = s._pixels[id]?.[pixel] || 0;
+            const v = s._pixels[id]?.get(pixel) || 0;
             return ID_TO_ORIENTATION[v];
         },
         pathOf: (s) => (id) => {
             return pixelsToUnionPath(s._pixels[id]);
         },
         disconnectedCountOf: (s) => (id) => {
-            const arr = s._pixels[id];
-            return groupConnectedPixels(arr).length;
+            const map = s._pixels[id];
+            return groupConnectedPixels(map).length;
         },
         has: (s) => (id, pixel) => {
-            return (s._pixels[id]?.[pixel] || 0) > 0;
+            return s._pixels[id]?.has(pixel) || false;
         }
     },
     actions: {
@@ -75,15 +74,15 @@ export const usePixelStore = defineStore('pixels', {
             if (!Array.isArray(ids)) ids = [ids];
             for (const id of ids) {
                 if (id == null || this._pixels[id]) continue;
-                this._pixels[id] = new Uint8Array(MAX_DIMENSION * MAX_DIMENSION);
+                this._pixels[id] = new Map();
                 this._hash.layers[id] = 0;
                 this._hash.all ^= mixHash(id, 0);
             }
         },
         set(id, pixels) {
-            this._pixels[id] = pixels;
+            this._pixels[id] = pixels instanceof Map ? pixels : new Map(pixels);
             rehashLayer(this, id);
-        }
+        },
         removeLayer(ids = []) {
             if (!Array.isArray(ids)) ids = [ids];
             for (const id of ids) {
@@ -94,15 +93,15 @@ export const usePixelStore = defineStore('pixels', {
             }
         },
         add(id, pixels, orientation) {
-            const arr = this._pixels[id];
+            const map = this._pixels[id];
             orientation ??= this._defaultOrientation;
             if (orientation === 'checkerboard') {
                 for (const pixel of pixels) {
                     const [x, y] = indexToCoord(pixel);
                     const o = (x + y) % 2 === 0 ? 'horizontal' : 'vertical';
                     const newVal = ORIENTATION_IDS[o];
-                    const oldVal = arr[pixel];
-                    arr[pixel] = newVal;
+                    const oldVal = map.get(pixel) || 0;
+                    map.set(pixel, newVal);
                     updatePixelHash(this, id, pixel, oldVal, newVal);
                 }
             } else if (orientation === 'slopeCheckerboard') {
@@ -110,33 +109,33 @@ export const usePixelStore = defineStore('pixels', {
                     const [x, y] = indexToCoord(pixel);
                     const o = (x + y) % 2 === 0 ? 'downSlope' : 'upSlope';
                     const newVal = ORIENTATION_IDS[o];
-                    const oldVal = arr[pixel];
-                    arr[pixel] = newVal;
+                    const oldVal = map.get(pixel) || 0;
+                    map.set(pixel, newVal);
                     updatePixelHash(this, id, pixel, oldVal, newVal);
                 }
             } else {
                 const idOri = ORIENTATION_IDS[orientation] || ORIENTATION_IDS.none;
                 for (const pixel of pixels) {
-                    const oldVal = arr[pixel];
-                    arr[pixel] = idOri;
+                    const oldVal = map.get(pixel) || 0;
+                    map.set(pixel, idOri);
                     updatePixelHash(this, id, pixel, oldVal, idOri);
                 }
             }
         },
         remove(id, pixels) {
-            const arr = this._pixels[id];
+            const map = this._pixels[id];
             for (const pixel of pixels) {
-                const oldVal = arr[pixel];
+                const oldVal = map.get(pixel);
                 if (!oldVal) continue;
-                arr[pixel] = 0;
+                map.delete(pixel);
                 updatePixelHash(this, id, pixel, oldVal, 0);
             }
         },
         togglePixel(id, pixel) {
-            const arr = this._pixels[id];
-            const oldVal = arr[pixel];
+            const map = this._pixels[id];
+            const oldVal = map.get(pixel);
             if (oldVal) {
-                arr[pixel] = 0;
+                map.delete(pixel);
                 updatePixelHash(this, id, pixel, oldVal, 0);
                 return;
             }
@@ -149,7 +148,7 @@ export const usePixelStore = defineStore('pixels', {
                 ori = (x + y) % 2 === 0 ? 'downSlope' : 'upSlope';
             }
             const newVal = ORIENTATION_IDS[ori] || ORIENTATION_IDS.none;
-            arr[pixel] = newVal;
+            map.set(pixel, newVal);
             updatePixelHash(this, id, pixel, oldVal, newVal);
         },
         translateAll(dx = 0, dy = 0) {
@@ -158,29 +157,23 @@ export const usePixelStore = defineStore('pixels', {
             const keys = Object.keys(this._pixels);
             for (const idStr of keys) {
                 const id = Number(idStr);
-                const arr = this._pixels[id];
-                const moved = new Uint8Array(arr.length);
-                let layerHash = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    const v = arr[i];
-                    if (!v) continue;
+                const map = this._pixels[id];
+                const moved = new Map();
+                for (const [i, v] of map) {
                     const [x, y] = indexToCoord(i);
                     const nx = x + dx;
                     const ny = y + dy;
                     const ni = coordToIndex(nx, ny);
-                    moved[ni] = v;
-                    layerHash ^= mixHash(v, PIXEL_HASHES[ni]);
+                    moved.set(ni, v);
                 }
-                const oldHash = this._hash.layers[id] || 0;
-                this._hash.layers[id] = layerHash;
-                this._hash.all ^= mixHash(id, oldHash) ^ mixHash(id, layerHash);
                 this._pixels[id] = moved;
+                rehashLayer(this, id);
             }
         },
         serialize() {
             const result = {};
-            for (const [id, arr] of Object.entries(this._pixels)) {
-                result[id] = Array.from(arr);
+            for (const [id, map] of Object.entries(this._pixels)) {
+                result[id] = Array.from(map.entries());
             }
             return result;
         },
@@ -188,8 +181,8 @@ export const usePixelStore = defineStore('pixels', {
             this._pixels = {};
             this._hash = { layers: {}, all: 0 };
             for (const [id, data] of Object.entries(byId)) {
-                const arr = data instanceof Uint8Array ? data : Uint8Array.from(data);
-                this._pixels[id] = arr;
+                const map = data instanceof Map ? data : new Map(data);
+                this._pixels[id] = map;
                 rehashLayer(this, Number(id));
             }
         },

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -19,10 +19,9 @@ function toPixelSet(target) {
 }
 
 export function getPixelUnion(pixelsList = []) {
-    const layers = Array.isArray(pixelsList) ? pixelsList : [pixelsList];
     const union = new Set();
-    for (const layer of layers) {
-        for (const p of toPixelSet(layer)) union.add(p);
+    for (const pixels of pixelsList) {
+        for (const p of pixels.keys()) union.add(p);
     }
     return Array.from(union);
 }
@@ -147,8 +146,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
     return id;
   }
 
-export function groupConnectedPixels(target) {
-    const pixels = target instanceof Set ? target : toPixelSet(target);
+export function groupConnectedPixels(pixels) {
     const visited = new Set();
     const components = [];
     const neighbors = [
@@ -157,7 +155,7 @@ export function groupConnectedPixels(target) {
         [0, 1],
         [0, -1]
     ];
-    for (const i of pixels) {
+    for (const i of pixels.keys()) {
         if (visited.has(i)) continue;
         const comp = [];
         const stack = [i];
@@ -182,18 +180,17 @@ export function groupConnectedPixels(target) {
     return components;
 }
 
-export function buildOutline(target) {
-    const pixelSet = target instanceof Set ? target : toPixelSet(target);
+export function buildOutline(pixels) {
     const paths = [];
-    const components = groupConnectedPixels(pixelSet);
+    const components = groupConnectedPixels(pixels);
     for (const component of components) {
         const edges = [];
         for (const pixel of component) {
             const [x, y] = indexToCoord(pixel);
-            if (y === 0 || !pixelSet.has(coordToIndex(x, y - 1))) edges.push([[x, y], [x + 1, y]]);
-            if (x === MAX_DIMENSION - 1 || !pixelSet.has(coordToIndex(x + 1, y))) edges.push([[x + 1, y], [x + 1, y + 1]]);
-            if (y === MAX_DIMENSION - 1 || !pixelSet.has(coordToIndex(x, y + 1))) edges.push([[x, y + 1], [x + 1, y + 1]]);
-            if (x === 0 || !pixelSet.has(coordToIndex(x - 1, y))) edges.push([[x, y], [x, y + 1]]);
+            if (y === 0 || !pixels.has(coordToIndex(x, y - 1))) edges.push([[x, y], [x + 1, y]]);
+            if (x === MAX_DIMENSION - 1 || !pixels.has(coordToIndex(x + 1, y))) edges.push([[x + 1, y], [x + 1, y + 1]]);
+            if (y === MAX_DIMENSION - 1 || !pixels.has(coordToIndex(x, y + 1))) edges.push([[x, y + 1], [x + 1, y + 1]]);
+            if (x === 0 || !pixels.has(coordToIndex(x - 1, y))) edges.push([[x, y], [x, y + 1]]);
         }
         paths.push(edges);
     }


### PR DESCRIPTION
## Summary
- store layer pixels in `Map<number, number>` instead of typed arrays
- refactor pixel operations to work on pixel indices with Map-backed hashing
- adapt pixel utilities for Map layers and connected-component logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0661b9e54832cb31277e9227fae39