### PR TITLE
Fix corner handling in SVG export

### DIFF
--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -137,22 +137,22 @@ export const useOutputStore = defineStore('output', {
                         result += `<g id="${sanitizeId(props.name)}" ${attrStr}>${children}</g>`;
                     } else {
                         let path = pixels.pathOf(node.id);
-                        const attrs = props.attributes || {};
-                        if (attrs.tl || attrs.tr || attrs.bl || attrs.br) {
+                        // temp corner removal
+                        if (attributes.tl || attributes.tr || attributes.bl || attributes.br) {
                             const removals = [];
-                            for (const idx of attrs.tl || []) {
+                            for (const idx of attributes.tl || []) {
                                 const [x, y] = indexToCoord(idx);
                                 removals.push([x + 1, y + 1]);
                             }
-                            for (const idx of attrs.tr || []) {
+                            for (const idx of attributes.tr || []) {
                                 const [x, y] = indexToCoord(idx);
                                 removals.push([x, y + 1]);
                             }
-                            for (const idx of attrs.bl || []) {
+                            for (const idx of attributes.bl || []) {
                                 const [x, y] = indexToCoord(idx);
                                 removals.push([x + 1, y]);
                             }
-                            for (const idx of attrs.br || []) {
+                            for (const idx of attributes.br || []) {
                                 const [x, y] = indexToCoord(idx);
                                 removals.push([x, y]);
                             }
@@ -162,8 +162,8 @@ export const useOutputStore = defineStore('output', {
                             }
                             path = path.replace(/(^|Z)\s*L/g, '$1 M').trim().replace(/\s+/g, ' ');
                         }
-                        const fill = rgbaToHexU32(props.color);
-                        const opacity = alphaU32(props.color);
+
+                        // temp orientation satin rung
                         const map = pixels.get(node.id) || new Map();
                         const overflow = 0.01;
                         const segments = [];
@@ -184,6 +184,9 @@ export const useOutputStore = defineStore('output', {
                         for (const segment of segments) {
                             orientationPaths += `<path d="${segment}" stroke="#000" stroke-width="0.02" fill="none"/>`;
                         }
+                        
+                        const fill = rgbaToHexU32(props.color);
+                        const opacity = alphaU32(props.color);
                         result += `<g id="${sanitizeId(props.name)}"><path d="${path}" fill="${fill}" opacity="${opacity}" ${attrStr} fill-rule="evenodd" shape-rendering="crispEdges"/>${orientationPaths}</g>`;
                     }
                 }


### PR DESCRIPTION
## Summary
- strip moves to opposite corners when layer includes corner attributes (tl, tr, bl, br) during SVG export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c38d42b3e8832ca885b01f0d195538