### PR TITLE
refactor orientation to OT enum

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -246,7 +246,7 @@ function applyToSelection(id, fn, ids = nodeTree.selectedNodeIds) {
 
 function onColorInput(id, event) {
     const colorU32 = hexToRgbaU32(event.target.value);
-    applyToSelection(id, sid => preview.applyNodePreview(sid, { color: colorU32 }), nodeTree.selectedLayerIds);
+    applyToSelection(id, sid => preview.applyProperty(sid, { color: colorU32 }), nodeTree.selectedLayerIds);
 }
 
 function onColorChange() {

--- a/src/components/SettingsPopup.vue
+++ b/src/components/SettingsPopup.vue
@@ -13,6 +13,14 @@
               <option v-for="ori in orientations" :key="ori" :value="ori">{{ ori }}</option>
             </select>
           </label>
+          <div v-if="defaultOrientation === 'checkerboard'" class="flex gap-2">
+            <select v-model="cbOriA" class="flex-1 rounded bg-slate-700 px-2 py-1">
+              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ori }}</option>
+            </select>
+            <select v-model="cbOriB" class="flex-1 rounded bg-slate-700 px-2 py-1">
+              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ori }}</option>
+            </select>
+          </div>
         </div>
         <div v-else-if="currentTab === 'Stage'" class="space-y-2 text-white/70">
           <label class="block">
@@ -31,7 +39,7 @@
 <script setup>
 import { ref, watch } from 'vue';
 import { useService } from '../services';
-import { usePixelStore, PIXEL_DEFAULT_ORIENTATIONS } from '@/stores/pixels';
+import { usePixelStore, PIXEL_DEFAULT_ORIENTATIONS, PIXEL_ORIENTATIONS } from '@/stores/pixels';
 import { CHECKERBOARD_CONFIG } from '@/constants';
 import { checkerboardPatternUrl } from '@/utils/pixels.js';
 
@@ -42,8 +50,13 @@ const tabs = ['Pixels', 'Stage'];
 const currentTab = ref(tabs[0]);
 
 const orientations = PIXEL_DEFAULT_ORIENTATIONS;
+const pixelOrientations = PIXEL_ORIENTATIONS;
 const defaultOrientation = ref(pixelStore.defaultOrientation);
 watch(defaultOrientation, ori => pixelStore.setDefaultOrientation(ori));
