### PR TITLE
Refactor pixel consumers for Map-backed pixel state

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -116,12 +116,10 @@ const flatNodes = computed(() => {
   const layerIds = ids.filter(id => !nodes.isGroup(id));
   const pixelArr = pixelStore.get(layerIds);
   const pixelMap = Object.fromEntries(layerIds.map((id, idx) => [id, pixelArr[idx]]));
-  const pixelCountMap = Object.fromEntries(layerIds.map(id => [id, pixelStore.sizeOf(id)]));
-  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelMap[id] || new Map(), count: pixelCountMap[id] || 0 } }));
+  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelMap[id], count: pixelMap[id].size } }));
 });
 
 const ancestorsOfSelected = computed(() => {
-  nodeTree.tree;
   const selected = new Set(nodeTree.selectedNodeIds);
   const result = new Set();
   for (const id of selected) {

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -117,7 +117,7 @@ const flatNodes = computed(() => {
   const pixelArr = pixelStore.get(layerIds);
   const pixelMap = Object.fromEntries(layerIds.map((id, idx) => [id, pixelArr[idx]]));
   const pixelCountMap = Object.fromEntries(layerIds.map(id => [id, pixelStore.sizeOf(id)]));
-  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelMap[id] || new Uint8Array(), count: pixelCountMap[id] || 0 } }));
+  return ids.map((id, i) => ({ id, depth: depths[i], isGroup: propsList[i].isGroup, props: { ...propsList[i], pixels: pixelMap[id] || new Map(), count: pixelCountMap[id] || 0 } }));
 });
 
 const ancestorsOfSelected = computed(() => {

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -25,7 +25,7 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
         return {
             type: 'layer',
             ...base,
-            pixels: Array.from(pixelStore.get(id).entries()),
+            pixels: pixelStore.get(id)
         };
     }
 }
@@ -59,7 +59,7 @@ export const useClipboardService = defineStore('clipboardService', () => {
         if (data.type === 'layer') {
             const id = nodes.addLayer(base);
             pixelStore.addLayer(id);
-            pixelStore.set(id, new Map(data.pixels));
+            pixelStore.set(id, data.pixels);
             return { id, children: [] };
         }
     }

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -25,7 +25,7 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
         return {
             type: 'layer',
             ...base,
-            pixels: pixelStore.get(id),
+            pixels: Array.from(pixelStore.get(id).entries()),
         };
     }
 }
@@ -59,7 +59,7 @@ export const useClipboardService = defineStore('clipboardService', () => {
         if (data.type === 'layer') {
             const id = nodes.addLayer(base);
             pixelStore.addLayer(id);
-            pixelStore.set(id, data.pixels);
+            pixelStore.set(id, new Map(data.pixels));
             return { id, children: [] };
         }
     }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -70,7 +70,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     attributes: props.attributes,
                 });
                 pixels.addLayer(newId);
-                pixels.set(newId, pixels.get(srcId));
+                pixels.set(newId, new Map(pixels.get(srcId)));
                 if (parentId == null) nodeTree.insert([newId], srcId, false);
                 else nodeTree.append([newId], parentId, false);
             }

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -70,7 +70,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
                     attributes: props.attributes,
                 });
                 pixels.addLayer(newId);
