### PR TITLE
Refine star orientation export start and coloring

### DIFF
--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -5,6 +5,7 @@ export const OT = Object.freeze({
   DOWNSLOPE: 3,
   VERTICAL: 4,
   UPSLOPE: 5,
+  STAR: 6,
 });
 
 export const PIXEL_ORIENTATIONS = Object.values(OT).filter(o => o !== OT.DEFAULT);
@@ -16,5 +17,6 @@ export const ORIENTATION_LABELS = {
   [OT.DOWNSLOPE]: 'downslope',
   [OT.VERTICAL]: 'vertical',
   [OT.UPSLOPE]: 'upslope',
+  [OT.STAR]: 'star',
   checkerboard: 'checkerboard'
 };

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -3,7 +3,7 @@ import { nextTick, watch } from 'vue';
 import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
 import { rgbaToHexU32, alphaU32 } from '../utils';
-import { indexToCoord } from '../utils/pixels.js';
+import { indexToCoord, buildStarPath } from '../utils/pixels.js';
 import { OT } from '../constants/orientation.js';
 
 export const useOutputStore = defineStore('output', {
@@ -126,6 +126,7 @@ export const useOutputStore = defineStore('output', {
         exportToSVG() {
             const { nodeTree, nodes, pixels, viewport } = useStore();
             const sanitizeId = (name) => String(name).replace(/[^A-Za-z0-9_-]/g, '_');
+            const orientationEndpoints = new Map();
             const serialize = (tree) => {
                 let result = '';
                 for (const node of tree) {
@@ -163,6 +164,9 @@ export const useOutputStore = defineStore('output', {
                             path = path.replace(/(^|Z)\s*L/g, '$1 M').trim().replace(/\s+/g, ' ');
                         }
 
+                        const fill = rgbaToHexU32(props.color);
+                        const opacity = alphaU32(props.color);
+
                         // temp orientation satin rung
                         const map = pixels.get(node.id) || new Map();
                         const overflow = 0.025;
@@ -170,23 +174,62 @@ export const useOutputStore = defineStore('output', {
                         for (const [idx, ori] of map) {
                             if (ori === OT.NONE) continue;
                             const [x, y] = indexToCoord(idx);
-                            if (ori === OT.VERTICAL) {
-                                segments.push(`M ${x - overflow} ${y + 0.5} L ${x + 1 + overflow} ${y + 0.5}`);
-                            } else if (ori === OT.HORIZONTAL) {
-                                segments.push(`M ${x + 0.5} ${y - overflow} L ${x + 0.5} ${y + 1 + overflow}`);
-                            } else if (ori === OT.DOWNSLOPE) {
-                                segments.push(`M ${x - overflow} ${y + 1 + overflow} L ${x + 1 + overflow} ${y - overflow}`);
-                            } else if (ori === OT.UPSLOPE) {
-                                segments.push(`M ${x - overflow} ${y - overflow} L ${x + 1 + overflow} ${y + 1 + overflow}`);
+                            if (ori === OT.STAR) {
+                                const corners = [
+                                    [x, y],
+                                    [x + 1, y],
+                                    [x + 1, y + 1],
+                                    [x, y + 1]
+                                ];
+                                const prevEnd = orientationEndpoints.get(idx);
+                                let startCornerIndex = 0;
+                                if (prevEnd) {
+                                    let minDist = Infinity;
+                                    for (let i = 0; i < corners.length; i++) {
+                                        const [cx, cy] = corners[i];
+                                        const dx = prevEnd[0] - cx;
+                                        const dy = prevEnd[1] - cy;
+                                        const dist = dx * dx + dy * dy;
+                                        if (dist < minDist) {
+                                            minDist = dist;
+                                            startCornerIndex = i;
+                                        }
+                                    }
+                                }
+                                const starPath = buildStarPath(x, y, 1, startCornerIndex);
+                                if (starPath.d) {
+                                    segments.push({ d: starPath.d, stroke: fill });
+                                    if (starPath.end) orientationEndpoints.set(idx, starPath.end);
+                                }
+                            } else {
+                                let start;
+                                let end;
+                                if (ori === OT.VERTICAL) {
+                                    start = [x - overflow, y + 0.5];
+                                    end = [x + 1 + overflow, y + 0.5];
+                                } else if (ori === OT.HORIZONTAL) {
+                                    start = [x + 0.5, y - overflow];
+                                    end = [x + 0.5, y + 1 + overflow];
+                                } else if (ori === OT.DOWNSLOPE) {
+                                    start = [x - overflow, y + 1 + overflow];
+                                    end = [x + 1 + overflow, y - overflow];
+                                } else if (ori === OT.UPSLOPE) {
+                                    start = [x - overflow, y - overflow];
+                                    end = [x + 1 + overflow, y + 1 + overflow];
+                                } else {
+                                    continue;
+                                }
+                                segments.push({ d: `M ${start[0]} ${start[1]} L ${end[0]} ${end[1]}` });
+                                orientationEndpoints.set(idx, end);
                             }
                         }
                         let orientationPaths = '';
-                        for (const segment of segments) {
-                            orientationPaths += `<path d="${segment}" stroke="#000" stroke-width="0.02" fill="none"/>`;
+                        for (const { d, stroke } of segments) {
+                            if (!d) continue;
+                            const strokeColor = stroke || '#000';
+                            orientationPaths += `<path d="${d}" stroke="${strokeColor}" stroke-width="0.02" fill="none"/>`;
                         }
-                        
-                        const fill = rgbaToHexU32(props.color);
-                        const opacity = alphaU32(props.color);
+
                         result += `<g id="${sanitizeId(props.name)}"><path d="${path}" fill="${fill}" opacity="${opacity}" ${attrStr} fill-rule="evenodd" shape-rendering="crispEdges"/>${orientationPaths}</g>`;
                     }
                 }

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -6,6 +6,77 @@ export const MAX_DIMENSION = 128;
 export const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 export const indexToCoord = (index) => [index % MAX_DIMENSION, Math.floor(index / MAX_DIMENSION)];
 
+export function buildStarPath(x, y, size = 1, startCornerIndex = 0) {
+    const half = size / 2;
+    const corners = [
+        [x, y],
+        [x + size, y],
+        [x + size, y + size],
+        [x, y + size]
+    ];
+    const midpoints = [
+        [x + half, y],
+        [x + size, y + half],
+        [x + half, y + size],
+        [x, y + half]
+    ];
+    const triangles = [
+        { midpoint: midpoints[0], cornerIndices: [2, 3] },
+        { midpoint: midpoints[1], cornerIndices: [3, 0] },
+        { midpoint: midpoints[2], cornerIndices: [0, 1] },
+        { midpoint: midpoints[3], cornerIndices: [1, 2] }
+    ];
+    const normalizedStart = Number.isFinite(startCornerIndex) ? Math.round(startCornerIndex) : 0;
+    let currentCornerIdx = ((normalizedStart % 4) + 4) % 4;
+    const pathPoints = [corners[currentCornerIdx]];
+    let currentTriangleIdx = triangles.findIndex(tri => tri.cornerIndices.includes(currentCornerIdx));
+    if (currentTriangleIdx === -1) currentTriangleIdx = 0;
+    const visited = new Set();
+
+    for (let i = 0; i < triangles.length; i++) {
+        const triangle = triangles[currentTriangleIdx];
+        visited.add(currentTriangleIdx);
+
+        if (!triangle.cornerIndices.includes(currentCornerIdx)) {
+            currentCornerIdx = triangle.cornerIndices[0];
+            pathPoints.push(corners[currentCornerIdx]);
+        }
+
+        const otherCornerIdx = triangle.cornerIndices[0] === currentCornerIdx
+            ? triangle.cornerIndices[1]
+            : triangle.cornerIndices[0];
+
+        pathPoints.push(triangle.midpoint, corners[otherCornerIdx]);
+        currentCornerIdx = otherCornerIdx;
+
+        if (visited.size === triangles.length) break;
+
+        const nextTriangleIdx = triangles.findIndex((tri, idx) => !visited.has(idx) && tri.cornerIndices.includes(currentCornerIdx));
+        if (nextTriangleIdx !== -1) {
+            currentTriangleIdx = nextTriangleIdx;
+        } else {
+            currentTriangleIdx = triangles.findIndex((_, idx) => !visited.has(idx));
+            if (currentTriangleIdx === -1) break;
+        }
+    }
+
+    if (pathPoints.length < 2) {
+        return { d: '', points: [], start: null, end: null };
+    }
+
+    let path = `M ${pathPoints[0][0]} ${pathPoints[0][1]}`;
+    for (let i = 1; i < pathPoints.length; i++) {
+        const [px, py] = pathPoints[i];
+        path += ` L ${px} ${py}`;
+    }
+    return {
+        d: path,
+        points: pathPoints,
+        start: pathPoints[0],
+        end: pathPoints[pathPoints.length - 1]
+    };
+}
+
 export function getPixelUnion(pixelsList = []) {
     if (!Array.isArray(pixelsList)) pixelsList = [pixelsList];
     const union = new Set();
@@ -129,6 +200,23 @@ export function orientationPatternUrl(orientation, target = document.body) {
         line.setAttribute('stroke', '#FFFFFF');
         line.setAttribute('stroke-width', '.08');
         pattern.appendChild(line);
+    }
+    else if (orientation === OT.STAR) {
+        const { d } = buildStarPath(0, 0, 1, 0);
+        if (d) {
+            const border = document.createElementNS(SVG_NAMESPACE, 'path');
+            border.setAttribute('d', d);
+            border.setAttribute('stroke', '#000000');
+            border.setAttribute('stroke-width', '.1');
+            border.setAttribute('fill', 'none');
+            pattern.appendChild(border);
+            const inner = document.createElementNS(SVG_NAMESPACE, 'path');
+            inner.setAttribute('d', d);
+            inner.setAttribute('stroke', '#FFFFFF');
+            inner.setAttribute('stroke-width', '.08');
+            inner.setAttribute('fill', 'none');
+            pattern.appendChild(inner);
+        }
     }
     defs.appendChild(pattern);
     svg.appendChild(defs);


### PR DESCRIPTION
## Summary
- expose buildStarPath metadata so SVG export can reuse start/end points
- begin star orientation strokes at the nearest lower-layer endpoint and tint them with the pixel fill color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99b468ba0832c907d3b01cc19bcbb