### PR TITLE
Refactor orientation tool and prevent pixel overwrites

### DIFF
--- a/src/components/SettingsPopup.vue
+++ b/src/components/SettingsPopup.vue
@@ -10,15 +10,15 @@
           <label class="block">
             <span>Default Orientation</span>
             <select v-model="defaultOrientation" class="mt-1 w-full rounded bg-slate-700 px-2 py-1">
-              <option v-for="ori in orientations" :key="ori" :value="ori">{{ ori }}</option>
+              <option v-for="ori in orientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
             </select>
           </label>
           <div v-if="defaultOrientation === 'checkerboard'" class="flex gap-2">
             <select v-model="cbOriA" class="flex-1 rounded bg-slate-700 px-2 py-1">
-              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ori }}</option>
+              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
             </select>
             <select v-model="cbOriB" class="flex-1 rounded bg-slate-700 px-2 py-1">
-              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ori }}</option>
+              <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
             </select>
           </div>
         </div>
@@ -41,6 +41,7 @@ import { ref, watch } from 'vue';
 import { useService } from '../services';
 import { usePixelStore, PIXEL_DEFAULT_ORIENTATIONS, PIXEL_ORIENTATIONS } from '@/stores/pixels';
 import { CHECKERBOARD_CONFIG } from '@/constants';
+import { ORIENTATION_LABELS } from '@/constants/orientation.js';
 import { checkerboardPatternUrl } from '@/utils/pixels.js';
 
 const { settings: settingsService } = useService();

