### PR TITLE
Refactor preview store and pixel update workflow

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -245,7 +245,7 @@ function applyToSelection(id, fn, ids = nodeTree.selectedNodeIds) {
 
 function onColorInput(id, event) {
     const colorU32 = hexToRgbaU32(event.target.value);
-    applyToSelection(id, sid => preview.applyProperty(sid, { color: colorU32 }), nodeTree.selectedLayerIds);
+    applyToSelection(id, sid => preview.setProperties(sid, { color: colorU32 }), nodeTree.selectedLayerIds);
 }
 
 function onColorChange() {

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -254,7 +254,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                 }
             }
             orientationPreviews[target][next].add(pixel);
-            preview.clearPixel(target);
+            preview.clear();
             preview.updatePixels(target, toUpdateMap(orientationPreviews[target]));
         }
         rebuild();

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -207,7 +207,6 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     watch(() => tool.current === 'orientation', (isOrientation) => {
         if (!isOrientation) {
             overlays.forEach(id => overlayService.clear(id));
-            preview.clear();
             orientationPreviews = {};
             return;
         }
@@ -261,8 +260,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'orientation') return;
-        if (pixels.length) preview.commitPreview();
-        else preview.clear();
+        preview.commitPreview();
         orientationPreviews = {};
         rebuild();
     });
@@ -282,7 +280,6 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     watch(() => tool.current === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) {
             overlayService.clear(overlayId);
-            preview.clear();
             return;
         }
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
@@ -330,14 +327,11 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             for (const pixel of erasablePixels) {
                 if (targetPixels.has(pixel)) pixelsToRemove.push(pixel);
             }
-            if (pixelsToRemove.length) {
-                preview.removePixels(id, pixelsToRemove);
-            }
+            preview.removePixels(id, pixelsToRemove);
         }
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'globalErase') return;
-        if (!pixels.length) { preview.clear(); return; }
         preview.commitPreview();
     });
     return { usable };

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -145,7 +145,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         return res;
     }
     function orientationOfWithPreview(id, pixel) {
-        const previewMap = preview.pixels[id]?.update;
+        const previewMap = preview.pixels[id];
         if (previewMap && previewMap[pixel] != null) return previewMap[pixel];
         return pixelStore.orientationOf(id, pixel);
     }
@@ -168,7 +168,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                     const id = nodeTree.layerOrder[i];
                     if (!nodes.visibility(id)) continue;
                     let pixels = orientationPixels(id, orientation);
