### PR TITLE
Use hex colors for SVG output

### DIFF
--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="viewportStore.display!=='result'" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="hexCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->
@@ -24,7 +24,7 @@
 <script setup>
 import { ref } from 'vue';
 import { useStore } from '../stores';
-import { rgbaCssU32 } from '../utils';
+import { hexCssU32 } from '../utils';
 import { checkerboardPatternUrl } from '../utils/pixels.js';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -6,7 +6,7 @@
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOf(child.id)" :fill="rgbaCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOf(child.id)" :fill="hexCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <div class="min-w-0 flex-1 relative overflow-hidden fade-mask">
@@ -36,7 +36,7 @@
         <div v-if="item.depth===0" @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path :d="pixelStore.pathOf(item.id)" :fill="rgbaCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path :d="pixelStore.pathOf(item.id)" :fill="hexCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <!-- 색상 -->
@@ -81,7 +81,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, onUnmounted } from 'vue';
 import { useStore } from '../stores';
-import { rgbaCssU32, rgbaToHexU32, hexToRgbaU32 } from '../utils';
+import { hexCssU32, rgbaToHexU32, hexToRgbaU32 } from '../utils';
 import { checkerboardPatternUrl, getPixelUnion } from '../utils/pixels.js';
 import blockIcons from '../image/layer_block';
 

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -23,7 +23,7 @@
       <!-- 결과 레이어 -->
         <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
           <g>
-              <path v-for="id in nodeTree.layerIdsBottomToTop" :key="'pix-'+id" :d="preview.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaCssU32(preview.nodeColor(id))" :visibility="preview.nodeVisibility(id)?'visible':'hidden'"></path>
+              <path v-for="id in nodeTree.layerIdsBottomToTop" :key="'pix-'+id" :d="preview.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="hexCssU32(preview.nodeColor(id))" :visibility="preview.nodeVisibility(id)?'visible':'hidden'"></path>
           </g>
         </svg>
       <!-- 그리드 -->
@@ -68,7 +68,7 @@ import { useTemplateRef, computed, onMounted, onUnmounted } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
 import { OVERLAY_STYLES, GRID_STROKE_COLOR } from '@/constants';
-import { rgbaCssU32 } from '../utils';
+import { hexCssU32 } from '../utils';
 import { checkerboardPatternUrl } from '../utils/pixels.js';
 
 const { viewport: viewportStore, nodeTree, preview, viewportEvent: viewportEvents } = useStore();

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { nextTick, watch } from 'vue';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
-import { rgbaCssU32 } from '../utils';
+import { hexCssU32 } from '../utils';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -113,7 +113,7 @@ export const useOutputStore = defineStore('output', {
                         result += `<g${attrStr ? ' ' + attrStr : ''}${visibility}>${children}</g>`;
                     } else {
                         const path = pixels.pathOf(node.id);
-                        const fill = rgbaCssU32(props.color);
+                        const fill = hexCssU32(props.color);
                         result += `<path d="${path}" fill="${fill}" fill-rule="evenodd" shape-rendering="crispEdges"${attrStr ? ' ' + attrStr : ''}${visibility}/>`;
                     }
                 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -123,3 +123,8 @@ export function rgbaToHexU32(packedColor) {
     } = unpackRGBA(packedColor);
     return '#' + [r, g, b].map(value => value.toString(16).padStart(2, '0')).join('');
 }
+
+export function hexCssU32(packedColor) {
+    const { r, g, b, a } = unpackRGBA(packedColor);
+    return '#' + [r, g, b, a].map(value => value.toString(16).padStart(2, '0')).join('');
+}


### PR DESCRIPTION
## Summary
- add `hexCssU32` helper to emit `#RRGGBBAA` strings
- use hex colors in SVG fills for viewport, layers panel, export preview, and export output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c28ddac43c832c9a64bc128bbc1828