### PR TITLE
Align star orientation start points with previous layer

### DIFF
--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -126,7 +126,7 @@ export const useOutputStore = defineStore('output', {
         exportToSVG() {
             const { nodeTree, nodes, pixels, viewport } = useStore();
             const sanitizeId = (name) => String(name).replace(/[^A-Za-z0-9_-]/g, '_');
-            const orientationEndpoints = new Map();
+            let lastOrientationEndpoint = null;
             const serialize = (tree) => {
                 let result = '';
                 for (const node of tree) {
@@ -168,6 +168,8 @@ export const useOutputStore = defineStore('output', {
                         const map = pixels.get(node.id) || new Map();
                         const overflow = 0.025;
                         const segments = [];
+                        const referenceEndPoint = lastOrientationEndpoint;
+                        let layerLastOrientationEndpoint = null;
                         for (const [idx, ori] of map) {
                             if (ori === OT.NONE) continue;
                             const [x, y] = indexToCoord(idx);
@@ -178,14 +180,13 @@ export const useOutputStore = defineStore('output', {
                                     [x + 1, y + 1],
                                     [x, y + 1]
                                 ];
-                                const prevEnd = orientationEndpoints.get(idx);
                                 let startCornerIndex = 0;
-                                if (prevEnd) {
+                                if (referenceEndPoint) {
                                     let minDist = Infinity;
                                     for (let i = 0; i < corners.length; i++) {
                                         const [cx, cy] = corners[i];
-                                        const dx = prevEnd[0] - cx;
-                                        const dy = prevEnd[1] - cy;
+                                        const dx = referenceEndPoint[0] - cx;
+                                        const dy = referenceEndPoint[1] - cy;
                                         const dist = dx * dx + dy * dy;
                                         if (dist < minDist) {
                                             minDist = dist;
@@ -196,7 +197,7 @@ export const useOutputStore = defineStore('output', {
                                 const d = buildStarPath(x, y, 1, startCornerIndex);
                                 if (d) {
                                     segments.push({ d });
-                                    orientationEndpoints.set(idx, corners[startCornerIndex]);
+                                    layerLastOrientationEndpoint = corners[startCornerIndex];
                                 }
                             } else {
                                 let start;
@@ -217,14 +218,17 @@ export const useOutputStore = defineStore('output', {
                                     continue;
                                 }
                                 segments.push({ d: `M ${start[0]} ${start[1]} L ${end[0]} ${end[1]}` });
-                                orientationEndpoints.set(idx, end);
+                                layerLastOrientationEndpoint = end;
                             }
                         }
                         let orientationPaths = '';
                         for (const { d } of segments) {
                             orientationPaths += `<path d="${d}" stroke="#000" stroke-width="0.02" fill="none"/>`;
                         }
-                        
+                        if (layerLastOrientationEndpoint) {
+                            lastOrientationEndpoint = layerLastOrientationEndpoint;
+                        }
+
                         const fill = rgbaToHexU32(props.color);
                         const opacity = alphaU32(props.color);
                         result += `<g id="${sanitizeId(props.name)}"><path d="${path}" fill="${fill}" opacity="${opacity}" ${attrStr} fill-rule="evenodd" shape-rendering="crispEdges"/>${orientationPaths}</g>`;


### PR DESCRIPTION
## Summary
- track the most recent orientation path endpoint while exporting SVG
- start each star orientation segment at the corner closest to the lower layer's last endpoint so all stars in a layer share the same reference point

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c06b90c0832c8eb23beef0afc244