--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -10,3 +10,11 @@ export const OT = Object.freeze({
 export const PIXEL_ORIENTATIONS = Object.values(OT).filter(o => o !== OT.DEFAULT);
 export const PIXEL_DEFAULT_ORIENTATIONS = [...PIXEL_ORIENTATIONS, 'checkerboard'];
 export const DEFAULT_CHECKERBOARD_ORIENTATIONS = [OT.HORIZONTAL, OT.VERTICAL];
+export const ORIENTATION_LABELS = {
+  [OT.NONE]: 'none',
+  [OT.HORIZONTAL]: 'horizontal',
+  [OT.DOWNSLOPE]: 'downslope',
+  [OT.VERTICAL]: 'vertical',
+  [OT.UPSLOPE]: 'upslope',
+  checkerboard: 'checkerboard'
+};

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -226,17 +226,12 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                 return;
             }
-            ensurePreview(target);
-            for (const o of PIXEL_ORIENTATIONS) orientationPreviews[target][o].delete(pixel);
-            let next;
-            if (prevPixel == null) {
-                const current = orientationOfWithPreview(target, pixel);
-                const idx = PIXEL_ORIENTATIONS.indexOf(current);
-                next = PIXEL_ORIENTATIONS[(idx + 1) % PIXEL_ORIENTATIONS.length];
-            }
-            else {
+            if (prevPixel != null) {
+                ensurePreview(target);
+                for (const o of PIXEL_ORIENTATIONS) orientationPreviews[target][o].delete(pixel);
                 const [px, py] = indexToCoord(pixel);
                 const [prevX, prevY] = indexToCoord(prevPixel);
+                let next;
                 if (prevX === px) {
                     next = OT.VERTICAL;
                     if (prevY < py)
@@ -251,15 +246,26 @@ export const useOrientationToolService = defineStore('orientationToolService', (
                     else
                         tool.setCursor({ stroke: CURSOR_STYLE.LEFT, rect: CURSOR_STYLE.LEFT });
                 }
+                orientationPreviews[target][next].add(pixel);
+                preview.clear();
+                preview.updatePixels(target, toUpdateMap(orientationPreviews[target]));
             }
-            orientationPreviews[target][next].add(pixel);
-            preview.clear();
-            preview.updatePixels(target, toUpdateMap(orientationPreviews[target]));
         }
         rebuild();
     });
     watch(() => tool.affectedPixels, (pixels) => {
         if (tool.current !== 'orientation') return;
+        if (pixels.length === 1) {
+            const pixel = pixels[0];
+            const target = layerQuery.topVisibleAt(pixel);
+            const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
+            if (target != null && editable && !nodes.locked(target)) {
+                const current = pixelStore.orientationOf(target, pixel);
+                const idx = PIXEL_ORIENTATIONS.indexOf(current);
+                const next = PIXEL_ORIENTATIONS[(idx + 1) % PIXEL_ORIENTATIONS.length];
+                pixelStore.update(target, { [pixel]: next });
+            }
+        }
         preview.commitPreview();
         orientationPreviews = {};
         rebuild();

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -129,18 +129,18 @@ export const usePixelStore = defineStore('pixels', {
             if (orientation === 'checkerboard') {
                 const [o1, o2] = this._checkerboardOrientations;
                 for (const pixel of pixels) {
+                    if (map.has(pixel)) continue;
                     const [x, y] = indexToCoord(pixel);
                     const o = (x + y) % 2 === 0 ? o1 : o2;
-                    const oldVal = map.get(pixel) || 0;
                     map.set(pixel, o);
-                    updatePixelHash(this, id, pixel, oldVal, o);
+                    updatePixelHash(this, id, pixel, 0, o);
                 }
             } else {
                 const idOri = orientation || OT.NONE;
                 for (const pixel of pixels) {
-                    const oldVal = map.get(pixel) || 0;
+                    if (map.has(pixel)) continue;
                     map.set(pixel, idOri);
-                    updatePixelHash(this, id, pixel, oldVal, idOri);
+                    updatePixelHash(this, id, pixel, 0, idOri);
                 }
             }
         },

--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -122,25 +122,23 @@ export const usePixelStore = defineStore('pixels', {
                 updatePixelHash(this, id, pixel, oldVal, orientation);
             }
         },
-        add(id, pixels, orientation) {
+        add(id, pixels, orientation = OT.DEFAULT) {
             const map = this._pixels[id];
-            orientation ??= this._defaultOrientation;
             if (orientation === OT.DEFAULT) orientation = this._defaultOrientation;
             if (orientation === 'checkerboard') {
                 const [o1, o2] = this._checkerboardOrientations;
                 for (const pixel of pixels) {
                     if (map.has(pixel)) continue;
                     const [x, y] = indexToCoord(pixel);
-                    const o = (x + y) % 2 === 0 ? o1 : o2;
-                    map.set(pixel, o);
-                    updatePixelHash(this, id, pixel, 0, o);
+                    const value = (x + y) % 2 === 0 ? o1 : o2;
+                    map.set(pixel, value);
+                    updatePixelHash(this, id, pixel, 0, value);
                 }
             } else {
-                const idOri = orientation || OT.NONE;
                 for (const pixel of pixels) {
                     if (map.has(pixel)) continue;
-                    map.set(pixel, idOri);
-                    updatePixelHash(this, id, pixel, 0, idOri);
+                    map.set(pixel, orientation);
+                    updatePixelHash(this, id, pixel, 0, orientation);
                 }
             }
         },

--- a/test/pixelHash.test.js
+++ b/test/pixelHash.test.js
@@ -46,7 +46,7 @@ test('changing pixel orientation updates hash', () => {
   const px = coordToIndex(0, 0);
   store.add(layer, [px], OT.HORIZONTAL);
   const hash1 = store._hash.all;
-  store.add(layer, [px], OT.VERTICAL);
+  store.update(layer, { [px]: OT.VERTICAL });
   const hash2 = store._hash.all;
   assert.notStrictEqual(hash1, hash2);
 });


### PR DESCRIPTION
## Summary
- refine orientation tool drag behavior; rotate single pixels directly and only preview when dragging to another pixel
- avoid overriding existing pixels when adding, updating tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11f77a78c832c8798c425d0dc0d30