### PR TITLE
Add uppermost layer query and keep orientation on merge

### DIFF
--- a/src/components/ViewportInfo.vue
+++ b/src/components/ViewportInfo.vue
@@ -31,7 +31,7 @@ const pixelInfo = computed(() => {
       const colorObject = input.readPixel(pixel);
       return `[${px},${py}] ${rgbaCssObj(colorObject)}`;
     } else {
-      const id = layerQuery.topVisibleAt(pixel);
+      const id = layerQuery.uppermostAt(pixel, true);
       const colorU32 = id ? nodes.color(id) : 0;
       return `[${px},${py}] ${rgbaCssU32(colorU32)}`;
     }

--- a/src/services/layerQuery.js
+++ b/src/services/layerQuery.js
@@ -44,13 +44,13 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         return order[idx - 1] ?? null;
     }
 
-    function topVisibleAt(pixel, ids = null) {
+    function uppermostAt(pixel, filterHidden = false, ids = null) {
         const order = nodeTree.layerIdsBottomToTop;
         const idSet = ids ? new Set(ids) : null;
         for (let i = order.length - 1; i >= 0; i--) {
             const id = order[i];
             if (idSet && !idSet.has(id)) continue;
-            if (!nodes._visibility[id]) continue;
+            if (filterHidden && !nodes._visibility[id]) continue;
             if (pixels.has(id, pixel)) return id;
         }
         return null;
@@ -87,7 +87,7 @@ export const useLayerQueryService = defineStore('layerQueryService', () => {
         lowermost,
         above,
         below,
-        topVisibleAt,
+        uppermostAt,
         empty,
         disconnected,
         byColor,

--- a/src/services/layerTool.js
+++ b/src/services/layerTool.js
@@ -15,10 +15,13 @@ export const useLayerToolService = defineStore('layerToolService', () => {
 
         const pixelUnion = getPixelUnion(pixels.get(nodeTree.selectedLayerIds) || []);
         const colors = [];
+        const orientationMap = {};
         if (pixelUnion.length) {
             for (const pixel of pixelUnion) {
-                const id = layerQuery.topVisibleAt(pixel, nodeTree.selectedLayerIds);
-                if (id) colors.push(nodes.color(id));
+                const visibleId = layerQuery.uppermostAt(pixel, true, nodeTree.selectedLayerIds);
+                if (visibleId) colors.push(nodes.color(visibleId));
+                const topId = layerQuery.uppermostAt(pixel, false, nodeTree.selectedLayerIds);
+                if (topId) orientationMap[pixel] = pixels.orientationOf(topId, pixel);
             }
         } else {
             for (const id of nodeTree.selectedLayerIds) {
@@ -38,7 +41,7 @@ export const useLayerToolService = defineStore('layerToolService', () => {
             attributes: maintainedAttrs,
         });
         pixels.addLayer(newLayerId);
-        pixels.add(newLayerId, pixelUnion);
+        pixels.update(newLayerId, orientationMap);
         nodeTree.insert([newLayerId], baseId, true);
         const removed = nodeTree.remove(nodeTree.selectedNodeIds);
         nodes.remove(removed);

--- a/src/services/multiLayerTools.js
+++ b/src/services/multiLayerTools.js
@@ -36,7 +36,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        const id = layerQuery.topVisibleAt(pixel);
+        const id = layerQuery.uppermostAt(pixel, true);
         if (!keyboardEvents.isPressed('Shift')) {
             mode = 'select';
             overlayService.setStyles(overlayId, OVERLAY_STYLES.SELECT_ADD);
@@ -64,7 +64,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'select') return;
         if (pixel) {
-            const id = layerQuery.topVisibleAt(pixel);
+            const id = layerQuery.uppermostAt(pixel, true);
             if (id && nodes.locked(id)) {
                 tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
                 return;
@@ -76,7 +76,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         if (tool.current !== 'select') return;
         const intersectedIds = [];
         for (const pixel of pixels) {
-            const id = layerQuery.topVisibleAt(pixel);
+            const id = layerQuery.uppermostAt(pixel, true);
             if (id === null) continue;
             if (!nodes.locked(id)) intersectedIds.push(id);
         }
@@ -93,7 +93,7 @@ export const useSelectToolService = defineStore('selectToolService', () => {
         if (pixels.length > 0) {
             const intersectedIds = new Set();
             for (const pixel of pixels) {
-                const id = layerQuery.topVisibleAt(pixel);
+                const id = layerQuery.uppermostAt(pixel, true);
                 if (id !== null && !nodes.locked(id)) intersectedIds.add(id);
             }
             const currentSelection = new Set(mode === 'select' ? [] : nodeTree.selectedLayerIds);
@@ -153,7 +153,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         overlayService.setPixels(currentOverlayId, pixel != null ? [pixel] : []);
         overlayService.setPixels(prevOverlayId, pixel != null && prevPixel != null ? [prevPixel] : []);
         if (pixel == null) return;
-        const target = layerQuery.topVisibleAt(pixel);
+        const target = layerQuery.uppermostAt(pixel, true);
         const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
         if (target != null && editable) {
             if (nodes.locked(target)) {
@@ -182,7 +182,7 @@ export const useOrientationToolService = defineStore('orientationToolService', (
         if (tool.current !== 'orientation') return;
         if (pixels.length === 1) {
             const pixel = pixels[0];
-            const target = layerQuery.topVisibleAt(pixel);
+            const target = layerQuery.uppermostAt(pixel, true);
             const editable = nodeTree.selectedLayerIds.length === 0 || nodeTree.selectedLayerIds.includes(target);
             if (target != null && editable && !nodes.locked(target)) {
                 const current = pixelStore.orientationOf(target, pixel);

--- a/src/services/singleLayerTools.js
+++ b/src/services/singleLayerTools.js
@@ -192,7 +192,7 @@ export const useTopToolService = defineStore('topToolService', () => {
             overlayService.clear(overlayId);
             return;
         }
-        const id = layerQuery.topVisibleAt(pixel);
+        const id = layerQuery.uppermostAt(pixel, true);
         if (id && nodes.locked(id)) {
             overlayService.setLayers(overlayId, [id]);
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });
@@ -204,7 +204,7 @@ export const useTopToolService = defineStore('topToolService', () => {
     });
     watch(() => tool.dragPixel, (pixel) => {
         if (tool.current !== 'top' || !pixel) return;
-        const id = layerQuery.topVisibleAt(pixel);
+        const id = layerQuery.uppermostAt(pixel, true);
         if (!id) return;
         if (nodes.locked(id)) {
             tool.setCursor({ stroke: CURSOR_STYLE.LOCKED, rect: CURSOR_STYLE.LOCKED });


### PR DESCRIPTION
## Summary
- Rename layerQuery `topVisibleAt` to `uppermostAt` with optional hidden-layer filtering
- Update consumers to use new `filterHidden` flag
- Merge now copies pixel orientations from the highest selected layer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c27c490894832ca0b2e769bb07cbb9