-                    const delta = preview.pixels[id]?.update;
+                    const delta = preview.pixels[id];
                     if (delta) {
                         const set = new Set(pixels);
                         for (const [pStr, o] of Object.entries(delta)) {
@@ -189,7 +189,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
             else {
                 for (const id of layerIds) {
                     let pixels = orientationPixels(id, orientation);
-                    const delta = preview.pixels[id]?.update;
+                    const delta = preview.pixels[id];
                     if (delta) {
                         const set = new Set(pixels);
                         for (const [pStr, o] of Object.entries(delta)) {
@@ -207,7 +207,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     watch(() => tool.current === 'orientation', (isOrientation) => {
         if (!isOrientation) {
             overlays.forEach(id => overlayService.clear(id));
-            preview.clearPreview();
+            preview.clear();
             orientationPreviews = {};
             return;
         }
@@ -254,14 +254,15 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                 }
             }
             orientationPreviews[target][next].add(pixel);
-            preview.applyPixelUpdate(target, toUpdateMap(orientationPreviews[target]));
+            preview.clearPixel(target);
+            preview.updatePixels(target, toUpdateMap(orientationPreviews[target]));
         }
         rebuild();
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'orientation') return;
         if (pixels.length) preview.commitPreview();
-        else preview.clearPreview();
+        else preview.clear();
         orientationPreviews = {};
         rebuild();
     });
@@ -281,7 +282,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     watch(() => tool.current === 'globalErase', (isGlobalErase) => {
         if (!isGlobalErase) {
             overlayService.clear(overlayId);
-            preview.clearPreview();
+            preview.clear();
             return;
         }
         tool.setCursor({ stroke: CURSOR_STYLE.GLOBAL_ERASE_STROKE, rect: CURSOR_STYLE.GLOBAL_ERASE_RECT });
@@ -319,7 +320,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
             }
         }
         overlayService.setPixels(overlayId, erasablePixels);
-        preview.clearPreview();
+        preview.clear();
         if (!erasablePixels.length) return;
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
             .filter(id => !nodes.locked(id));
@@ -330,13 +331,13 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
                 if (targetPixels.has(pixel)) pixelsToRemove.push(pixel);
             }
             if (pixelsToRemove.length) {
-                preview.applyPixelRemove(id, pixelsToRemove);
+                preview.removePixels(id, pixelsToRemove);
             }
         }
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'globalErase') return;
-        if (!pixels.length) { preview.clearPreview(); return; }
+        if (!pixels.length) { preview.clear(); return; }
         preview.commitPreview();
     });
     return { usable };

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -24,7 +24,6 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     watch(() => tool.current === 'draw', (isDraw) => {
         if (!isDraw) {
             overlayService.clear(overlayId);
-            preview.clear();
             return;
         }
         tool.setCursor({ stroke: CURSOR_STYLE.DRAW_STROKE, rect: CURSOR_STYLE.DRAW_RECT });
@@ -48,19 +47,15 @@ export const useDrawToolService = defineStore('drawToolService', () => {
         if (tool.current !== 'draw') return;
         overlayService.setPixels(overlayId, pixels);
         const id = nodeTree.selectedLayerIds[0];
-        if (nodes.locked(id)) { preview.clear(); return; }
-        if (pixels.length) {
-            preview.clearPixel(id);
-            preview.addPixels(id, pixels, OT.DEFAULT);
-        }
-        else preview.clear();
+        if (nodes.locked(id)) return;
+        preview.clear();
+        preview.addPixels(id, pixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'draw') return;
         const id = nodeTree.selectedLayerIds[0];
-        if (nodes.locked(id)) { preview.clear(); return; }
-        if (pixels.length) preview.commitPreview();
-        else preview.clear();
+        if (nodes.locked(id)) return;
+        preview.commitPreview();
     });
     return { usable };
 });
@@ -78,7 +73,6 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     watch(() => tool.current === 'erase', (isErase) => {
         if (!isErase) {
             overlayService.clear(overlayId);
-            preview.clear();
             return;
         }
         tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
@@ -104,18 +98,15 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         const sourcePixels = new Set(pixelsOf(id));
         const previewPixels = pixels.filter(pixel => sourcePixels.has(pixel));
         overlayService.setPixels(overlayId, previewPixels);
-        if (nodes.locked(id)) { preview.clear(); return; }
-        if (previewPixels.length) {
-            preview.clearPixel(id);
-            preview.removePixels(id, previewPixels);
-        } else preview.clear();
+        if (nodes.locked(id)) return;
+        preview.clear();
+        preview.removePixels(id, previewPixels);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'erase') return;
         const id = nodeTree.selectedLayerIds[0];
-        if (nodes.locked(id)) { preview.clear(); return; }
-        if (pixels.length) preview.commitPreview();
-        else preview.clear();
+        if (nodes.locked(id)) return;
+        preview.commitPreview();
     });
     return { usable };
 });
