### PR TITLE
feat: add multi-layer move tool

### DIFF
--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -4,6 +4,7 @@ import draw from './draw.svg';
 import erase from './erase.svg';
 import cut from './cut.svg';
 import select from './select.svg';
+import move from './move.svg';
 import globalErase from './global_erase.svg';
 import top from './top.svg';
 import resize from './resize.svg';
@@ -25,6 +26,7 @@ export default {
   erase,
   cut,
   select,
+  move,
   globalErase,
   top,
   path,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -6,7 +6,7 @@ import { useNodeQueryService } from './nodeQuery';
 import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
-import { useSelectToolService, useOrientationToolService, useGlobalEraseToolService } from './multiLayerTools';
+import { useSelectToolService, useMoveToolService, useOrientationToolService, useGlobalEraseToolService } from './multiLayerTools';
 import { usePathToolService, useRelayToolService, useExpandToolService, useBorderToolService, useMarginToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
@@ -23,6 +23,7 @@ export {
     useLayerQueryService,
     useNodeQueryService,
     useSelectToolService,
+    useMoveToolService,
     useDrawToolService,
     useEraseToolService,
     useTopToolService,
@@ -57,6 +58,7 @@ export const useService = () => {
     const margin = useMarginToolService();
 
     const select = useSelectToolService();
+    const move = useMoveToolService();
     const globalErase = useGlobalEraseToolService();
     const orientation = useOrientationToolService();
 
@@ -83,6 +85,7 @@ export const useService = () => {
             border,
             margin,
             select,
+            move,
             globalErase,
             orientation,
         },

--- a/src/services/shortcut.js
+++ b/src/services/shortcut.js
@@ -8,6 +8,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useClipboardService } from './clipboard';
 import { usePathToolService } from './wandTools';
+import { useMoveToolService } from './multiLayerTools';
 import { TOOL_MODIFIERS } from '@/constants';
 
 export const useShortcutService = defineStore('shortcutService', () => {
@@ -19,6 +20,7 @@ export const useShortcutService = defineStore('shortcutService', () => {
     const toolbar = useToolbarStore();
     const clipboard = useClipboardService();
     const pathToolService = usePathToolService();
+    const moveTool = useMoveToolService();
 
     function deleteSelection() {
         if (!nodeTree.selectedNodeCount) return;
@@ -105,11 +107,31 @@ export const useShortcutService = defineStore('shortcutService', () => {
                 }
                 case 'ArrowUp':
                     e.preventDefault();
-                    layerPanel.onArrowUp(shift, ctrl);
+                    if (toolSelectionService.current === 'move') {
+                        moveTool.shift(0, -1);
+                    } else {
+                        layerPanel.onArrowUp(shift, ctrl);
+                    }
                     break;
                 case 'ArrowDown':
                     e.preventDefault();
-                    layerPanel.onArrowDown(shift, ctrl);
+                    if (toolSelectionService.current === 'move') {
+                        moveTool.shift(0, 1);
+                    } else {
+                        layerPanel.onArrowDown(shift, ctrl);
+                    }
+                    break;
+                case 'ArrowLeft':
+                    if (toolSelectionService.current === 'move') {
+                        e.preventDefault();
+                        moveTool.shift(-1, 0);
+                    }
+                    break;
+                case 'ArrowRight':
+                    if (toolSelectionService.current === 'move') {
+                        e.preventDefault();
+                        moveTool.shift(1, 0);
+                    }
                     break;
                 case 'Delete':
                 case 'Backspace':


### PR DESCRIPTION
## Summary
- add move tool for multi-layer operations
- allow arrow keys to shift selected pixels, disabling layer navigation
- include move icon and register service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a3b977a0832ca1ef166e82026bed