+const [initialA, initialB] = pixelStore.checkerboardOrientations;
+const cbOriA = ref(initialA);
+const cbOriB = ref(initialB);
+watch([cbOriA, cbOriB], ([a, b]) => pixelStore.setCheckerboardOrientations(a, b));
 
 const checkerboardRepeat = ref(CHECKERBOARD_CONFIG.REPEAT);
 watch(checkerboardRepeat, repeat => {

--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -1,0 +1,12 @@
+export const OT = Object.freeze({
+  DEFAULT: 255,
+  NONE: 1,
+  HORIZONTAL: 2,
+  DOWNSLOPE: 3,
+  VERTICAL: 4,
+  UPSLOPE: 5,
+});
+
+export const PIXEL_ORIENTATIONS = Object.values(OT).filter(o => o !== OT.DEFAULT);
+export const PIXEL_DEFAULT_ORIENTATIONS = [...PIXEL_ORIENTATIONS, 'checkerboard'];
+export const DEFAULT_CHECKERBOARD_ORIENTATIONS = [OT.HORIZONTAL, OT.VERTICAL];

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -9,6 +9,7 @@ import { useToolbarStore } from '../stores/toolbar';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
 import { getPixelUnion } from '../utils/pixels.js';
+import { OT } from '../stores/pixels';
 
 export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
@@ -48,7 +49,9 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         overlayService.setPixels(overlayId, pixels);
         const id = nodeTree.selectedLayerIds[0];
         if (nodes.locked(id)) { preview.clearPreview(); return; }
-        if (pixels.length) preview.applyPixelPreview(id, { add: pixels });
+        if (pixels.length) {
+            preview.applyPixelAdd(id, pixels, OT.DEFAULT);
+        }
         else preview.clearPreview();
     });
     watch(() => tool.affectedPixels, (pixels) => {
@@ -101,7 +104,7 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         const previewPixels = pixels.filter(pixel => sourcePixels.has(pixel));
         overlayService.setPixels(overlayId, previewPixels);
         if (nodes.locked(id)) { preview.clearPreview(); return; }
-        if (previewPixels.length) preview.applyPixelPreview(id, { remove: previewPixels });
+        if (previewPixels.length) preview.applyPixelRemove(id, previewPixels);
         else preview.clearPreview();
     });
     watch(() => tool.affectedPixels, (pixels) => {
@@ -154,7 +157,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (nodes.locked(sourceId)) { preview.clearPreview(); return; }
         const sourcePixels = new Set(pixelsOf(sourceId));
         const cutPreview = pixels.filter(pixel => sourcePixels.has(pixel));
-        if (cutPreview.length) preview.applyPixelPreview(sourceId, { remove: cutPreview });
+        if (cutPreview.length) preview.applyPixelRemove(sourceId, cutPreview);
         else preview.clearPreview();
     });
     watch(() => tool.affectedPixels, (pixels) => {

--- a/src/services/wandTools.js
+++ b/src/services/wandTools.js
@@ -7,6 +7,7 @@ import { useNodeQueryService } from './nodeQuery';
 import { useStore } from '../stores';
 import { CURSOR_STYLE } from '@/constants';
 import { coordToIndex, indexToCoord, groupConnectedPixels, getPixelUnion } from '../utils/pixels.js';
+import { OT } from '../stores/pixels';
 
 export const usePathToolService = defineStore('pathToolService', () => {
     const tool = useToolSelectionService();
@@ -98,8 +99,8 @@ export const useRelayToolService = defineStore('relayToolService', () => {
                 const dx = bottomAvg[0] - topAvg[0];
                 const dy = bottomAvg[1] - topAvg[1];
                 if (Math.abs(dx) === Math.abs(dy)) continue;
-                orientation = Math.abs(dx) > Math.abs(dy) ? 'horizontal' : 'vertical';
-                if (dist >= 2) orientation = orientation === 'horizontal' ? 'vertical' : 'horizontal';
+                orientation = Math.abs(dx) > Math.abs(dy) ? OT.HORIZONTAL : OT.VERTICAL;
+                if (dist >= 2) orientation = orientation === OT.HORIZONTAL ? OT.VERTICAL : OT.HORIZONTAL;
                 break;
             }
             if (!orientation) continue;

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -6,7 +6,7 @@ import { pixelsToUnionPath } from '../utils/pixels.js';
 export const usePreviewStore = defineStore('preview', {
     state: () => ({
         nodes: {}, // id -> partial node props
-        pixels: {} // id -> delta of pixel changes
+        pixels: {} // id -> { add?, remove?, update? }
     }),
     getters: {
         nodeColor(state) {
@@ -25,12 +25,13 @@ export const usePreviewStore = defineStore('preview', {
                     const base = pixelStore.get(id) || new Map();
                     const set = new Set(base.keys());
                     if (delta.remove) delta.remove.forEach(p => set.delete(p));
-                    if (delta.orientationMap) {
-                        for (const arr of Object.values(delta.orientationMap)) {
-                            arr.forEach(p => set.add(p));
+                    if (delta.update) {
+                        for (const [p, o] of Object.entries(delta.update)) {
+                            const idx = Number(p);
+                            if (o === 0) set.delete(idx); else set.add(idx);
                         }
                     }
-                    if (delta.add) delta.add.forEach(p => set.add(p));
+                    if (delta.add) delta.add.pixels.forEach(p => set.add(p));
                     return pixelsToUnionPath(set);
                 }
                 return pixelStore.pathOf(id);
@@ -38,19 +39,26 @@ export const usePreviewStore = defineStore('preview', {
         }
     },
     actions: {
-        applyNodePreview(id, props = {}) {
+        applyProperty(id, props = {}) {
             if (Object.keys(props).length) this.nodes[id] = { ...props };
             else delete this.nodes[id];
         },
-        applyPixelPreview(id, { add = [], remove = [], orientation, orientationMap } = {}) {
-            const entry = {};
-            if (add.length) {
-                entry.add = [...add];
-                if (orientation != null) entry.orientation = orientation;
-            }
-            if (remove.length) entry.remove = [...remove];
-            if (orientationMap && Object.keys(orientationMap).length) entry.orientationMap = { ...orientationMap };
-            if (Object.keys(entry).length) this.pixels[id] = entry;
+        applyPixelAdd(id, pixels = [], orientation) {
+            const entry = this.pixels[id] || {};
+            entry.add = { pixels: [...pixels], orientation };
+            if (entry.remove || entry.update || entry.add.pixels.length) this.pixels[id] = entry;
+            else delete this.pixels[id];
+        },
+        applyPixelRemove(id, pixels = []) {
+            const entry = this.pixels[id] || {};
+            entry.remove = [...pixels];
+            if (entry.add || entry.update || entry.remove.length) this.pixels[id] = entry;
+            else delete this.pixels[id];
+        },
+        applyPixelUpdate(id, update = {}) {
+            const entry = this.pixels[id] || {};
+            entry.update = { ...update };
+            if (entry.add || entry.remove || Object.keys(entry.update).length) this.pixels[id] = entry;
             else delete this.pixels[id];
         },
         commitPreview() {
@@ -62,12 +70,8 @@ export const usePreviewStore = defineStore('preview', {
             for (const [id, delta] of Object.entries(this.pixels)) {
                 const numId = Number(id);
                 if (delta.remove?.length) pixelStore.remove(numId, delta.remove);
-                if (delta.orientationMap) {
-                    for (const [ori, arr] of Object.entries(delta.orientationMap)) {
-                        pixelStore.add(numId, arr, ori);
-                    }
-                }
-                if (delta.add?.length) pixelStore.add(numId, delta.add, delta.orientation);
+                if (delta.update) pixelStore.update(numId, delta.update);
+                if (delta.add) pixelStore.add(numId, delta.add.pixels, delta.add.orientation);
             }
             this.clearPreview();
         },

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -1,5 +1,6 @@
 import { SVG_NAMESPACE } from '../constants/svg.js';
 import { CHECKERBOARD_CONFIG } from '../constants/stage.js';
+import { OT } from '../constants/orientation.js';
 
 export const MAX_DIMENSION = 128;
 export const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
@@ -79,10 +80,10 @@ export function ensureOrientationPattern(orientation, target = document.body) {
     pattern.setAttribute('width', '1');
     pattern.setAttribute('height', '1');
     pattern.setAttribute('patternUnits', 'userSpaceOnUse');
-    if (orientation === 'vertical' || orientation === 'horizontal' || orientation === 'downSlope' || orientation === 'upSlope') {
+    if (orientation === OT.VERTICAL || orientation === OT.HORIZONTAL || orientation === OT.DOWNSLOPE || orientation === OT.UPSLOPE) {
         const border = document.createElementNS(SVG_NAMESPACE, 'line');
         const line = document.createElementNS(SVG_NAMESPACE, 'line');
-        if (orientation === 'vertical') {
+        if (orientation === OT.VERTICAL) {
             border.setAttribute('x1', '.5');
             border.setAttribute('y1', '0');
             border.setAttribute('x2', '.5');
@@ -92,7 +93,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
             line.setAttribute('x2', '.5');
             line.setAttribute('y2', '1');
         }
-        else if (orientation === 'horizontal') {
+        else if (orientation === OT.HORIZONTAL) {
             border.setAttribute('x1', '0');
             border.setAttribute('y1', '.5');
             border.setAttribute('x2', '1');
@@ -102,7 +103,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
             line.setAttribute('x2', '1');
             line.setAttribute('y2', '.5');
         }
-        else if (orientation === 'downSlope') {
+        else if (orientation === OT.DOWNSLOPE) {
             border.setAttribute('x1', '0');
             border.setAttribute('y1', '0');
             border.setAttribute('x2', '1');
@@ -112,7 +113,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
             line.setAttribute('x2', '1');
             line.setAttribute('y2', '1');
         }
-        else { // upSlope
+        else { // OT.UPSLOPE
             border.setAttribute('x1', '0');
             border.setAttribute('y1', '1');
             border.setAttribute('x2', '1');
@@ -133,7 +134,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
     svg.appendChild(defs);
     target.appendChild(svg);
     return id;
-  }
+}
 
 export function groupConnectedPixels(pixels) {
     const visited = new Set();

--- a/test/pixelHash.test.js
+++ b/test/pixelHash.test.js
@@ -13,7 +13,7 @@ globalThis.localStorage = {
   setItem: () => {},
 };
 
-const { usePixelStore } = await import('../src/stores/pixels.js');
+const { usePixelStore, OT } = await import('../src/stores/pixels.js');
 
 test('swapping layer pixels changes hash', () => {
   setActivePinia(createPinia());
@@ -24,15 +24,15 @@ test('swapping layer pixels changes hash', () => {
   const p2 = coordToIndex(1, 0);
   const p3 = coordToIndex(0, 1);
   const p4 = coordToIndex(1, 1);
-  storeA.add(l1, [p1, p2], 'horizontal');
-  storeA.add(l2, [p3, p4], 'vertical');
+  storeA.add(l1, [p1, p2], OT.HORIZONTAL);
+  storeA.add(l2, [p3, p4], OT.VERTICAL);
   const hashA = storeA._hash.all;
 
   setActivePinia(createPinia());
   const storeB = usePixelStore();
   storeB.addLayer([l1, l2]);
-  storeB.add(l1, [p3, p4], 'horizontal');
-  storeB.add(l2, [p1, p2], 'vertical');
+  storeB.add(l1, [p3, p4], OT.HORIZONTAL);
+  storeB.add(l2, [p1, p2], OT.VERTICAL);
   const hashB = storeB._hash.all;
 
   assert.notStrictEqual(hashA, hashB);
@@ -44,9 +44,48 @@ test('changing pixel orientation updates hash', () => {
   const layer = 1;
   store.addLayer(layer);
   const px = coordToIndex(0, 0);
-  store.add(layer, [px], 'horizontal');
+  store.add(layer, [px], OT.HORIZONTAL);
   const hash1 = store._hash.all;
-  store.add(layer, [px], 'vertical');
+  store.add(layer, [px], OT.VERTICAL);
   const hash2 = store._hash.all;
   assert.notStrictEqual(hash1, hash2);
+});
+
+test('checkerboard uses chosen orientations', () => {
+  setActivePinia(createPinia());
+  const store = usePixelStore();
+  const layer = 1;
+  store.addLayer(layer);
+  store.setDefaultOrientation('checkerboard');
+  store.setCheckerboardOrientations(OT.DOWNSLOPE, OT.UPSLOPE);
+  const px1 = coordToIndex(0, 0);
+  const px2 = coordToIndex(1, 0);
+  store.add(layer, [px1, px2]);
+  assert.strictEqual(store.orientationOf(layer, px1), OT.DOWNSLOPE);
+  assert.strictEqual(store.orientationOf(layer, px2), OT.UPSLOPE);
+});
+
+test('update applies per-pixel orientations and OT.DEFAULT', () => {
+  setActivePinia(createPinia());
+  const store = usePixelStore();
+  const layer = 1;
+  store.addLayer(layer);
+  store.setDefaultOrientation(OT.VERTICAL);
+  const p1 = coordToIndex(0, 0);
+  const p2 = coordToIndex(1, 0);
+  store.update(layer, { [p1]: OT.HORIZONTAL, [p2]: OT.DEFAULT });
+  assert.strictEqual(store.orientationOf(layer, p1), OT.HORIZONTAL);
+  assert.strictEqual(store.orientationOf(layer, p2), OT.VERTICAL);
+});
+
+test('update with 0 removes pixel', () => {
+  setActivePinia(createPinia());
+  const store = usePixelStore();
+  const layer = 1;
+  store.addLayer(layer);
+  const px = coordToIndex(0, 0);
+  store.add(layer, [px], OT.HORIZONTAL);
+  assert.strictEqual(store.orientationOf(layer, px), OT.HORIZONTAL);
+  store.update(layer, { [px]: 0 });
+  assert.strictEqual(store.orientationOf(layer, px), undefined);
 });


### PR DESCRIPTION
## Summary
- use 255 for OT.DEFAULT to reserve 0 for deletions
- allow pixelStore.update to remove pixels when 0 is supplied
- rename preview applyNodePreview to applyProperty and split pixel previews into add/remove/update
- update tools to call the new preview actions and add a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e224d8fc832ca36b83770ad98322