### PR TITLE
Adjust SVG path start based on orientation anchor

### DIFF
--- a/src/stores/pixels.js
+++ b/src/stores/pixels.js
@@ -90,8 +90,8 @@ export const usePixelStore = defineStore('pixels', {
         orientationOf: (s) => (id, pixel) => {
             return s._pixels[id].get(pixel);
         },
-        pathOf: (s) => (id) => {
-            return pixelsToUnionPath(s._pixels[id]);
+        pathOf: (s) => (id, options) => {
+            return pixelsToUnionPath(s._pixels[id], options);
         },
         disconnectedCountOf: (s) => (id) => {
             const map = s._pixels[id];


### PR DESCRIPTION
## Summary
- add anchor-aware path generation so exported shapes start closest to the orientation path end
- restructure SVG export to reuse orientation segment data and pass the anchor to path generation
- update pixel store helpers to support the new anchor option when producing SVG paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b886adfc832cb146b6a0cbae8750