### PR TITLE
Refactor overlay service and add move tool overlays

### DIFF
--- a/src/services/overlay.js
+++ b/src/services/overlay.js
@@ -63,13 +63,25 @@ export const useOverlayService = defineStore('overlayService', () => {
         return { id: Number(id), pixels, path: pixelsToUnionPath(pixels), styles: styles[id] };
     }
 
-    const selectionId = createOverlay(OVERLAY_STYLES.SELECTED);
+    const targetId = createOverlay(OVERLAY_STYLES.SELECTED);
 
-    function rebuildSelection() {
-        setLayers(selectionId, nodeTree.selectedLayerIds);
+    function rebuildTarget() {
+        setLayers(targetId, nodeTree.selectedLayerIds);
     }
 
-    watch(() => nodeTree.selectedLayerIds.slice(), rebuildSelection, { immediate: true });
+    function setTargetPixels(pixels) {
+        setPixels(targetId, pixels);
+    }
+
+    function setTargetLayers(ids) {
+        setLayers(targetId, ids);
+    }
+
+    function clearTarget() {
+        clear(targetId);
+    }
+
+    watch(() => nodeTree.selectedLayerIds.slice(), rebuildTarget, { immediate: true });
 
     return {
         overlayPixels,
@@ -84,6 +96,9 @@ export const useOverlayService = defineStore('overlayService', () => {
         setPixels,
         setStyles,
         getOverlay,
+        setTargetPixels,
+        setTargetLayers,
+        clearTarget,
     };
 });
 


### PR DESCRIPTION
## Summary
- refactor selection overlay into reusable target pixel overlay
- use a dedicated green overlay for move tool hover and preview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ac2d1c50832cae07c16be90eedfd