### PR TITLE
Update buildGraphFromPixels tests for refactor

### DIFF
--- a/src/services/hamiltonian.js
+++ b/src/services/hamiltonian.js
@@ -10,9 +10,9 @@ function buildGraphFromPixels(pixels) {
     const x = p % MAX_DIMENSION;
     const y = Math.floor(p / MAX_DIMENSION);
     const nbs = [];
-    for (const [dx, dy] in DIRECTION_PRIORITY) {
+    for (const [dx, dy] of DIRECTION_PRIORITY) {
       const neighbor = x + dx + MAX_DIMENSION * (y + dy);
-      const idx = nodes.indexOf(neighbor)
+      const idx = nodes.indexOf(neighbor);
       if (idx !== -1) nbs.push(idx);
     }
     neighbors.push(nbs);

--- a/test/hamiltonian.test.js
+++ b/test/hamiltonian.test.js
@@ -16,11 +16,10 @@ test('buildGraphFromPixels orders neighbors around a center pixel', () => {
       grid.set(coordToIndex(x, y), 1);
     }
   }
-  const neighbors = buildGraphFromPixels(grid);
-  const keys = Array.from(grid.keys());
+  const { nodes, neighbors } = buildGraphFromPixels(grid);
   const center = coordToIndex(1, 1);
-  const centerIdx = keys.indexOf(center);
-  const neighborPixels = neighbors[centerIdx].map((i) => keys[i]);
+  const centerIdx = nodes.indexOf(center);
+  const neighborPixels = neighbors[centerIdx].map((i) => nodes[i]);
   const expected = [
     coordToIndex(1, 0), // up
     coordToIndex(2, 1), // right
@@ -39,7 +38,7 @@ test('partitionAtEdgeCut detects a bridge in a line of three pixels', () => {
   const p1 = coordToIndex(1, 0);
   const p2 = coordToIndex(2, 0);
   const map = new Map([[p0, 1], [p1, 1], [p2, 1]]);
-  const neighbors = buildGraphFromPixels(map);
+  const { neighbors } = buildGraphFromPixels(map);
   const res = partitionAtEdgeCut(neighbors);
   assert(res);
   assert.strictEqual(res.edges.length, 1);


### PR DESCRIPTION
## Summary
- Fix neighbor construction in `buildGraphFromPixels`
- Adapt tests to new `{ nodes, neighbors }` return value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c113efe208832c90a7a6691f4a4b76