-                pixels.set(newId, new Map(pixels.get(srcId)));
+                pixels.set(newId, pixels.get(srcId));
                 if (parentId == null) nodeTree.insert([newId], srcId, false);
                 else nodeTree.append([newId], parentId, false);
             }

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -153,10 +153,10 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         return pixelStore.orientationOf(id, pixel);
     }
     function orientationPixels(id, orientation) {
-        const arr = pixelStore.get(id);
+        const map = pixelStore.get(id);
         const target = PIXEL_ORIENTATIONS.indexOf(orientation) + 1;
         const res = [];
-        for (let i = 0; i < arr.length; i++) if (arr[i] === target) res.push(i);
+        for (const [i, v] of map) if (v === target) res.push(i);
         return res;
     }
     function rebuild() {
@@ -299,8 +299,8 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             const unlockedIds = nodeTree.layerOrder.filter(id => !nodes.locked(id));
             const unlockedPixels = new Set();
             for (const id of unlockedIds) {
-                const arr = pixelStore.get(id);
-                for (let i = 0; i < arr.length; i++) if (arr[i]) unlockedPixels.add(i);
+                const map = pixelStore.get(id);
+                for (const i of map.keys()) unlockedPixels.add(i);
             }
             for (const pixel of pixels) {
                 if (unlockedPixels.has(pixel)) erasablePixels.push(pixel);

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -153,10 +153,10 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         return pixelStore.orientationOf(id, pixel);
     }
     function orientationPixels(id, orientation) {
-        const map = pixelStore.get(id);
-        const target = PIXEL_ORIENTATIONS.indexOf(orientation) + 1;
+        const targetId = PIXEL_ORIENTATIONS.indexOf(orientation) + 1;
         const res = [];
-        for (const [i, v] of map) if (v === target) res.push(i);
+        const map = pixelStore.get(id);
+        for (const [idx, orientationId] of map) if (orientationId === targetId) res.push(idx);
         return res;
     }
     function rebuild() {

--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -43,8 +43,7 @@ export const useOverlayService = defineStore('overlayService', () => {
         const overlaySet = overlayPixels[id];
         for (const layerId of ids) {
             const layerMap = pixelStore.get(layerId);
-            if (!layerMap) continue;
-            for (const i of layerMap.keys()) overlaySet.add(i);
+            for (const idx of layerMap.keys()) overlaySet.add(idx);
         }
     }
 

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -22,9 +22,8 @@ export const usePreviewStore = defineStore('preview', {
             return (id) => {
                 const delta = state.pixels[id];
                 if (delta) {
-                    const base = pixelStore.get(id) || [];
-                    const set = new Set();
-                    for (let i = 0; i < base.length; i++) if (base[i]) set.add(i);
+                    const base = pixelStore.get(id) || new Map();
+                    const set = new Set(base.keys());
                     if (delta.remove) delta.remove.forEach(p => set.delete(p));
                     if (delta.orientationMap) {
                         for (const arr of Object.values(delta.orientationMap)) {
@@ -32,7 +31,7 @@ export const usePreviewStore = defineStore('preview', {
                         }
                     }
                     if (delta.add) delta.add.forEach(p => set.add(p));
-                    return pixelsToUnionPath([...set]);
+                    return pixelsToUnionPath(set);
                 }
                 return pixelStore.pathOf(id);
             };

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -73,13 +73,13 @@ export const useViewportStore = defineStore('viewport', {
             for (const id of tree.layerIdsBottomToTop) {
                 const map = pixelStore.get(id);
                 const toRemove = [];
-                for (const i of map.keys()) {
-                    const [x, y] = indexToCoord(i);
+                for (const idx of map.keys()) {
+                    const [x, y] = indexToCoord(idx);
                     if (x < 0 || y < 0 || x >= newWidth || y >= newHeight) {
-                        toRemove.push(i);
+                        toRemove.push(idx);
                     }
                 }
-                if (toRemove.length) pixelStore.remove(id, toRemove);
+                pixelStore.remove(id, toRemove);
             }
             this._stage.width = newWidth;
             this._stage.height = newHeight;

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -71,16 +71,15 @@ export const useViewportStore = defineStore('viewport', {
             const newWidth = Math.max(1, this._stage.width + left + right);
             const newHeight = Math.max(1, this._stage.height + top + bottom);
             for (const id of tree.layerIdsBottomToTop) {
-                const arr = pixelStore.get(id);
+                const map = pixelStore.get(id);
                 const toRemove = [];
-                for (let i = 0; i < arr.length; i++) {
-                    if (!arr[i]) continue;
+                for (const i of map.keys()) {
                     const [x, y] = indexToCoord(i);
                     if (x < 0 || y < 0 || x >= newWidth || y >= newHeight) {
                         toRemove.push(i);
                     }
                 }
-                pixelStore.remove(id, toRemove);
+                if (toRemove.length) pixelStore.remove(id, toRemove);
             }
             this._stage.width = newWidth;
             this._stage.height = newHeight;

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -19,9 +19,15 @@ function toPixelSet(target) {
 }
 
 export function getPixelUnion(pixelsList = []) {
+    if (!Array.isArray(pixelsList)) pixelsList = [pixelsList];
     const union = new Set();
     for (const pixels of pixelsList) {
-        for (const p of pixels.keys()) union.add(p);
+        if (!pixels) continue;
+        if (pixels instanceof Map || pixels instanceof Set) {
+            for (const p of pixels.keys()) union.add(p);
+        } else if (pixels instanceof Uint8Array || Array.isArray(pixels)) {
+            for (let i = 0; i < pixels.length; i++) if (pixels[i]) union.add(i);
+        }
     }
     return Array.from(union);
 }


### PR DESCRIPTION
## Summary
- update pixel utility `getPixelUnion` and services to work with Map-based pixel storage
- convert overlay pixels to reactive Sets and adjust preview/viewport logic for Maps
- handle Map cloning in clipboard and layer copying and fix multi-layer tools for Map iteration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c06f67a35c832cba3c86e55d4dc8bb