### PR TITLE
Add layer orientation popup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@
     <StageResizePopup />
     <ImageLoadPopup />
     <SettingsPopup />
+    <LayerOrientationPopup />
     <ContextMenu />
 </template>
 
@@ -49,6 +50,7 @@ import StageResizePopup from './components/StageResizePopup.vue';
 import ImageLoadPopup from './components/ImageLoadPopup.vue';
 import SettingsPopup from './components/SettingsPopup.vue';
 import ContextMenu from './components/ContextMenu.vue';
+import LayerOrientationPopup from './components/LayerOrientationPopup.vue';
 const { input } = useStore();
 const { imageLoad: imageLoadService } = useService();
 

--- a/src/components/LayerOrientationPopup.vue
+++ b/src/components/LayerOrientationPopup.vue
@@ -1,0 +1,33 @@
+<template>
+  <div v-if="layerOrientation.show" class="fixed inset-0 flex items-center justify-center bg-black/50 layer-orientation-popup">
+    <div class="bg-slate-800 p-6 rounded-lg text-xs w-60 space-y-4">
+      <label class="block text-white/70">
+        <span>Orientation</span>
+        <select v-model="layerOrientation.orientation" class="mt-1 w-full rounded bg-slate-700 px-2 py-1">
+          <option v-for="ori in orientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
+        </select>
+      </label>
+      <div v-if="layerOrientation.orientation === 'checkerboard'" class="flex gap-2">
+        <select v-model="layerOrientation.cbOriA" class="flex-1 rounded bg-slate-700 px-2 py-1">
+          <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
+        </select>
+        <select v-model="layerOrientation.cbOriB" class="flex-1 rounded bg-slate-700 px-2 py-1">
+          <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
+        </select>
+      </div>
+      <div class="flex justify-end gap-2">
+        <button @click="layerOrientation.close" class="px-2 py-1 rounded bg-white/5 hover:bg-white/10">Cancel</button>
+        <button @click="layerOrientation.apply" class="px-2 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white">Apply</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { PIXEL_DEFAULT_ORIENTATIONS, ORIENTATION_LABELS, PIXEL_ORIENTATIONS } from '@/constants/orientation.js';
+import { useService } from '../services';
+
+const { layerOrientation } = useService();
+const orientations = PIXEL_DEFAULT_ORIENTATIONS;
+const pixelOrientations = PIXEL_ORIENTATIONS;
+</script>

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -89,7 +89,7 @@ import { useService } from '../services';
 import { useContextMenuStore } from '../stores/contextMenu';
 
 const { viewport: viewportStore, nodeTree, nodes, pixels: pixelStore, preview } = useStore();
-const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc, clipboard } = useService();
+const { layerPanel, layerQuery, nodeQuery, viewport, stageResize: stageResizeService, layerTool: layerSvc, clipboard, layerOrientation } = useService();
 const contextMenu = useContextMenuStore();
 
 const dragging = ref(false);
@@ -303,6 +303,14 @@ function onContextMenu(item, event) {
             }
         },
         {
+            label: 'Set Orientation',
+            disabled: nodeTree.selectedLayerCount === 0,
+            action: () => {
+                if (nodeTree.selectedLayerCount === 0) return;
+                layerOrientation.open();
+            }
+        },
+        {
             label: 'Flip Order',
             disabled: !flipEnabled,
             action: () => {
@@ -403,8 +411,9 @@ function handleGlobalPointerDown(event) {
     const isStage = stageEl && stageEl.contains(target);
     const isLayers = listElement.value && listElement.value.contains(target);
     const isButton = !!target.closest('button');
+    const isOrientationPopup = layerOrientation.show && !!target.closest('.layer-orientation-popup');
     const isContextMenu = contextMenu.visible;
-    if (isLayers || isButton) return;
+    if (isLayers || isButton || isOrientationPopup) return;
     if (isViewport && !isStage) {
         let moved = false;
         const pid = event.pointerId;
@@ -418,7 +427,7 @@ function handleGlobalPointerDown(event) {
         window.addEventListener('pointerup', onUp, { capture: true, once: true });
         return;
     }
-    if (!isViewport && !isStage && !isLayers && !isButton && !isContextMenu)
+    if (!isViewport && !isStage && !isLayers && !isButton && !isContextMenu && !isOrientationPopup)
         nodeTree.clearSelection();
 }
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -15,6 +15,7 @@ import { useImageLoadService } from './imageLoad';
 import { useSettingsService } from './settings';
 import { useShortcutService } from './shortcut';
 import { useClipboardService } from './clipboard';
+import { useLayerOrientationService } from './layerOrientation';
 
 export {
     useLayerPanelService,
@@ -43,7 +44,8 @@ export {
     useImageLoadService,
     useSettingsService,
     useShortcutService,
-    useClipboardService
+    useClipboardService,
+    useLayerOrientationService
 };
 
 export const useService = () => {
@@ -99,5 +101,6 @@ export const useService = () => {
         settings: useSettingsService(),
         shortcut: useShortcutService(),
         clipboard: useClipboardService(),
+        layerOrientation: useLayerOrientationService(),
     };
 };

--- a/src/services/layerOrientation.js
+++ b/src/services/layerOrientation.js
@@ -1,0 +1,39 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useStore } from '../stores';
+import { OT } from '@/constants/orientation.js';
+
+export const useLayerOrientationService = defineStore('layerOrientationService', () => {
+  const { nodeTree, pixels } = useStore();
+  const show = ref(false);
+  const orientation = ref(OT.NONE);
+  const cbOriA = ref(pixels.checkerboardOrientations[0]);
+  const cbOriB = ref(pixels.checkerboardOrientations[1]);
+
+  function open(initial = OT.NONE) {
+    orientation.value = initial;
+    [cbOriA.value, cbOriB.value] = pixels.checkerboardOrientations;
+    show.value = true;
+  }
+
+  function close() {
+    show.value = false;
+  }
+
+  function apply() {
+    const ori = orientation.value;
+    if (ori === 'checkerboard') {
+      pixels.setCheckerboardOrientations(cbOriA.value, cbOriB.value);
+    }
+    const ids = nodeTree.selectedLayerIds;
+    for (const id of ids) {
+      const map = pixels.get(id);
+      if (map) {
+        pixels.override(id, map.keys(), ori);
+      }
+    }
+    close();
+  }
+
+  return { show, orientation, cbOriA, cbOriB, open, close, apply };
+});


### PR DESCRIPTION
## Summary
- add context-menu option to set orientation for selected layers
- implement LayerOrientationPopup component and service
- register orientation service and integrate popup into app
- preserve layer selection when using orientation popup and support checkerboard orientation choices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c82177f774832c8250c855e96b50ec