### PR TITLE
Refactor output history tracking to tick-based detection

### DIFF
--- a/src/components/LayersToolbar.vue
+++ b/src/components/LayersToolbar.vue
@@ -27,42 +27,34 @@ import { useService } from '../services';
 import { computed } from 'vue';
 import toolbarIcons from '../image/layer_toolbar';
 
-const { nodeTree, nodes, pixels: pixelStore, output } = useStore();
+const { nodeTree, nodes, pixels: pixelStore } = useStore();
 const { layerTool: layerSvc, layerPanel, layerQuery } = useService();
 
 const hasEmptyLayers = computed(() => nodeTree.layerOrder.some(id => pixelStore.sizeOf(id) === 0));
 const canSplit = computed(() => nodeTree.selectedLayerIds.some(id => pixelStore.disconnectedCountOf(id) > 1));
 
 const onAdd = () => {
-    output.setRollbackPoint();
     const above = nodeTree.selectedLayerCount ? layerQuery.uppermost(nodeTree.selectedLayerIds) : null;
     const id = nodes.addLayer({color: 0xFFFFFFFF});
     pixelStore.addLayer(id);
     nodeTree.insert([id], above, false);
     nodeTree.replaceSelection([id]);
     layerPanel.setScrollRule({ type: 'follow', target: id });
-    output.commit();
 };
 const onAddGroup = () => {
-    output.setRollbackPoint();
     const id = layerSvc.groupSelected();
     layerPanel.setRange(id, id);
     layerPanel.setScrollRule({ type: 'follow', target: id });
-    output.commit();
 };
 const onMerge = () => {
-    output.setRollbackPoint();
     const id = layerSvc.mergeSelected();
     nodeTree.replaceSelection([id]);
     layerPanel.setScrollRule({ type: 'follow', target: id });
-    output.commit();
 };
 const onCopy = () => {
-    output.setRollbackPoint();
     const ids = layerSvc.copySelected();
     nodeTree.replaceSelection(ids);
     layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
-    output.commit();
 };
 const onSelectEmpty = () => {
     const ids = layerQuery.empty();
@@ -70,9 +62,7 @@ const onSelectEmpty = () => {
     layerPanel.setScrollRule({ type: 'follow', target: ids[0] });
 };
 const onSplit = () => {
-    output.setRollbackPoint();
     const newIds = layerSvc.splitSelected();
     layerPanel.setScrollRule({ type: 'follow', target: newIds[0] });
-    output.commit();
 };
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -2,10 +2,11 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
-import { useKeyboardEventStore } from './stores';
+import { useKeyboardEventStore, useOutputStore } from './stores';
 
 const app = createApp(App);
 const pinia = createPinia();
 app.use(pinia);
 useKeyboardEventStore(pinia).listen();
+useOutputStore(pinia).listen();
 app.mount('#app');

--- a/src/services/clipboard.js
+++ b/src/services/clipboard.js
@@ -31,7 +31,7 @@ function serializeNode(id, nodeTree, nodes, pixelStore) {
 }
 
 export const useClipboardService = defineStore('clipboardService', () => {
-    const { nodeTree, nodes, pixels: pixelStore, output } = useStore();
+    const { nodeTree, nodes, pixels: pixelStore } = useStore();
     const nodeQuery = useNodeQueryService();
     const layerPanel = useLayerPanelService();
 
@@ -67,7 +67,6 @@ export const useClipboardService = defineStore('clipboardService', () => {
     function paste() {
         if (!clipboardData.length) return [];
 
-        output.setRollbackPoint();
         const infos = clipboardData.map(createFrom);
         const topIds = infos.map(info => info.id);
         const uppermost = nodeQuery.uppermost(nodeTree.selectedIds);
@@ -83,7 +82,6 @@ export const useClipboardService = defineStore('clipboardService', () => {
         nodeTree.replaceSelection(topIds);
         layerPanel.setRange(topIds[0], topIds[topIds.length - 1]);
         layerPanel.setScrollRule({ type: 'follow', target: topIds[0] });
-        output.commit();
         return topIds;
     }
 

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -22,7 +22,6 @@ export const useShortcutService = defineStore('shortcutService', () => {
 
     function deleteSelection() {
         if (!nodeTree.selectedNodeCount) return;
-        output.setRollbackPoint();
         const ids = nodeTree.selectedIds;
         const lowermostTarget = nodeQuery.lowermost(ids);
         const parentId = nodeQuery.parentOf(lowermostTarget);
@@ -44,7 +43,6 @@ export const useShortcutService = defineStore('shortcutService', () => {
         }
         layerPanel.setRange(newSelect, newSelect);
         if (newSelect) layerPanel.setScrollRule({ type: 'follow', target: newSelect });
-        output.commit();
     }
 
     watch(() => keyboardEvents.recent.down, (downs) => {
@@ -113,12 +111,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
                     }
                     break;
                 case 'Escape':
-                    if (output.hasPendingRollback) {
-                        e.preventDefault();
-                        output.rollbackPending();
-                    } else {
-                        nodeTree.clearSelection();
-                    }
+                    nodeTree.clearSelection();
                     break;
             }
 
@@ -129,13 +122,11 @@ export const useShortcutService = defineStore('shortcutService', () => {
                     layerPanel.selectAll();
                 } else if (lower === 'g') {
                     e.preventDefault();
-                    output.setRollbackPoint();
                     const ordered = nodeTree.orderedSelection;
                     nodeTree.replaceSelection(ordered);
                     const id = layerSvc.groupSelected();
                     layerPanel.setRange(id, id);
                     layerPanel.setScrollRule({ type: 'follow', target: id });
-                    output.commit();
                 }
             }
         }

--- a/src/services/stageResize.js
+++ b/src/services/stageResize.js
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { useStore } from '../stores';
 
 export const useStageResizeService = defineStore('stageResizeService', () => {
-  const { viewport, output } = useStore();
+  const { viewport } = useStore();
   const show = ref(false);
 
   function open() {
@@ -15,7 +15,6 @@ export const useStageResizeService = defineStore('stageResizeService', () => {
   }
 
   function apply(payload) {
-    output.setRollbackPoint();
     viewport.resizeByEdges(payload);
     viewport.recalcContentSize();
     viewport.setScale(viewport.stage.containScale * 0.75);
@@ -24,7 +23,6 @@ export const useStageResizeService = defineStore('stageResizeService', () => {
     const x = (viewport.content.width - w) / 2;
     const y = (viewport.content.height - h) / 2;
     viewport.setOffset(x, y);
-    output.commit();
     close();
   }
 

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -1,52 +1,70 @@
 import { defineStore } from 'pinia';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
+import { watch } from 'vue';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
         _stack: [],
         _pointer: -1,
-        _pendingRollback: null,
-        _commitScheduled: false,
+        _lastSnapshot: null,
+        _lastHash: 0,
+        _beforeSnapshot: null,
+        _changed: false,
+        _tickScheduled: false,
+        _ignoreChanges: false,
         _commitVersion: 0
     }),
     getters: {
-        hasPendingRollback: (state) => !!state._pendingRollback,
         commitVersion: (state) => state._commitVersion
     },
     actions: {
+        _calcHash() {
+            const { nodeTree, nodes, pixels } = useStore();
+            return nodeTree._hash.tree.hash ^ nodes._hash.all ^ pixels._hash.all;
+        },
         _apply(snapshot) {
             const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
+            this._ignoreChanges = true;
             nodeTree.applySerialized(parsed.nodeTreeState);
             nodes.applySerialized(parsed.nodeState);
             pixels.applySerialized(parsed.pixelState);
             layerPanel.applySerialized(parsed.layerPanelState);
             viewport.applySerialized(parsed.viewportState);
-            this._commitVersion++; // ← Undo/Redo/롤백 시에도 썸네일 갱신
+            this._ignoreChanges = false;
+            this._lastSnapshot = snapshot;
+            this._lastHash = this._calcHash();
+            this._commitVersion++; // ← Undo/Redo 시에도 썸네일 갱신
         },
-        commit() {
-            if (!this._pendingRollback || this._commitScheduled) return;
-            this._commitScheduled = true;
-            requestAnimationFrame(() => {
-                const before = this._pendingRollback;
-                const after = this.currentSnap();
-                if (before === after) {
-                    this._pendingRollback = null;
-                    this._commitScheduled = false;
-                    return;
-                }
+        _record() {
+            this._tickScheduled = false;
+            if (!this._changed) return;
+            const after = this.currentSnap();
+            const hash = this._calcHash();
+            if (hash !== this._lastHash) {
                 this._stack = this._stack.slice(0, this._pointer + 1);
-                this._stack.push({
-                    before,
-                    after
-                });
+                this._stack.push({ before: this._beforeSnapshot, after });
                 this._pointer = this._stack.length - 1;
-                this._pendingRollback = null;
-                this._commitScheduled = false;
-                this._commitVersion++; // ← 실제 커밋 때 썸네일 갱신 트리거
-            })
+                this._lastSnapshot = after;
+                this._lastHash = hash;
+                this._commitVersion++;
+            }
+            this._changed = false;
+        },
+        _scheduleRecord() {
+            if (this._tickScheduled) return;
+            this._tickScheduled = true;
+            requestAnimationFrame(() => this._record());
+        },
+        _onStoreChanged() {
+            if (this._ignoreChanges) return;
+            if (!this._changed) {
+                this._beforeSnapshot = this._lastSnapshot;
+                this._changed = true;
+            }
+            this._scheduleRecord();
         },
         currentSnap() {
             const { nodeTree, nodes, pixels, viewport } = useStore();
@@ -59,32 +77,25 @@ export const useOutputStore = defineStore('output', {
                 viewportState: viewport.serialize()
             });
         },
-        setRollbackPoint(snapshot) {
-            if (!this._pendingRollback) {
-                this._pendingRollback = snapshot || this.currentSnap();
+        listen() {
+            if (this._lastSnapshot === null) {
+                this._lastSnapshot = this.currentSnap();
+                this._lastHash = this._calcHash();
             }
-        },
-        clearRollbackPoint() {
-            this._pendingRollback = null;
-        },
-        rollbackPending() {
-            if (!this._pendingRollback) return;
-            this._apply(this._pendingRollback);
-            this._pendingRollback = null;
+            const { nodeTree, nodes, pixels } = useStore();
+            watch(() => [nodeTree._hash.tree.hash, nodes._hash.all, pixels._hash.all], () => this._onStoreChanged());
         },
         undo() {
             if (this._pointer < 0) return;
             const cur = this._stack[this._pointer];
             this._apply(cur.before);
             this._pointer--;
-            this._pendingRollback = null;
         },
         redo() {
             if (this._pointer + 1 >= this._stack.length) return;
             const next = this._stack[this._pointer + 1];
             this._apply(next.after);
             this._pointer++;
-            this._pendingRollback = null;
         },
         exportToJSON() {
             const { input } = useStore();

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
-import { watch } from 'vue';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -9,10 +8,6 @@ export const useOutputStore = defineStore('output', {
         _pointer: -1,
         _lastSnapshot: null,
         _lastHash: 0,
-        _beforeSnapshot: null,
-        _changed: false,
-        _tickScheduled: false,
-        _ignoreChanges: false,
         _commitVersion: 0
     }),
     getters: {
@@ -27,44 +22,28 @@ export const useOutputStore = defineStore('output', {
             const { nodeTree, nodes, pixels, viewport } = useStore();
             const layerPanel = useLayerPanelService();
             const parsed = JSON.parse(snapshot);
-            this._ignoreChanges = true;
             nodeTree.applySerialized(parsed.nodeTreeState);
             nodes.applySerialized(parsed.nodeState);
             pixels.applySerialized(parsed.pixelState);
             layerPanel.applySerialized(parsed.layerPanelState);
             viewport.applySerialized(parsed.viewportState);
-            this._ignoreChanges = false;
             this._lastSnapshot = snapshot;
             this._lastHash = this._calcHash();
             this._commitVersion++; // ← Undo/Redo 시에도 썸네일 갱신
         },
-        _record() {
-            this._tickScheduled = false;
-            if (!this._changed) return;
-            const after = this.currentSnap();
+        _tick() {
             const hash = this._calcHash();
             if (hash !== this._lastHash) {
+                const before = this._lastSnapshot;
+                const after = this.currentSnap();
                 this._stack = this._stack.slice(0, this._pointer + 1);
-                this._stack.push({ before: this._beforeSnapshot, after });
+                this._stack.push({ before, after });
                 this._pointer = this._stack.length - 1;
                 this._lastSnapshot = after;
                 this._lastHash = hash;
                 this._commitVersion++;
             }
-            this._changed = false;
-        },
-        _scheduleRecord() {
-            if (this._tickScheduled) return;
-            this._tickScheduled = true;
-            requestAnimationFrame(() => this._record());
-        },
-        _onStoreChanged() {
-            if (this._ignoreChanges) return;
-            if (!this._changed) {
-                this._beforeSnapshot = this._lastSnapshot;
-                this._changed = true;
-            }
-            this._scheduleRecord();
+            requestAnimationFrame(() => this._tick());
         },
         currentSnap() {
             const { nodeTree, nodes, pixels, viewport } = useStore();
@@ -82,8 +61,7 @@ export const useOutputStore = defineStore('output', {
                 this._lastSnapshot = this.currentSnap();
                 this._lastHash = this._calcHash();
             }
-            const { nodeTree, nodes, pixels } = useStore();
-            watch(() => [nodeTree._hash.tree.hash, nodes._hash.all, pixels._hash.all], () => this._onStoreChanged());
+            this._tick();
         },
         undo() {
             if (this._pointer < 0) return;


### PR DESCRIPTION
## Summary
- Replace manual rollback/commit with automatic tick-based history tracking using store hashes
- Initialize output store listener at app startup
- Remove legacy rollback calls across UI and services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c14269a96c832ca2669144c645bb4b