### PR TITLE
Set save-as default name to loaded file

### DIFF
--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -287,8 +287,11 @@ export const useOutputStore = defineStore('output', {
                 return false;
             }
             try {
+                const loadedName = fileSystem.loadHandle?.name || '';
+                const baseName = loadedName.replace(/\.[^./\\]+$/, '') || 'pixel-edit';
+                const suggestedName = `${baseName}.${defaultFormat}`;
                 const handle = await window.showSaveFilePicker({
-                    suggestedName: `pixel-edit.${defaultFormat}`,
+                    suggestedName,
                     types: [
                         {
                             description: 'Pixel Edit JSON',


### PR DESCRIPTION
## Summary
- derive the suggested Save As filename from the currently loaded file handle
- fall back to the existing pixel-edit default when no loaded name is present

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae4882d74832ca2ee8fdce308b68b