### PR TITLE
Add star pixel orientation and export star paths

### DIFF
--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -5,6 +5,7 @@ export const OT = Object.freeze({
   DOWNSLOPE: 3,
   VERTICAL: 4,
   UPSLOPE: 5,
+  STAR: 6,
 });
 
 export const PIXEL_ORIENTATIONS = Object.values(OT).filter(o => o !== OT.DEFAULT);
@@ -16,5 +17,6 @@ export const ORIENTATION_LABELS = {
   [OT.DOWNSLOPE]: 'downslope',
   [OT.VERTICAL]: 'vertical',
   [OT.UPSLOPE]: 'upslope',
+  [OT.STAR]: 'star',
   checkerboard: 'checkerboard'
 };

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -3,7 +3,7 @@ import { nextTick, watch } from 'vue';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
 import { rgbaToHexU32, alphaU32 } from '../utils';
-import { indexToCoord } from '../utils/pixels.js';
+import { indexToCoord, buildStarPath } from '../utils/pixels.js';
 import { OT } from '../constants/orientation.js';
 
 export const useOutputStore = defineStore('output', {
@@ -126,6 +126,7 @@ export const useOutputStore = defineStore('output', {
         exportToSVG() {
             const { nodeTree, nodes, pixels, viewport } = useStore();
             const sanitizeId = (name) => String(name).replace(/[^A-Za-z0-9_-]/g, '_');
+            const orientationEndpoints = new Map();
             const serialize = (tree) => {
                 let result = '';
                 for (const node of tree) {
@@ -170,19 +171,58 @@ export const useOutputStore = defineStore('output', {
                         for (const [idx, ori] of map) {
                             if (ori === OT.NONE) continue;
                             const [x, y] = indexToCoord(idx);
-                            if (ori === OT.VERTICAL) {
-                                segments.push(`M ${x - overflow} ${y + 0.5} L ${x + 1 + overflow} ${y + 0.5}`);
-                            } else if (ori === OT.HORIZONTAL) {
-                                segments.push(`M ${x + 0.5} ${y - overflow} L ${x + 0.5} ${y + 1 + overflow}`);
-                            } else if (ori === OT.DOWNSLOPE) {
-                                segments.push(`M ${x - overflow} ${y + 1 + overflow} L ${x + 1 + overflow} ${y - overflow}`);
-                            } else if (ori === OT.UPSLOPE) {
-                                segments.push(`M ${x - overflow} ${y - overflow} L ${x + 1 + overflow} ${y + 1 + overflow}`);
+                            if (ori === OT.STAR) {
+                                const corners = [
+                                    [x, y],
+                                    [x + 1, y],
+                                    [x + 1, y + 1],
+                                    [x, y + 1]
+                                ];
+                                const prevEnd = orientationEndpoints.get(idx);
+                                let startCornerIndex = 0;
+                                if (prevEnd) {
+                                    let minDist = Infinity;
+                                    for (let i = 0; i < corners.length; i++) {
+                                        const [cx, cy] = corners[i];
+                                        const dx = prevEnd[0] - cx;
+                                        const dy = prevEnd[1] - cy;
+                                        const dist = dx * dx + dy * dy;
+                                        if (dist < minDist) {
+                                            minDist = dist;
+                                            startCornerIndex = i;
+                                        }
+                                    }
+                                }
+                                const d = buildStarPath(x, y, 1, startCornerIndex);
+                                if (d) {
+                                    segments.push({ d });
+                                    orientationEndpoints.set(idx, corners[startCornerIndex]);
+                                }
+                            } else {
+                                let start;
+                                let end;
+                                if (ori === OT.VERTICAL) {
+                                    start = [x - overflow, y + 0.5];
+                                    end = [x + 1 + overflow, y + 0.5];
+                                } else if (ori === OT.HORIZONTAL) {
+                                    start = [x + 0.5, y - overflow];
+                                    end = [x + 0.5, y + 1 + overflow];
+                                } else if (ori === OT.DOWNSLOPE) {
+                                    start = [x - overflow, y + 1 + overflow];
+                                    end = [x + 1 + overflow, y - overflow];
+                                } else if (ori === OT.UPSLOPE) {
+                                    start = [x - overflow, y - overflow];
+                                    end = [x + 1 + overflow, y + 1 + overflow];
+                                } else {
+                                    continue;
+                                }
+                                segments.push({ d: `M ${start[0]} ${start[1]} L ${end[0]} ${end[1]}` });
+                                orientationEndpoints.set(idx, end);
                             }
                         }
                         let orientationPaths = '';
-                        for (const segment of segments) {
-                            orientationPaths += `<path d="${segment}" stroke="#000" stroke-width="0.02" fill="none"/>`;
+                        for (const { d } of segments) {
+                            orientationPaths += `<path d="${d}" stroke="#000" stroke-width="0.02" fill="none"/>`;
                         }
                         
                         const fill = rgbaToHexU32(props.color);


### PR DESCRIPTION
## Summary
- add a STAR option to the pixel orientation constants and labels
- draw a star-shaped orientation pattern for overlays using reusable path helper
- export star orientation pixels as four-triangle paths that start near the previous layer’s path endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99b468ba0832c907d3b01cc19bcbb