### PR TITLE
refactor orientation tool service

### DIFF
--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -1,11 +1,13 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, watch } from 'vue';
-import { useStore } from '../stores';
+import { useNodeTreeStore } from '../stores/nodeTree.js';
+import { usePixelStore } from '../stores/pixels.js';
 import { pixelsToUnionPath } from '../utils/pixels.js';
 import { OVERLAY_STYLES } from '@/constants';
 
 export const useOverlayService = defineStore('overlayService', () => {
-    const { nodeTree, pixels: pixelStore } = useStore();
+    const nodeTree = useNodeTreeStore();
+    const pixelStore = usePixelStore();
 
     const overlayPixels = reactive({});
     const styles = reactive({});

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -66,9 +66,9 @@ export function checkerboardPatternUrl(target = document.body) {
     return `url(#${id})`;
 }
 
-export function ensureOrientationPattern(orientation, target = document.body) {
+export function orientationPatternUrl(orientation, target = document.body) {
     const id = `pixel-orientation-${orientation}`;
-    if (document.getElementById(id)) return id;
+    if (document.getElementById(id)) return `url(#${id})`;
     const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
     svg.setAttribute('width', '0');
     svg.setAttribute('height', '0');
@@ -133,7 +133,7 @@ export function ensureOrientationPattern(orientation, target = document.body) {
     defs.appendChild(pattern);
     svg.appendChild(defs);
     target.appendChild(svg);
-    return id;
+    return `url(#${id})`;
 }
 
 export function groupConnectedPixels(pixels) {


### PR DESCRIPTION
## Summary
- add orientationPatternUrl helper returning reusable SVG pattern urls
- shift pixel orientation rendering to preview store with layer-driven overlays
- simplify orientation tool service to delegate rendering and rerender only on preview pixel updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c12b229088832caf26c32046a79719