### PR TITLE
Refactor tools to use pixel maps

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -16,8 +16,10 @@ function dirPriority(dx, dy) {
 
 // Build adjacency info for pixels with 8-way connectivity
 // Returns adjacency list `neighbors` only
-function buildGraphFromPixels(pixels) {
-  const indexMap = new Map(pixels.map((p, i) => [p, i]));
+function buildGraphFromPixels(pixelMap) {
+  const pixels = Array.from(pixelMap.keys());
+  const indexMap = new Map();
+  for (let i = 0; i < pixels.length; i++) indexMap.set(pixels[i], i);
   const neighbors = [];
 
   for (let i = 0; i < pixels.length; i++) {
@@ -418,9 +420,9 @@ async function solve(neighbors, opts = {}) {
   return await solver.run();
 }
 
-async function solveFromPixels(pixels, opts = {}) {
-  const nodes = Array.from(new Set(pixels));
-  const neighbors = buildGraphFromPixels(nodes);
+async function solveFromPixels(pixelMap, opts = {}) {
+  const nodes = Array.from(pixelMap.keys());
+  const neighbors = buildGraphFromPixels(pixelMap);
   const anchors = (opts.anchors || []).map((anchor) => {
     const idx = nodes.indexOf(anchor);
     if (idx === -1) throw new Error('Anchor pixel missing');
@@ -431,16 +433,16 @@ async function solveFromPixels(pixels, opts = {}) {
 }
 
 class HamiltonianService {
-  async traverseWithStart(pixels, start) {
-    return await solveFromPixels(pixels, { anchors: [start] });
+  async traverseWithStart(pixelMap, start) {
+    return await solveFromPixels(pixelMap, { anchors: [start] });
   }
 
-  async traverseWithStartEnd(pixels, start, end) {
-    return await solveFromPixels(pixels, { anchors: [start, end] });
+  async traverseWithStartEnd(pixelMap, start, end) {
+    return await solveFromPixels(pixelMap, { anchors: [start, end] });
   }
 
-  async traverseFree(pixels) {
-    return await solveFromPixels(pixels);
+  async traverseFree(pixelMap) {
+    return await solveFromPixels(pixelMap);
   }
 }
 

--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -1,47 +1,23 @@
 const MAX_DIMENSION = 128;
 const TIME_LIMIT = 5000;
 
-// Return a orientation priority for a given offset.
-function dirPriority(dx, dy) {
-  if (dx === 0 && dy === -1) return 0; // up
-  if (dx === 1 && dy === 0) return 1; // right
-  if (dx === 0 && dy === 1) return 2; // down
-  if (dx === -1 && dy === 0) return 3; // left
-  if (dx === -1 && dy === -1) return 4; // left-up
-  if (dx === -1 && dy === 1) return 5; // left-down
-  if (dx === 1 && dy === 1) return 6; // right-down
-  if (dx === 1 && dy === -1) return 7; // right-up
-  return 8;
-}
+const DIRECTION_PRIORITY = [[0, -1], [1, 0], [0, 1], [-1, 0], [-1, -1], [-1, 1], [1, 1], [1, -1]]
 
-// Build adjacency info for pixels with 8-way connectivity
-// Returns adjacency list `neighbors` only
-function buildGraphFromPixels(pixelMap) {
-  const pixels = Array.from(pixelMap.keys());
-  const indexMap = new Map();
-  for (let i = 0; i < pixels.length; i++) indexMap.set(pixels[i], i);
+function buildGraphFromPixels(pixels) {
+  const nodes = Array.from(pixels.keys());
   const neighbors = [];
-
-  for (let i = 0; i < pixels.length; i++) {
-    const p = pixels[i];
+  for (const p of nodes) {
     const x = p % MAX_DIMENSION;
     const y = Math.floor(p / MAX_DIMENSION);
     const nbs = [];
-    for (let dx = -1; dx <= 1; dx++) {
-      for (let dy = -1; dy <= 1; dy++) {
-        if (dx === 0 && dy === 0) continue;
-        const nPixel = x + dx + MAX_DIMENSION * (y + dy);
-        const idx = indexMap.get(nPixel);
-        if (idx !== undefined) {
-          nbs.push({ idx, order: dirPriority(dx, dy) });
-        }
-      }
+    for (const [dx, dy] in DIRECTION_PRIORITY) {
+      const neighbor = x + dx + MAX_DIMENSION * (y + dy);
+      const idx = nodes.indexOf(neighbor)
+      if (idx !== -1) nbs.push(idx);
     }
-    nbs.sort((a, b) => a.order - b.order);
-    neighbors.push(nbs.map((n) => n.idx));
+    neighbors.push(nbs);
   }
-
-  return neighbors;
+  return { nodes, neighbors };
 }
 
 // Check if removing specific edges disconnects the graph
@@ -420,9 +396,8 @@ async function solve(neighbors, opts = {}) {
   return await solver.run();
 }
 
-async function solveFromPixels(pixelMap, opts = {}) {
-  const nodes = Array.from(pixelMap.keys());
-  const neighbors = buildGraphFromPixels(pixelMap);
+async function solveFromPixels(pixels, opts = {}) {
+  const { nodes, neighbors } = buildGraphFromPixels(pixels);
   const anchors = (opts.anchors || []).map((anchor) => {
     const idx = nodes.indexOf(anchor);
     if (idx === -1) throw new Error('Anchor pixel missing');
@@ -433,16 +408,16 @@ async function solveFromPixels(pixelMap, opts = {}) {
 }
 
 class HamiltonianService {
-  async traverseWithStart(pixelMap, start) {
-    return await solveFromPixels(pixelMap, { anchors: [start] });
+  async traverseWithStart(pixels, start) {
+    return await solveFromPixels(pixels, { anchors: [start] });
   }
 
-  async traverseWithStartEnd(pixelMap, start, end) {
-    return await solveFromPixels(pixelMap, { anchors: [start, end] });
+  async traverseWithStartEnd(pixels, start, end) {
+    return await solveFromPixels(pixels, { anchors: [start, end] });
   }
 
-  async traverseFree(pixelMap) {
-    return await solveFromPixels(pixelMap);
+  async traverseFree(pixels) {
+    return await solveFromPixels(pixels);
   }
 }
 

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 import { useLayerQueryService } from './layerQuery';
 import { averageColorU32 } from '../utils';
-import { groupConnectedPixels } from '../utils/pixels.js';
+import { groupConnectedPixels, getPixelUnion } from '../utils/pixels.js';
 
 export const useLayerToolService = defineStore('layerToolService', () => {
     const { nodeTree, nodes, pixels } = useStore();
@@ -11,19 +11,12 @@ export const useLayerToolService = defineStore('layerToolService', () => {
     function mergeSelected() {
         if (nodeTree.selectedLayerCount < 2 && nodeTree.selectedGroupCount === 0) return;
 
-        const maps = pixels.get(nodeTree.selectedLayerIds);
-        const unionSet = new Set();
-        for (const map of maps) {
-            if (map instanceof Map) {
-                for (const i of map.keys()) unionSet.add(i);
-            }
-        }
-        const pixelUnion = Array.from(unionSet);
+        const pixelUnion = getPixelUnion(pixels.get(nodeTree.selectedLayerIds) || []);
         const colors = [];
         if (pixelUnion.length) {
             for (const pixel of pixelUnion) {
                 const id = layerQuery.topVisibleAt(pixel, nodeTree.selectedLayerIds);
-                colors.push(id ? nodes.color(id) : 0);
+                if (id) colors.push(nodes.color(id));
             }
         } else {
             for (const id of nodeTree.selectedLayerIds) {

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useStore } from '../stores';
 import { useLayerQueryService } from './layerQuery';
 import { averageColorU32 } from '../utils';
-import { groupConnectedPixels, getPixelUnion } from '../utils/pixels.js';
+import { groupConnectedPixels } from '../utils/pixels.js';
 
 export const useLayerToolService = defineStore('layerToolService', () => {
     const { nodeTree, nodes, pixels } = useStore();
@@ -11,7 +11,14 @@ export const useLayerToolService = defineStore('layerToolService', () => {
     function mergeSelected() {
         if (nodeTree.selectedLayerCount < 2 && nodeTree.selectedGroupCount === 0) return;
 
-        const pixelUnion = getPixelUnion(pixels.get(nodeTree.selectedLayerIds));
+        const maps = pixels.get(nodeTree.selectedLayerIds);
+        const unionSet = new Set();
+        for (const map of maps) {
+            if (map instanceof Map) {
+                for (const i of map.keys()) unionSet.add(i);
+            }
+        }
+        const pixelUnion = Array.from(unionSet);
         const colors = [];
         if (pixelUnion.length) {
             for (const pixel of pixelUnion) {

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -293,7 +293,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         if (pixel){
             const lockedIds = nodeTree.layerOrder.filter(id => nodes.locked(id));
             for (const id of lockedIds) {
-                const lockedPixels = new Set(pixelStore.get(id).keys());
+                const lockedPixels = pixelStore.get(id);
                 if (lockedPixels.has(pixel)) {
                     tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                     return;
@@ -319,15 +319,10 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         overlayService.setPixels(overlayId, erasablePixels);
         preview.clear();
         if (!erasablePixels.length) return;
-        const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
-            .filter(id => !nodes.locked(id));
-        for (const id of targetIds) {
-            const targetPixels = pixelStore.get(id);
-            const pixelsToRemove = [];
-            for (const pixel of erasablePixels) {
-                if (targetPixels.has(pixel)) pixelsToRemove.push(pixel);
-            }
-            preview.removePixels(id, pixelsToRemove);
+        const targetLayers = nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder
+        for (const layer of targetLayers) {
+            if (nodes.locked(id)) return;
+            preview.removePixels(layer, erasablePixels);
         }
     });
     watch(() => tool.affectedPixels, (pixels) => {

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -7,7 +7,7 @@ import { useLayerQueryService } from './layerQuery';
 import { useStore } from '../stores';
 import { useToolbarStore } from '../stores/toolbar';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
-import { indexToCoord, ensureOrientationPattern, getPixelUnion } from '../utils/pixels.js';
+import { indexToCoord, ensureOrientationPattern } from '../utils/pixels.js';
 import { PIXEL_ORIENTATIONS, OT } from '../stores/pixels';
 import stageIcons from '../image/stage_toolbar';
 
@@ -293,7 +293,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         if (pixel){
             const lockedIds = nodeTree.layerOrder.filter(id => nodes.locked(id));
             for (const id of lockedIds) {
-                const lockedPixels = new Set(getPixelUnion(pixelStore.get(id)));
+                const lockedPixels = new Set(pixelStore.get(id).keys());
                 if (lockedPixels.has(pixel)) {
                     tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                     return;
@@ -322,7 +322,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
         const targetIds = (nodeTree.layerSelectionExists ? nodeTree.selectedLayerIds : nodeTree.layerOrder)
             .filter(id => !nodes.locked(id));
         for (const id of targetIds) {
-            const targetPixels = new Set(getPixelUnion(pixelStore.get(id)));
+            const targetPixels = pixelStore.get(id);
             const pixelsToRemove = [];
             for (const pixel of erasablePixels) {
                 if (targetPixels.has(pixel)) pixelsToRemove.push(pixel);

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -82,8 +82,8 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         if (tool.current !== 'erase') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) {
-            const sourceMap = pixelStore.get(sourceId);
-            if (pixel != null && sourceMap.has(pixel))
+            const sourcePx = pixelStore.get(sourceId);
+            if (pixel != null && sourcePx.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
                 tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
@@ -91,9 +91,9 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     });
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.current !== 'erase') return;
-        const id = nodeTree.selectedLayerIds[0];
-        const sourceMap = pixelStore.get(id);
-        const previewPixels = pixels.filter(pixel => sourceMap.has(pixel));
+        const sourceId = nodeTree.selectedLayerIds[0];
+        const sourcePx = pixelStore.get(sourceId);
+        const previewPixels = pixels.filter(pixel => sourcePx.has(pixel));
         overlayService.setPixels(overlayId, previewPixels);
         if (nodes.locked(id)) return;
         preview.clear();
@@ -133,8 +133,8 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.current !== 'cut') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) {
-            const sourceMap = pixelStore.get(sourceId);
-            if (pixel != null && sourceMap.has(pixel))
+            const sourcePx = pixelStore.get(sourceId);
+            if (pixel != null && sourcePx.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
                 tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
@@ -150,9 +150,9 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.current !== 'cut') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) return;
-        const sourceMap = pixelStore.get(sourceId);
-        const cutPixels = pixels.filter(pixel => sourceMap.has(pixel));
-        if (!cutPixels.length || cutPixels.length === sourceMap.size) return;
+        const sourcePx = pixelStore.get(sourceId);
+        const cutPixels = pixels.filter(pixel => sourcePx.has(pixel));
+        if (!cutPixels.length || cutPixels.length === sourcePx.size) return;
         pixelStore.remove(sourceId, cutPixels);
         const id = nodes.addLayer({
             name: `Cut of ${nodes.name(sourceId)}`,

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -8,8 +8,7 @@ import { useStore } from '../stores';
 import { useToolbarStore } from '../stores/toolbar';
 import { OVERLAY_STYLES, CURSOR_STYLE } from '@/constants';
 import stageIcons from '../image/stage_toolbar';
-import { getPixelUnion } from '../utils/pixels.js';
-import { OT } from '../stores/pixels';
+// Tools now access pixelStore maps directly instead of using getPixelUnion
 
 export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
@@ -17,7 +16,6 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
     const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
-    const pixelsOf = (id) => getPixelUnion(pixelStore.get(id));
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'draw', name: 'Draw', icon: stageIcons.draw, usable });
@@ -66,7 +64,6 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
-    const pixelsOf = (id) => getPixelUnion(pixelStore.get(id));
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'erase', name: 'Erase', icon: stageIcons.erase, usable });
@@ -85,8 +82,8 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
         if (tool.current !== 'erase') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) {
-            const sourcePixels = new Set(pixelsOf(sourceId));
-            if (pixel != null && sourcePixels.has(pixel))
+            const sourceMap = pixelStore.get(sourceId);
+            if (pixel != null && sourceMap.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
                 tool.setCursor({ stroke: CURSOR_STYLE.ERASE_STROKE, rect: CURSOR_STYLE.ERASE_RECT });
@@ -95,8 +92,8 @@ export const useEraseToolService = defineStore('eraseToolService', () => {
     watch(() => tool.previewPixels, (pixels) => {
         if (tool.current !== 'erase') return;
         const id = nodeTree.selectedLayerIds[0];
-        const sourcePixels = new Set(pixelsOf(id));
-        const previewPixels = pixels.filter(pixel => sourcePixels.has(pixel));
+        const sourceMap = pixelStore.get(id);
+        const previewPixels = pixels.filter(pixel => sourceMap.has(pixel));
         overlayService.setPixels(overlayId, previewPixels);
         if (nodes.locked(id)) return;
         preview.clear();
@@ -117,7 +114,7 @@ export const useCutToolService = defineStore('cutToolService', () => {
     const overlayId = overlayService.createOverlay();
     overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
     const layerPanel = useLayerPanelService();
-    const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'cut', name: 'Cut', icon: stageIcons.cut, usable });
@@ -136,8 +133,8 @@ export const useCutToolService = defineStore('cutToolService', () => {
         if (tool.current !== 'cut') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) {
-            const sourcePixels = new Set(pixelsOf(sourceId));
-            if (pixel != null && sourcePixels.has(pixel))
+            const sourceMap = pixelStore.get(sourceId);
+            if (pixel != null && sourceMap.has(pixel))
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
             else
                 tool.setCursor({ stroke: CURSOR_STYLE.CUT_STROKE, rect: CURSOR_STYLE.CUT_RECT });
@@ -148,19 +145,15 @@ export const useCutToolService = defineStore('cutToolService', () => {
         overlayService.setPixels(overlayId, pixels);
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) return;
-        const sourcePixels = new Set(pixelsOf(sourceId));
-        const cutPreview = pixels.filter(pixel => sourcePixels.has(pixel));
-        preview.clearPixel(sourceId);
-        preview.removePixels(sourceId, cutPreview);
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'cut') return;
         const sourceId = nodeTree.selectedLayerIds[0];
         if (nodes.locked(sourceId)) return;
-        const sourcePixels = new Set(pixelsOf(sourceId));
-        const cutPixels = pixels.filter(pixel => sourcePixels.has(pixel));
-        if (!cutPixels.length || cutPixels.length === sourcePixels.size) { preview.clear(); return; }
-        preview.commitPreview();
+        const sourceMap = pixelStore.get(sourceId);
+        const cutPixels = pixels.filter(pixel => sourceMap.has(pixel));
+        if (!cutPixels.length || cutPixels.length === sourceMap.size) return;
+        pixelStore.remove(sourceId, cutPixels);
         const id = nodes.addLayer({
             name: `Cut of ${nodes.name(sourceId)}`,
             color: nodes.color(sourceId),
@@ -170,7 +163,6 @@ export const useCutToolService = defineStore('cutToolService', () => {
         pixelStore.addLayer(id);
         pixelStore.add(id, cutPixels);
         nodeTree.insert([id], sourceId, false);
-
         nodeTree.replaceSelection([sourceId]);
         layerPanel.setScrollRule({ type: 'follow', target: sourceId });
     });

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -10,16 +10,17 @@ const MAX_DIMENSION = 128;
 const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 
 test('buildGraphFromPixels orders neighbors around a center pixel', () => {
-  const grid = [];
+  const grid = new Map();
   for (let y = 0; y < 3; y++) {
     for (let x = 0; x < 3; x++) {
-      grid.push(coordToIndex(x, y));
+      grid.set(coordToIndex(x, y), 1);
     }
   }
   const neighbors = buildGraphFromPixels(grid);
+  const keys = Array.from(grid.keys());
   const center = coordToIndex(1, 1);
-  const centerIdx = grid.indexOf(center);
-  const neighborPixels = neighbors[centerIdx].map((i) => grid[i]);
+  const centerIdx = keys.indexOf(center);
+  const neighborPixels = neighbors[centerIdx].map((i) => keys[i]);
   const expected = [
     coordToIndex(1, 0), // up
     coordToIndex(2, 1), // right
@@ -37,7 +38,8 @@ test('partitionAtEdgeCut detects a bridge in a line of three pixels', () => {
   const p0 = coordToIndex(0, 0);
   const p1 = coordToIndex(1, 0);
   const p2 = coordToIndex(2, 0);
-  const neighbors = buildGraphFromPixels([p0, p1, p2]);
+  const map = new Map([[p0, 1], [p1, 1], [p2, 1]]);
+  const neighbors = buildGraphFromPixels(map);
   const res = partitionAtEdgeCut(neighbors);
   assert(res);
   assert.strictEqual(res.edges.length, 1);
@@ -49,11 +51,11 @@ test('solveFromPixels respects start and end anchors', async () => {
   const p1 = coordToIndex(1, 0);
   const p2 = coordToIndex(2, 0);
   const p3 = coordToIndex(3, 0);
-  const pixels = [p0, p1, p2, p3];
-  const paths = await solveFromPixels(pixels, { anchors: [p0, p3] });
+  const map = new Map([[p0, 1], [p1, 1], [p2, 1], [p3, 1]]);
+  const paths = await solveFromPixels(map, { anchors: [p0, p3] });
   assert.strictEqual(paths.length, 1);
   const path = paths[0];
-  assert.strictEqual(path.length, pixels.length);
+  assert.strictEqual(path.length, map.size);
   assert(path.includes(p0) && path.includes(p3));
   assert(
     (path[0] === p0 && path.at(-1) === p3) ||
@@ -64,7 +66,8 @@ test('solveFromPixels respects start and end anchors', async () => {
 test('solveFromPixels returns separate paths for disconnected pixels', async () => {
   const a = coordToIndex(0, 0);
   const b = coordToIndex(5, 0);
-  const paths = await solveFromPixels([a, b]);
+  const map = new Map([[a, 1], [b, 1]]);
+  const paths = await solveFromPixels(map);
   assert.strictEqual(paths.length, 2);
   assert(paths.some((p) => p.length === 1 && p[0] === a));
   assert(paths.some((p) => p.length === 1 && p[0] === b));
@@ -72,15 +75,16 @@ test('solveFromPixels returns separate paths for disconnected pixels', async () 
 
 test('HamiltonianService.traverseFree covers all pixels in a 2x2 square', async () => {
   const service = useHamiltonianService();
-  const pixels = [
+  const coords = [
     coordToIndex(0, 0),
     coordToIndex(1, 0),
     coordToIndex(0, 1),
     coordToIndex(1, 1),
   ];
-  const paths = await service.traverseFree(pixels);
+  const map = new Map(coords.map((p) => [p, 1]));
+  const paths = await service.traverseFree(map);
   assert.strictEqual(paths.length, 1);
   const covered = new Set(paths.flat());
-  assert.strictEqual(covered.size, pixels.length);
+  assert.strictEqual(covered.size, coords.length);
 });
 


### PR DESCRIPTION
## Summary
- Use pixelStore maps directly in tool services instead of pixelsOf/getPixelUnion helpers
- Remove preview store usage from cut tool and operate directly on pixel data
- Simplify map handling across wand and global erase tools
- Update Hamiltonian service and helpers to accept pixel maps directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1001bbcdc832cb99eba65e710f328