### PR TITLE
Prevent color chip click from altering selection

### DIFF
--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -41,7 +41,7 @@
         </div>
         <!-- 색상 -->
         <div class="h-6 w-6 rounded border border-white/25 p-0 relative overflow-hidden">
-          <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.props.locked }" :disabled="item.props.locked" :value="rgbaToHexU32(item.props.color)" @pointerdown.stop @mousedown.stop @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
+          <input type="color" class="h-10 w-10 p-0 cursor-pointer absolute -top-2 -left-2" :class="{ 'cursor-not-allowed': item.props.locked }" :disabled="item.props.locked" :value="rgbaToHexU32(item.props.color)" @pointerdown.stop @mousedown.stop @click.stop @input.stop="onColorInput(item.id, $event)" @change.stop="onColorChange()" title="색상 변경" />
         </div>
         <!-- 이름/픽셀 -->
         <div class="min-w-0 flex-1 relative overflow-hidden fade-mask">


### PR DESCRIPTION
## Summary
- stop click events on the layer color input so multi-selection stays intact when changing colors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cacc87d144832cb0e7e56c73eef8d4