### PR TITLE
Add download option to export panel

### DIFF
--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -11,43 +11,37 @@
       <!-- 원본 -->
         <img v-show="viewportStore.display!=='original'" class="w-44 h-44 object-contain rounded-md border border-white/15" :src="viewportStore.imageSrc" alt="source image"/>
     </div>
-    <div class="flex-1 min-w-0 flex flex-col gap-2">
-      <div class="flex gap-2 items-center">
-        <select v-model="type" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-slate-950">
-          <option value="json">JSON</option>
-          <option value="svg">SVG</option>
-        </select>
-        <button @click="generate" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">새로고침</button>
-        <button @click="copy" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">복사</button>
-      </div>
-      <textarea readonly v-model="text" class="w-full h-28 resize-y rounded-md border border-white/15 bg-slate-950 text-sky-100 p-2 text-sm"></textarea>
+    <div class="flex-1 min-w-0 flex gap-2 items-center">
+      <select v-model="type" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-slate-950">
+        <option value="json">JSON</option>
+        <option value="svg">SVG</option>
+      </select>
+      <button @click="download" class="px-2 py-1 text-xs rounded-md border border-white/15 bg-white/5 hover:bg-white/10">다운로드</button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref } from 'vue';
 import { useStore } from '../stores';
 import { rgbaCssU32 } from '../utils';
 import { checkerboardPatternUrl } from '../utils/pixels.js';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();
-const text = ref('');
 const type = ref('json');
 
 const patternUrl = checkerboardPatternUrl();
 
-function generate() {
-    text.value = type.value === 'json' ? output.exportToJSON() : output.exportToSVG();
+function download() {
+    const content = type.value === 'json' ? output.exportToJSON() : output.exportToSVG();
+    const blob = new Blob([content], { type: type.value === 'json' ? 'application/json' : 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `pixel-edit.${type.value}`;
+    a.click();
+    URL.revokeObjectURL(url);
 }
-async function copy() {
-    if (!text.value) generate();
-    try {
-        await navigator.clipboard.writeText(text.value);
-    } catch {}
-}
-
-onMounted(generate);
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- replace refresh and copy actions with a single download button in export panel
- remove unused textarea and related logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c28af5e4a8832ca36800c576b7f376