### PR TITLE
Center stage at zero offset

### DIFF
--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -81,10 +81,12 @@ const dpr = window.devicePixelRatio || 1;
 const stageStyle = computed(() => {
     const width = stage.width / dpr;
     const height = stage.height / dpr;
+    const offsetX = stage.offset.x + (viewportStore.content.width - stage.width * stage.scale) / 2;
+    const offsetY = stage.offset.y + (viewportStore.content.height - stage.height * stage.scale) / 2;
     return {
         width: width + 'px',
         height: height + 'px',
-        transform: `translate3d(${stage.offset.x}px, ${stage.offset.y}px, 0) scale(${stage.scale * dpr})`,
+        transform: `translate3d(${offsetX}px, ${offsetY}px, 0) scale(${stage.scale * dpr})`,
         transformOrigin: 'top left',
         willChange: 'transform'
     };

--- a/src/services/stageResize.js
+++ b/src/services/stageResize.js
@@ -18,11 +18,7 @@ export const useStageResizeService = defineStore('stageResizeService', () => {
     viewport.resizeByEdges(payload);
     viewport.recalcContentSize();
     viewport.setScale(viewport.stage.containScale * 0.75);
-    const w = viewport.stage.width * viewport.stage.scale;
-    const h = viewport.stage.height * viewport.stage.scale;
-    const x = (viewport.content.width - w) / 2;
-    const y = (viewport.content.height - h) / 2;
-    viewport.setOffset(x, y);
+    viewport.setOffset(0, 0);
     close();
   }
 

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -69,11 +69,7 @@ export const useViewportService = defineStore('viewportService', () => {
       stage.offset.y - stage.offset.y * strength
     );
   }
-
-  function centerPosition() {
-    viewportStore.setOffset(0, 0);
-  }
-
+  
   watch(() => viewportEvents.recent.pointer.move, () => {
       if (viewportEvents.pinchIds) handlePinch();
   });
@@ -88,7 +84,6 @@ export const useViewportService = defineStore('viewportService', () => {
 
   return {
     element,
-    setElement,
-    centerPosition
+    setElement
   };
 });

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -13,26 +13,37 @@ export const useViewportService = defineStore('viewportService', () => {
     viewportStore.setElement(el);
   }
 
+  function zoomAt(px, py, factor) {
+    const oldScale = viewportStore.stage.scale;
+    const newScale = oldScale * factor;
+    const clamped = Math.max(viewportStore.stage.minScale, newScale);
+    const ratio = clamped / oldScale;
+    const { offset } = viewportStore.stage;
+    const centerX0 = (viewportStore.content.width - viewportStore.stage.width * oldScale) / 2;
+    const centerY0 = (viewportStore.content.height - viewportStore.stage.height * oldScale) / 2;
+    const t0x = offset.x + centerX0;
+    const t0y = offset.y + centerY0;
+    const t1x = px - ratio * (px - t0x);
+    const t1y = py - ratio * (py - t0y);
+    const centerX1 = (viewportStore.content.width - viewportStore.stage.width * clamped) / 2;
+    const centerY1 = (viewportStore.content.height - viewportStore.stage.height * clamped) / 2;
+    viewportStore.setOffset(t1x - centerX1, t1y - centerY1);
+    viewportStore.setScale(clamped);
+    return newScale < oldScale;
+  }
+
   function handleWheel(e) {
     if (!viewportStore.element) return;
-    const { offset } = viewportStore.stage;
     if (!e.ctrlKey) {
+      const { offset } = viewportStore.stage;
       viewportStore.setOffset(offset.x - e.deltaX, offset.y - e.deltaY);
     } else {
       if (e.deltaY === 0) return;
       const px = e.clientX - viewportStore.content.left;
       const py = e.clientY - viewportStore.content.top;
-      const oldScale = viewportStore.stage.scale;
       const factor = e.deltaY < 0 ? WHEEL_ZOOM_IN_FACTOR : WHEEL_ZOOM_OUT_FACTOR;
-      const newScale = oldScale * factor;
-      const clamped = Math.max(viewportStore.stage.minScale, newScale);
-      const ratio = clamped / oldScale;
-      viewportStore.setOffset(
-        px - ratio * (px - offset.x),
-        py - ratio * (py - offset.y)
-      );
-      viewportStore.setScale(clamped);
-      if (newScale < oldScale) interpolatePosition(true);
+      const shrink = zoomAt(px, py, factor);
+      if (shrink) interpolatePosition(true);
     }
   }
 
@@ -44,41 +55,23 @@ export const useViewportService = defineStore('viewportService', () => {
     const cy = (e1.clientY + e2.clientY) / 2 - viewportStore.content.top;
     const dist = Math.hypot(e2.clientX - e1.clientX, e2.clientY - e1.clientY);
     if (lastTouchDistance) {
-      const oldScale = viewportStore.stage.scale;
-      const newScale = oldScale * (dist / lastTouchDistance);
-      const clamped = Math.max(viewportStore.stage.minScale, newScale);
-      const ratio = clamped / oldScale;
-      const { offset } = viewportStore.stage;
-      viewportStore.setOffset(
-        cx - ratio * (cx - offset.x),
-        cy - ratio * (cy - offset.y)
-      );
-      viewportStore.setScale(clamped);
-      if (newScale < oldScale) interpolatePosition(true);
+      const shrink = zoomAt(cx, cy, dist / lastTouchDistance);
+      if (shrink) interpolatePosition(true);
     }
     lastTouchDistance = dist;
   }
 
   function interpolatePosition() {
     const stage = viewportStore.stage
-    const width = viewportStore.content.width;
-    const height = viewportStore.content.height;
-    const scaledWidth = stage.width * stage.scale;
-    const scaledHeight = stage.height * stage.scale;
     const strength = (stage.minScale / stage.scale) ** POSITION_LERP_EXPONENT;
     viewportStore.setOffset(
-      stage.offset.x + ((width - scaledWidth) / 2 - stage.offset.x) * strength,
-      stage.offset.y + ((height - scaledHeight) / 2 - stage.offset.y) * strength
+      stage.offset.x - stage.offset.x * strength,
+      stage.offset.y - stage.offset.y * strength
     );
   }
 
   function centerPosition() {
-    const stage = viewportStore.stage
-    const width = viewportStore.content.width;
-    const height = viewportStore.content.height;
-    const scaledWidth = stage.width * stage.scale;
-    const scaledHeight = stage.height * stage.scale;
-    viewportStore.setOffset((width - scaledWidth) / 2, (height - scaledHeight) / 2);
+    viewportStore.setOffset(0, 0);
   }
 
   watch(() => viewportEvents.recent.pointer.move, () => {

--- a/src/services/viewport.js
+++ b/src/services/viewport.js
@@ -29,7 +29,6 @@ export const useViewportService = defineStore('viewportService', () => {
     const centerY1 = (viewportStore.content.height - viewportStore.stage.height * clamped) / 2;
     viewportStore.setOffset(t1x - centerX1, t1y - centerY1);
     viewportStore.setScale(clamped);
-    return newScale < oldScale;
   }
 
   function handleWheel(e) {
@@ -42,8 +41,8 @@ export const useViewportService = defineStore('viewportService', () => {
       const px = e.clientX - viewportStore.content.left;
       const py = e.clientY - viewportStore.content.top;
       const factor = e.deltaY < 0 ? WHEEL_ZOOM_IN_FACTOR : WHEEL_ZOOM_OUT_FACTOR;
-      const shrink = zoomAt(px, py, factor);
-      if (shrink) interpolatePosition(true);
+      zoomAt(px, py, factor);
+      if (factor < 1) interpolatePosition();
     }
   }
 
@@ -55,8 +54,9 @@ export const useViewportService = defineStore('viewportService', () => {
     const cy = (e1.clientY + e2.clientY) / 2 - viewportStore.content.top;
     const dist = Math.hypot(e2.clientX - e1.clientX, e2.clientY - e1.clientY);
     if (lastTouchDistance) {
-      const shrink = zoomAt(cx, cy, dist / lastTouchDistance);
-      if (shrink) interpolatePosition(true);
+      const factor = dist / lastTouchDistance
+      zoomAt(cx, cy, factor);
+      if (factor < 1) interpolatePosition();
     }
     lastTouchDistance = dist;
   }

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -71,9 +71,7 @@ export const useInputStore = defineStore('input', {
             viewportStore.recalcContentSize();
             const stage = viewportStore.stage
             viewportStore.setScale(stage.containScale * 3/4);
-            const offsetX = (viewportStore.content.width - stage.width * stage.scale) / 2;
-            const offsetY = (viewportStore.content.height - stage.height * stage.scale) / 2;
-            viewportStore.setOffset(offsetX, offsetY);
+            viewportStore.setOffset(0, 0);
         
             if (initializeLayers) {
                 const autoSegments = this.segment(segmentTolerance);

--- a/src/stores/input.js
+++ b/src/stores/input.js
@@ -69,8 +69,7 @@ export const useInputStore = defineStore('input', {
             viewportStore.setImage(this.src || '', this.width, this.height);
             
             viewportStore.recalcContentSize();
-            const stage = viewportStore.stage
-            viewportStore.setScale(stage.containScale * 3/4);
+            viewportStore.setScale(viewportStore.stage.containScale * 3/4);
             viewportStore.setOffset(0, 0);
         
             if (initializeLayers) {

--- a/src/stores/viewport.js
+++ b/src/stores/viewport.js
@@ -116,8 +116,10 @@ export const useViewportStore = defineStore('viewport', {
             }
         },
         clientToIndex(event, { allowViewport } = {}) {
-            const left = this._content.left + this._stage.offset.x;
-            const top = this._content.top + this._stage.offset.y;
+            const centerX = (this._content.width - this._stage.width * this._stage.scale) / 2;
+            const centerY = (this._content.height - this._stage.height * this._stage.scale) / 2;
+            const left = this._content.left + centerX + this._stage.offset.x;
+            const top = this._content.top + centerY + this._stage.offset.y;
             let x = Math.floor((event.clientX - left) / this._stage.scale);
             let y = Math.floor((event.clientY - top) / this._stage.scale);
             if (!allowViewport && (x < 0 || y < 0 || x >= this._stage.width || y >= this._stage.height)) return null;


### PR DESCRIPTION
## Summary
- Interpret viewport stage offset `{x:0,y:0}` as centered
- Adjust event and zoom math for center-based offsets
- Simplify stage resize and initialization to reset offset to zero
- Deduplicate wheel and pinch zoom logic via shared `zoomAt`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15b0fa40c832cb6a6fe1cc8a17798