### PR TITLE
feat: add unify wand tool

### DIFF
--- a/src/constants/toolbar.js
+++ b/src/constants/toolbar.js
@@ -6,6 +6,7 @@ export const WAND_TOOLS = [
     { type: 'expand', name: 'Expand', icon: stageIcons.expand },
     { type: 'border', name: 'Border', icon: stageIcons.border },
     { type: 'margin', name: 'Margin', icon: stageIcons.margin },
+    { type: 'unify', name: 'Unify', icon: stageIcons.unify },
 ];
 
 export const TOOL_MODIFIERS = {

--- a/src/image/stage_toolbar/index.js
+++ b/src/image/stage_toolbar/index.js
@@ -16,6 +16,7 @@ import relay from './relay.svg';
 import border from './border.svg';
 import expand from './expand.svg';
 import margin from './margin.svg';
+import unify from './unify.svg';
 import settings from './settings.svg';
 import wand from './wand.svg';
 
@@ -34,6 +35,7 @@ export default {
   relay,
   border,
   margin,
+  unify,
   expand,
   wand,
   resize,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -7,7 +7,7 @@ import { useToolSelectionService } from './toolSelection';
 import { useToolbarStore } from '../stores/toolbar';
 import { useDrawToolService, useEraseToolService, useTopToolService, useCutToolService } from './singleLayerTools';
 import { useSelectToolService, useMoveToolService, useOrientationToolService, useGlobalEraseToolService } from './multiLayerTools';
-import { usePathToolService, useRelayToolService, useExpandToolService, useBorderToolService, useMarginToolService } from './wandTools';
+import { usePathToolService, useRelayToolService, useExpandToolService, useBorderToolService, useMarginToolService, useUnifyToolService } from './wandTools';
 import { useViewportService } from './viewport';
 import { useStageResizeService } from './stageResize';
 import { useHamiltonianService } from './hamiltonian';
@@ -33,6 +33,7 @@ export {
     useExpandToolService,
     useBorderToolService,
     useMarginToolService,
+    useUnifyToolService,
     useGlobalEraseToolService,
     useCutToolService,
     useToolSelectionService,
@@ -56,6 +57,7 @@ export const useService = () => {
     const expand = useExpandToolService();
     const border = useBorderToolService();
     const margin = useMarginToolService();
+    const unify = useUnifyToolService();
 
     const select = useSelectToolService();
     const move = useMoveToolService();
@@ -84,6 +86,7 @@ export const useService = () => {
             expand,
             border,
             margin,
+            unify,
             select,
             move,
             globalErase,


### PR DESCRIPTION
## Summary
- add `unify` wand operation to remove lower overlapping pixels
- register unify tool and icon in toolbar and services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c81df58ba4832cae3b6d6a0c1822ca