### PR TITLE
Use opacity attribute for SVG colors

### DIFF
--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -5,7 +5,7 @@
       <svg v-show="viewportStore.display!=='result'" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-44 h-44 rounded-md border border-white/15">
         <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
         <g>
-            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="hexCssU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
+            <path v-for="props in nodes.getProperties(nodeTree.layerIdsBottomToTop)" :key="'pix-'+props.id" :d="pixelStore.pathOf(props.id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaToHexU32(props.color)" :opacity="alphaU32(props.color)" :visibility="props.visibility?'visible':'hidden'"></path>
         </g>
       </svg>
       <!-- 원본 -->
@@ -24,7 +24,7 @@
 <script setup>
 import { ref } from 'vue';
 import { useStore } from '../stores';
-import { hexCssU32 } from '../utils';
+import { rgbaToHexU32, alphaU32 } from '../utils';
 import { checkerboardPatternUrl } from '../utils/pixels.js';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, output } = useStore();

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -6,7 +6,7 @@
         <div class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden" title="그룹 미리보기">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOf(child.id)" :fill="hexCssU32(child.color)" :opacity="child.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path v-for="child in descendantProps(item.id)" :key="child.id" :d="pixelStore.pathOf(child.id)" :fill="rgbaToHexU32(child.color)" :opacity="alphaU32(child.color) * (child.visibility?1:0.3)" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <div class="min-w-0 flex-1 relative overflow-hidden fade-mask">
@@ -36,7 +36,7 @@
         <div v-if="item.depth===0" @click.stop="onThumbnailClick(item.id)" class="w-16 h-16 rounded-md border border-white/15 bg-slate-950 overflow-hidden cursor-pointer" title="같은 색상의 모든 레이어 선택">
           <svg :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet" class="w-full h-full">
             <rect x="0" y="0" :width="viewportStore.stage.width" :height="viewportStore.stage.height" :fill="patternUrl"/>
-            <path :d="pixelStore.pathOf(item.id)" :fill="hexCssU32(item.props.color)" :opacity="item.props.visibility?1:0.3" fill-rule="evenodd" shape-rendering="crispEdges"/>
+            <path :d="pixelStore.pathOf(item.id)" :fill="rgbaToHexU32(item.props.color)" :opacity="alphaU32(item.props.color) * (item.props.visibility?1:0.3)" fill-rule="evenodd" shape-rendering="crispEdges"/>
           </svg>
         </div>
         <!-- 색상 -->
@@ -81,7 +81,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, onUnmounted } from 'vue';
 import { useStore } from '../stores';
-import { hexCssU32, rgbaToHexU32, hexToRgbaU32 } from '../utils';
+import { rgbaToHexU32, hexToRgbaU32, alphaU32 } from '../utils';
 import { checkerboardPatternUrl, getPixelUnion } from '../utils/pixels.js';
 import blockIcons from '../image/layer_block';
 

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -23,7 +23,7 @@
       <!-- 결과 레이어 -->
         <svg v-show="viewportStore.display==='result'" class="absolute w-full h-full top-0 left-0 pointer-events-none block" :viewBox="viewportStore.viewBox" preserveAspectRatio="xMidYMid meet">
           <g>
-              <path v-for="id in nodeTree.layerIdsBottomToTop" :key="'pix-'+id" :d="preview.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="hexCssU32(preview.nodeColor(id))" :visibility="preview.nodeVisibility(id)?'visible':'hidden'"></path>
+              <path v-for="id in nodeTree.layerIdsBottomToTop" :key="'pix-'+id" :d="preview.pathOf(id)" fill-rule="evenodd" shape-rendering="crispEdges" :fill="rgbaToHexU32(preview.nodeColor(id))" :opacity="alphaU32(preview.nodeColor(id))" :visibility="preview.nodeVisibility(id)?'visible':'hidden'"></path>
           </g>
         </svg>
       <!-- 그리드 -->
@@ -68,7 +68,7 @@ import { useTemplateRef, computed, onMounted, onUnmounted } from 'vue';
 import { useStore } from '../stores';
 import { useService } from '../services';
 import { OVERLAY_STYLES, GRID_STROKE_COLOR } from '@/constants';
-import { hexCssU32 } from '../utils';
+import { rgbaToHexU32, alphaU32 } from '../utils';
 import { checkerboardPatternUrl } from '../utils/pixels.js';
 
 const { viewport: viewportStore, nodeTree, preview, viewportEvent: viewportEvents } = useStore();

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { nextTick, watch } from 'vue';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
-import { hexCssU32 } from '../utils';
+import { rgbaToHexU32, alphaU32 } from '../utils';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -113,8 +113,9 @@ export const useOutputStore = defineStore('output', {
                         result += `<g${attrStr ? ' ' + attrStr : ''}${visibility}>${children}</g>`;
                     } else {
                         const path = pixels.pathOf(node.id);
-                        const fill = hexCssU32(props.color);
-                        result += `<path d="${path}" fill="${fill}" fill-rule="evenodd" shape-rendering="crispEdges"${attrStr ? ' ' + attrStr : ''}${visibility}/>`;
+                        const fill = rgbaToHexU32(props.color);
+                        const opacity = alphaU32(props.color);
+                        result += `<path d="${path}" fill="${fill}" opacity="${opacity}" fill-rule="evenodd" shape-rendering="crispEdges"${attrStr ? ' ' + attrStr : ''}${visibility}/>`;
                     }
                 }
                 return result;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -124,7 +124,4 @@ export function rgbaToHexU32(packedColor) {
     return '#' + [r, g, b].map(value => value.toString(16).padStart(2, '0')).join('');
 }
 
-export function hexCssU32(packedColor) {
-    const { r, g, b, a } = unpackRGBA(packedColor);
-    return '#' + [r, g, b, a].map(value => value.toString(16).padStart(2, '0')).join('');
-}
+export const alphaU32 = (packedColor) => ((packedColor >>> 24) & 255) / 255;


### PR DESCRIPTION
## Summary
- avoid 8-digit hex colors by removing embedded alpha channel
- apply opacity attribute when rendering or exporting SVG paths
- add alphaU32 util to extract opacity from packed RGBA values

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c292fe8f18832cb2ee56bcd6207ac3