### PR TITLE
Improve orientation tool overlays and selection handling

### DIFF
--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -117,6 +117,15 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const tool = useToolSelectionService();
     const layerQuery = useLayerQueryService();
+    const overlayService = useOverlayService();
+    const currentOverlayId = overlayService.createOverlay();
+    overlayService.setStyles(currentOverlayId, OVERLAY_STYLES.ADD);
+    const prevOverlayId = overlayService.createOverlay();
+    overlayService.setStyles(prevOverlayId, {
+        ...OVERLAY_STYLES.ADD,
+        FILL_COLOR: 'rgba(74, 222, 128, 0.1)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 0.5)',
+    });
     const usable = computed(() => tool.shape === 'stroke' || tool.shape === 'rect');
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'orientation', name: 'Orientation', icon: stageIcons.orientation, usable });
@@ -125,20 +134,31 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         if (!isOrientation) {
             preview.clearOrientationLayers();
             preview.clear();
+            overlayService.clear(currentOverlayId);
+            overlayService.clear(prevOverlayId);
             return;
         }
         preview.initOrientationRenderer();
-        preview.setOrientationLayers(nodeTree.selectedLayerIds);
+        const ids = nodeTree.selectedLayerIds.length ? nodeTree.selectedLayerIds : nodeTree.layerOrder;
+        preview.setOrientationLayers(ids);
+        overlayService.clear(currentOverlayId);
+        overlayService.clear(prevOverlayId);
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
 
     watch(() => tool.hoverPixel, pixel => {
-        if (tool.current !== 'orientation' || !pixel) return;
-        tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
+        if (tool.current !== 'orientation') return;
+        overlayService.setPixels(prevOverlayId, []);
+        overlayService.setPixels(currentOverlayId, pixel ? [pixel] : []);
+        if (pixel)
+            tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
 
     watch(() => tool.dragPixel, (pixel, prevPixel) => {
-        if (tool.current !== 'orientation' || pixel == null) return;
+        if (tool.current !== 'orientation') return;
+        overlayService.setPixels(currentOverlayId, pixel != null ? [pixel] : []);
+        overlayService.setPixels(prevOverlayId, pixel != null && prevPixel != null ? [prevPixel] : []);
+        if (pixel == null) return;
         const target = layerQuery.topVisibleAt(pixel);
         const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
         if (target != null && editable) {
@@ -181,7 +201,14 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     });
 
     watch(() => nodeTree.selectedLayerIds.slice(), ids => {
-        if (tool.current === 'orientation') preview.setOrientationLayers(ids);
+        if (tool.current !== 'orientation') return;
+        const layers = ids.length ? ids : nodeTree.layerOrder;
+        preview.setOrientationLayers(layers);
+    });
+
+    watch(() => nodeTree.layerOrder.slice(), ids => {
+        if (tool.current !== 'orientation') return;
+        if (nodeTree.selectedLayerIds.length === 0) preview.setOrientationLayers(ids);
     });
 
     return { usable };

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -141,8 +141,6 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         preview.initOrientationRenderer();
         const ids = nodeTree.selectedLayerIds.length ? nodeTree.selectedLayerIds : nodeTree.layerOrder;
         preview.setOrientationLayers(ids);
-        overlayService.clear(currentOverlayId);
-        overlayService.clear(prevOverlayId);
         tool.setCursor({ stroke: CURSOR_STYLE.CHANGE, rect: CURSOR_STYLE.CHANGE });
     });
 
@@ -200,13 +198,13 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         preview.commitPreview();
     });
 
-    watch(() => nodeTree.selectedLayerIds.slice(), ids => {
+    watch(() => nodeTree.selectedLayerIds, ids => {
         if (tool.current !== 'orientation') return;
         const layers = ids.length ? ids : nodeTree.layerOrder;
         preview.setOrientationLayers(layers);
     });
 
-    watch(() => nodeTree.layerOrder.slice(), ids => {
+    watch(() => nodeTree.layerOrder, ids => {
         if (tool.current !== 'orientation') return;
         if (nodeTree.selectedLayerIds.length === 0) preview.setOrientationLayers(ids);
     });

--- a/src/stores/preview.js
+++ b/src/stores/preview.js
@@ -149,21 +149,9 @@ export const usePreviewStore = defineStore('preview', {
                 PIXEL_ORIENTATIONS.forEach((orientation, idx) => {
                     const overlayId = this._orientationOverlays[idx];
                     overlayService.clear(overlayId);
-                    if (this.orientationLayers.length === 0) {
-                        const add = new Set();
-                        for (let i = nodeTree.layerOrder.length - 1; i >= 0; i--) {
-                            const id = nodeTree.layerOrder[i];
-                            if (!nodes.visibility(id)) continue;
-                            for (const pixel of getOrientationPixels(id, orientation)) {
-                                if (!add.has(pixel)) add.add(pixel);
-                            }
-                        }
-                        overlayService.addPixels(overlayId, [...add]);
-                    } else {
-                        for (const id of this.orientationLayers) {
-                            const pixels = getOrientationPixels(id, orientation);
-                            if (pixels.length) overlayService.addPixels(overlayId, pixels);
-                        }
+                    for (const id of this.orientationLayers) {
+                        const pixels = getOrientationPixels(id, orientation);
+                        if (pixels.length) overlayService.addPixels(overlayId, pixels);
                     }
                 });
             };


### PR DESCRIPTION
## Summary
- Remove special selection-none handling from orientation preview renderer
- When no layers selected in orientation tool, use all layers for orientation overlays
- Display hover overlay for orientation tool and add subtle overlay for previous pixel while dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c131fa4ffc832c9b6abf7fdaed1a66