### PR TITLE
feat: add tool-specific overlay style placeholders

### DIFF
--- a/src/constants/overlay.js
+++ b/src/constants/overlay.js
@@ -22,5 +22,47 @@ export const OVERLAY_STYLES = {
         STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
         STROKE_WIDTH_SCALE: 2,
         FILL_RULE: 'evenodd',
+    },
+    DRAW: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    TOP: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    SELECT_ADD: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    SELECT_REMOVE: {
+        FILL_COLOR: 'rgba(248, 113, 113, 0.25)',
+        STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    ORIENTATION: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    ORIENTATION_PREV: {
+        FILL_COLOR: 'rgba(74, 222, 128, 0.25)',
+        STROKE_COLOR: 'rgba(74, 222, 128, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
+    },
+    GLOBAL_ERASE: {
+        FILL_COLOR: 'rgba(248, 113, 113, 0.25)',
+        STROKE_COLOR: 'rgba(248, 113, 113, 1.0)',
+        STROKE_WIDTH_SCALE: 2,
+        FILL_RULE: 'evenodd',
     }
 };

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -15,7 +15,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
     const tool = useToolSelectionService();
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
-    overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+    overlayService.setStyles(overlayId, OVERLAY_STYLES.SELECT_ADD);
     const layerPanel = useLayerPanelService();
     const { nodeTree, nodes, keyboardEvent: keyboardEvents } = useStore();
     const layerQuery = useLayerQueryService();
@@ -39,15 +39,15 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         const id = layerQuery.topVisibleAt(pixel);
         if (!keyboardEvents.isPressed('Shift')) {
             mode = 'select';
-            overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+            overlayService.setStyles(overlayId, OVERLAY_STYLES.SELECT_ADD);
             tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
         } else if (nodeTree.selectedLayerIds.includes(id)) {
             mode = 'remove';
-            overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
+            overlayService.setStyles(overlayId, OVERLAY_STYLES.SELECT_REMOVE);
             tool.setCursor({ stroke: CURSOR_STYLE.REMOVE_STROKE, rect: CURSOR_STYLE.REMOVE_RECT });
         } else {
             mode = 'add';
-            overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+            overlayService.setStyles(overlayId, OVERLAY_STYLES.SELECT_ADD);
             tool.setCursor({ stroke: CURSOR_STYLE.ADD_STROKE, rect: CURSOR_STYLE.ADD_RECT });
         }
 
@@ -119,13 +119,9 @@ export const useOrientationToolService = defineStore('orientationToolService', (
     const layerQuery = useLayerQueryService();
     const overlayService = useOverlayService();
     const currentOverlayId = overlayService.createOverlay();
-    overlayService.setStyles(currentOverlayId, OVERLAY_STYLES.ADD);
+    overlayService.setStyles(currentOverlayId, OVERLAY_STYLES.ORIENTATION);
     const prevOverlayId = overlayService.createOverlay();
-    overlayService.setStyles(prevOverlayId, {
-        ...OVERLAY_STYLES.ADD,
-        FILL_COLOR: 'rgba(74, 222, 128, 0.1)',
-        STROKE_COLOR: 'rgba(74, 222, 128, 0.5)',
-    });
+    overlayService.setStyles(prevOverlayId, OVERLAY_STYLES.ORIENTATION_PREV);
     const usable = computed(() => tool.shape === 'stroke' || tool.shape === 'rect');
     const toolbar = useToolbarStore();
     toolbar.register({ type: 'orientation', name: 'Orientation', icon: stageIcons.orientation, usable });
@@ -216,7 +212,7 @@ export const useGlobalEraseToolService = defineStore('globalEraseToolService', (
     const tool = useToolSelectionService();
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
-    overlayService.setStyles(overlayId, OVERLAY_STYLES.REMOVE);
+    overlayService.setStyles(overlayId, OVERLAY_STYLES.GLOBAL_ERASE);
     const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const usable = computed(() => tool.shape === 'stroke' || tool.shape === 'rect');
     const toolbar = useToolbarStore();

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -14,7 +14,7 @@ export const useDrawToolService = defineStore('drawToolService', () => {
     const tool = useToolSelectionService();
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
-    overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+    overlayService.setStyles(overlayId, OVERLAY_STYLES.DRAW);
     const { nodeTree, nodes, pixels: pixelStore, preview } = useStore();
     const usable = computed(() => (tool.shape === 'stroke' || tool.shape === 'rect') && nodeTree.selectedLayerCount === 1);
     const toolbar = useToolbarStore();
@@ -173,7 +173,7 @@ export const useTopToolService = defineStore('topToolService', () => {
     const tool = useToolSelectionService();
     const overlayService = useOverlayService();
     const overlayId = overlayService.createOverlay();
-    overlayService.setStyles(overlayId, OVERLAY_STYLES.ADD);
+    overlayService.setStyles(overlayId, OVERLAY_STYLES.TOP);
     const layerPanel = useLayerPanelService();
     const layerQuery = useLayerQueryService();
     const { nodeTree, nodes } = useStore();


### PR DESCRIPTION
## Summary
- introduce overlay style entries for draw, top, select, orientation, orientation-prev, and global erase tools
- use new overlay style keys across tool services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c13b382b08832c8922705dba74ef12