### PR TITLE
Add configurable orientation overflow for SVG export

### DIFF
--- a/src/components/SettingsPopup.vue
+++ b/src/components/SettingsPopup.vue
@@ -21,6 +21,16 @@
               <option v-for="ori in pixelOrientations" :key="ori" :value="ori">{{ ORIENTATION_LABELS[ori] }}</option>
             </select>
           </div>
+          <label class="block">
+            <span>Orientation Overflow (%)</span>
+            <input type="number" min="0" max="100" step="0.1" v-model.number="orientationOverflowPercent"
+                   class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          </label>
+          <label class="block">
+            <span>Star Orientation Overflow (%)</span>
+            <input type="number" min="0" max="100" step="0.1" v-model.number="starOrientationOverflowPercent"
+                   class="mt-1 w-full rounded bg-slate-700 px-2 py-1" />
+          </label>
         </div>
         <div v-else-if="currentTab === 'Stage'" class="space-y-2 text-white/70">
           <label class="block">
@@ -41,7 +51,7 @@ import { ref, watch } from 'vue';
 import { useService } from '../services';
 import { usePixelStore, PIXEL_DEFAULT_ORIENTATIONS, PIXEL_ORIENTATIONS } from '@/stores/pixels';
 import { CHECKERBOARD_CONFIG } from '@/constants';
-import { ORIENTATION_LABELS } from '@/constants/orientation.js';
+import { ORIENTATION_LABELS, ORIENTATION_OVERFLOW_CONFIG } from '@/constants/orientation.js';
 import { checkerboardPatternUrl } from '@/utils/pixels.js';
 
 const { settings: settingsService } = useService();
@@ -58,6 +68,30 @@ const [initialA, initialB] = pixelStore.checkerboardOrientations;
 const cbOriA = ref(initialA);
 const cbOriB = ref(initialB);
 watch([cbOriA, cbOriB], ([a, b]) => pixelStore.setCheckerboardOrientations(a, b));
+
+const orientationOverflowPercent = ref(ORIENTATION_OVERFLOW_CONFIG.LINE_PERCENT);
+watch(orientationOverflowPercent, value => {
+  let clamped = Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
+  clamped = Math.round(clamped * 10) / 10;
+  if (clamped !== value) {
+    orientationOverflowPercent.value = clamped;
+    return;
+  }
+  ORIENTATION_OVERFLOW_CONFIG.LINE_PERCENT = clamped;
+  localStorage.setItem('settings.orientationOverflowPercent', String(clamped));
+});
+
+const starOrientationOverflowPercent = ref(ORIENTATION_OVERFLOW_CONFIG.STAR_PERCENT);
+watch(starOrientationOverflowPercent, value => {
+  let clamped = Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
+  clamped = Math.round(clamped * 10) / 10;
+  if (clamped !== value) {
+    starOrientationOverflowPercent.value = clamped;
+    return;
+  }
+  ORIENTATION_OVERFLOW_CONFIG.STAR_PERCENT = clamped;
+  localStorage.setItem('settings.starOrientationOverflowPercent', String(clamped));
+});
 
 const checkerboardRepeat = ref(CHECKERBOARD_CONFIG.REPEAT);
 watch(checkerboardRepeat, repeat => {

--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -20,3 +20,16 @@ export const ORIENTATION_LABELS = {
   [OT.STAR]: 'star',
   checkerboard: 'checkerboard'
 };
+
+const parseOverflowSetting = (key, fallback) => {
+  if (typeof localStorage === 'undefined') return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const ORIENTATION_OVERFLOW_CONFIG = {
+  LINE_PERCENT: parseOverflowSetting('settings.orientationOverflowPercent', 2.5),
+  STAR_PERCENT: parseOverflowSetting('settings.starOrientationOverflowPercent', 2.5)
+};

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -4,7 +4,7 @@ import { useStore } from '.';
 import { useLayerPanelService } from '../services/layerPanel';
 import { rgbaToHexU32, alphaU32 } from '../utils';
 import { indexToCoord, buildStarPath } from '../utils/pixels.js';
-import { OT } from '../constants/orientation.js';
+import { OT, ORIENTATION_OVERFLOW_CONFIG } from '../constants/orientation.js';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -166,18 +166,20 @@ export const useOutputStore = defineStore('output', {
 
                         // temp orientation satin rung
                         const map = pixels.get(node.id) || new Map();
-                        const overflow = 0.025;
+                        const overflow = ORIENTATION_OVERFLOW_CONFIG.LINE_PERCENT / 100;
+                        const starOverflow = ORIENTATION_OVERFLOW_CONFIG.STAR_PERCENT / 100;
                         const segments = [];
                         const starReference = lastOrientationEnd;
                         for (const [idx, ori] of map) {
                             if (ori === OT.NONE) continue;
                             const [x, y] = indexToCoord(idx);
                             if (ori === OT.STAR) {
+                                const starOffset = starOverflow;
                                 const corners = [
-                                    [x, y],
-                                    [x + 1, y],
-                                    [x + 1, y + 1],
-                                    [x, y + 1]
+                                    [x - starOffset, y - starOffset],
+                                    [x + 1 + starOffset, y - starOffset],
+                                    [x + 1 + starOffset, y + 1 + starOffset],
+                                    [x - starOffset, y + 1 + starOffset]
                                 ];
                                 let startCornerIndex = 0;
                                 if (starReference) {
@@ -193,7 +195,7 @@ export const useOutputStore = defineStore('output', {
                                         }
                                     }
                                 }
-                                const d = buildStarPath(x, y, 1, startCornerIndex);
+                                const d = buildStarPath(x, y, 1, startCornerIndex, starOverflow);
                                 if (d) {
                                     segments.push({ d, isStar: true });
                                     lastOrientationEnd = corners[startCornerIndex];

--- a/src/utils/pixels.js
+++ b/src/utils/pixels.js
@@ -6,19 +6,25 @@ export const MAX_DIMENSION = 128;
 export const coordToIndex = (x, y) => x + MAX_DIMENSION * y;
 export const indexToCoord = (index) => [index % MAX_DIMENSION, Math.floor(index / MAX_DIMENSION)];
 
-export function buildStarPath(x, y, size = 1, startCornerIndex = 0) {
+export function buildStarPath(x, y, size = 1, startCornerIndex = 0, overflow = 0) {
+    const normalizedOverflow = Number.isFinite(overflow) ? overflow : 0;
+    const offset = size * normalizedOverflow;
+    const minX = x - offset;
+    const minY = y - offset;
+    const maxX = x + size + offset;
+    const maxY = y + size + offset;
     const half = size / 2;
     const corners = [
-        [x, y],
-        [x + size, y],
-        [x + size, y + size],
-        [x, y + size]
+        [minX, minY],
+        [maxX, minY],
+        [maxX, maxY],
+        [minX, maxY]
     ];
     const midpoints = [
-        [x + half, y],
-        [x + size, y + half],
-        [x + half, y + size],
-        [x, y + half]
+        [x + half, minY],
+        [maxX, y + half],
+        [x + half, maxY],
+        [minX, y + half]
     ];
     const triangles = [
         { midpoint: midpoints[0], cornerIndices: [2, 3] },


### PR DESCRIPTION
## Summary
- convert SVG orientation overflow to percentage-based values
- expose controls in the settings popup for line and star overflow percentages
- apply configurable overflow to exported star orientation paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca5d0b5954832ca189b80db977e293