@@ -133,7 +124,6 @@ export const useCutToolService = defineStore('cutToolService', () => {
     watch(() => tool.current === 'cut', (isCut) => {
         if (!isCut) {
             overlayService.clear(overlayId);
-            preview.clear();
             return;
         }
         tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
@@ -157,18 +147,16 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.current !== 'cut') return;
         overlayService.setPixels(overlayId, pixels);
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.locked(sourceId)) { preview.clear(); return; }
+        if (nodes.locked(sourceId)) return;
         const sourcePixels = new Set(pixelsOf(sourceId));
         const cutPreview = pixels.filter(pixel => sourcePixels.has(pixel));
-        if (cutPreview.length) {
-            preview.clearPixel(sourceId);
-            preview.removePixels(sourceId, cutPreview);
-        } else preview.clear();
+        preview.clearPixel(sourceId);
+        preview.removePixels(sourceId, cutPreview);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'cut') return;
         const sourceId = nodeTree.selectedLayerIds[0];
-        if (nodes.locked(sourceId)) { preview.clear(); return; }
+        if (nodes.locked(sourceId)) return;
         const sourcePixels = new Set(pixelsOf(sourceId));
         const cutPixels = pixels.filter(pixel => sourcePixels.has(pixel));
         if (!cutPixels.length || cutPixels.length === sourcePixels.size) { preview.clear(); return; }

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -5,17 +5,17 @@ import { pixelsToUnionPath } from '../utils/pixels.js';
 
 export const usePreviewStore = defineStore('preview', {
     state: () => ({
-        nodes: {}, // id -> partial node props
-        pixels: {} // id -> { add?, remove?, update? }
+        properties: {}, // id -> partial node props
+        pixels: {} // id -> { pixel: orientation }
     }),
     getters: {
         nodeColor(state) {
             const nodes = useNodeStore();
-            return (id) => state.nodes[id]?.color ?? nodes.color(id);
+            return (id) => state.properties[id]?.color ?? nodes.color(id);
         },
         nodeVisibility(state) {
             const nodes = useNodeStore();
-            return (id) => state.nodes[id]?.visibility ?? nodes.visibility(id);
+            return (id) => state.properties[id]?.visibility ?? nodes.visibility(id);
         },
         pathOf(state) {
             const pixelStore = usePixelStore();
@@ -24,13 +24,9 @@ export const usePreviewStore = defineStore('preview', {
                 if (delta) {
                     const base = pixelStore.get(id) || new Map();
                     const set = new Set(base.keys());
-                    if (delta.add) delta.add.pixels.forEach(p => set.add(p));
-                    if (delta.remove) delta.remove.forEach(p => set.delete(p));
-                    if (delta.update) {
-                        for (const [p, o] of Object.entries(delta.update)) {
-                            const idx = Number(p);
-                            if (o) set.add(idx); else set.delete(idx);
-                        }
+                    for (const [p, o] of Object.entries(delta)) {
+                        const idx = Number(p);
+                        if (o) set.add(idx); else set.delete(idx);
                     }
                     return pixelsToUnionPath(set);
                 }
@@ -39,45 +35,82 @@ export const usePreviewStore = defineStore('preview', {
         }
     },
     actions: {
-        applyProperty(id, props = {}) {
-            if (Object.keys(props).length) this.nodes[id] = { ...props };
-            else delete this.nodes[id];
+        setProperties(id, props = {}) {
+            const prev = this.properties[id] || {};
+            const merged = { ...prev, ...props };
+            if (Object.keys(merged).length) this.properties[id] = merged;
+            else delete this.properties[id];
         },
-        applyPixelAdd(id, pixels = [], orientation) {
+        addPixels(id, pixels = [], orientation) {
+            if (!pixels.length) return;
             const entry = this.pixels[id] || {};
-            entry.add = { pixels: [...pixels], orientation };
-            if (entry.remove || entry.update || entry.add.pixels.length) this.pixels[id] = entry;
+            for (const p of pixels) entry[p] = orientation;
+            if (Object.keys(entry).length) this.pixels[id] = entry;
             else delete this.pixels[id];
         },
-        applyPixelRemove(id, pixels = []) {
+        removePixels(id, pixels = []) {
+            if (!pixels.length) return;
             const entry = this.pixels[id] || {};
-            entry.remove = [...pixels];
-            if (entry.add || entry.update || entry.remove.length) this.pixels[id] = entry;
+            for (const p of pixels) entry[p] = 0;
+            if (Object.keys(entry).length) this.pixels[id] = entry;
             else delete this.pixels[id];
         },
-        applyPixelUpdate(id, update = {}) {
+        updatePixels(id, update = {}) {
             const entry = this.pixels[id] || {};
-            entry.update = { ...update };
-            if (entry.add || entry.remove || Object.keys(entry.update).length) this.pixels[id] = entry;
+            Object.assign(entry, update);
+            if (Object.keys(entry).length) this.pixels[id] = entry;
             else delete this.pixels[id];
         },
         commitPreview() {
             const nodeStore = useNodeStore();
-            for (const [id, props] of Object.entries(this.nodes)) {
+            for (const [id, props] of Object.entries(this.properties)) {
                 nodeStore.update(Number(id), props);
             }
             const pixelStore = usePixelStore();
             for (const [id, delta] of Object.entries(this.pixels)) {
                 const numId = Number(id);
-                if (delta.add) pixelStore.add(numId, delta.add.pixels, delta.add.orientation);
-                if (delta.remove) pixelStore.remove(numId, delta.remove);
-                if (delta.update) pixelStore.update(numId, delta.update);
+                pixelStore.update(numId, delta);
             }
-            this.clearPreview();
+            this.clear();
         },
-        clearPreview() {
-            this.nodes = {};
-            this.pixels = {};
+        clear(id) {
+            if (id == null) {
+                this.properties = {};
+                this.pixels = {};
+            } else {
+                delete this.properties[id];
+                delete this.pixels[id];
+            }
+        },
+        clearProperty(id, property) {
+            if (id == null) {
+                this.properties = {};
+                return;
+            }
+            if (!property) {
+                delete this.properties[id];
+                return;
+            }
+            const entry = this.properties[id];
+            if (entry) {
+                delete entry[property];
+                if (!Object.keys(entry).length) delete this.properties[id];
+            }
+        },
+        clearPixel(id, pixel) {
+            if (id == null) {
+                this.pixels = {};
+                return;
+            }
+            if (pixel == null) {
+                delete this.pixels[id];
+                return;
+            }
+            const entry = this.pixels[id];
+            if (entry) {
+                delete entry[pixel];
+                if (!Object.keys(entry).length) delete this.pixels[id];
+            }
         }
     }
 });

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { useNodeStore } from './nodes';
-import { usePixelStore } from './pixels';
+import { usePixelStore, OT } from './pixels';
 import { pixelsToUnionPath } from '../utils/pixels.js';
 
 export const usePreviewStore = defineStore('preview', {
@@ -41,25 +41,23 @@ export const usePreviewStore = defineStore('preview', {
             if (Object.keys(merged).length) this.properties[id] = merged;
             else delete this.properties[id];
         },
-        addPixels(id, pixels = [], orientation) {
+        addPixels(id, pixels = [], orientation = OT.DEFAULT) {
             if (!pixels.length) return;
             const entry = this.pixels[id] || {};
             for (const p of pixels) entry[p] = orientation;
-            if (Object.keys(entry).length) this.pixels[id] = entry;
-            else delete this.pixels[id];
+            this.pixels[id] = entry;
         },
         removePixels(id, pixels = []) {
             if (!pixels.length) return;
             const entry = this.pixels[id] || {};
             for (const p of pixels) entry[p] = 0;
-            if (Object.keys(entry).length) this.pixels[id] = entry;
-            else delete this.pixels[id];
+            this.pixels[id] = entry;
         },
         updatePixels(id, update = {}) {
+            if (!Object.keys(update).length) return;
             const entry = this.pixels[id] || {};
             Object.assign(entry, update);
-            if (Object.keys(entry).length) this.pixels[id] = entry;
-            else delete this.pixels[id];
+            this.pixels[id] = entry;
         },
         commitPreview() {
             const nodeStore = useNodeStore();
@@ -74,7 +72,7 @@ export const usePreviewStore = defineStore('preview', {
             this.clear();
         },
         clear(id) {
-            if (id == null) {
+            if (!id) {
                 this.properties = {};
                 this.pixels = {};
             } else {
@@ -83,7 +81,7 @@ export const usePreviewStore = defineStore('preview', {
             }
         },
         clearProperty(id, property) {
-            if (id == null) {
+            if (!id) {
                 this.properties = {};
                 return;
             }
@@ -98,11 +96,11 @@ export const usePreviewStore = defineStore('preview', {
             }
         },
         clearPixel(id, pixel) {
-            if (id == null) {
+            if (!id) {
                 this.pixels = {};
                 return;
             }
-            if (pixel == null) {
+            if (!pixel) {
                 delete this.pixels[id];
                 return;
             }


### PR DESCRIPTION
## Summary
- unify preview pixel state into a single orientation map and rename preview actions
- add fine-grained clear, clearProperty, and clearPixel helpers
- update tool services and layer panel to use new preview API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f81dbc4c832c8ab0e0d986495cfb