### PR TITLE
Add SVG export pixel size settings

### DIFF
--- a/src/components/SettingsPopup.vue
+++ b/src/components/SettingsPopup.vue
@@ -37,6 +37,16 @@
             <span>Checkerboard Repeat</span>
             <input type="number" min="1" v-model.number="checkerboardRepeat" class="mt-1 w-full rounded bg-slate-700 px-2 py-1"/>
           </label>
+          <label class="block">
+            <span>SVG Pixel Size</span>
+            <div class="mt-1 flex gap-2">
+              <input type="number" min="0.01" step="0.01" v-model.number="svgPixelSize"
+                     class="flex-1 rounded bg-slate-700 px-2 py-1" />
+              <select v-model="svgUnit" class="w-20 rounded bg-slate-700 px-2 py-1">
+                <option v-for="unit in svgUnits" :key="unit" :value="unit">{{ unit }}</option>
+              </select>
+            </div>
+          </label>
         </div>
       </div>
       <div class="flex justify-end gap-2">
@@ -53,6 +63,7 @@ import { usePixelStore, PIXEL_DEFAULT_ORIENTATIONS, PIXEL_ORIENTATIONS } from '@
 import { CHECKERBOARD_CONFIG } from '@/constants';
 import { ORIENTATION_LABELS, ORIENTATION_OVERFLOW_CONFIG } from '@/constants/orientation.js';
 import { checkerboardPatternUrl } from '@/utils/pixels.js';
+import { SVG_EXPORT_CONFIG, SVG_EXPORT_UNITS } from '@/constants/svg.js';
 
 const { settings: settingsService } = useService();
 const pixelStore = usePixelStore();
@@ -100,5 +111,30 @@ watch(checkerboardRepeat, repeat => {
   const patternEl = document.getElementById(CHECKERBOARD_CONFIG.PATTERN_ID);
   patternEl?.parentNode?.parentNode?.remove();
   checkerboardPatternUrl(document.body);
+});
+
+const svgPixelSize = ref(SVG_EXPORT_CONFIG.PIXEL_SIZE);
+watch(svgPixelSize, value => {
+  let size = Number.isFinite(value) ? Math.max(0.01, value) : 1;
+  size = Math.round(size * 1000) / 1000;
+  if (size !== value) {
+    svgPixelSize.value = size;
+    return;
+  }
+  SVG_EXPORT_CONFIG.PIXEL_SIZE = size;
+  localStorage.setItem('settings.svgExportPixelSize', String(size));
+});
+
+const svgUnits = SVG_EXPORT_UNITS;
+const svgUnit = ref(SVG_EXPORT_CONFIG.UNIT);
+watch(svgUnit, unit => {
+  const fallback = SVG_EXPORT_UNITS[0];
+  const next = SVG_EXPORT_UNITS.includes(unit) ? unit : fallback;
+  if (next !== unit) {
+    svgUnit.value = next;
+    return;
+  }
+  SVG_EXPORT_CONFIG.UNIT = next;
+  localStorage.setItem('settings.svgExportUnit', next);
 });
 </script>

--- a/src/constants/svg.js
+++ b/src/constants/svg.js
@@ -1,1 +1,15 @@
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+export const SVG_EXPORT_UNITS = ['px', 'pt', 'in', 'mm'];
+
+const hasLocalStorage = typeof localStorage !== 'undefined';
+const storedUnit = hasLocalStorage ? localStorage.getItem('settings.svgExportUnit') : null;
+const storedPixelSize = hasLocalStorage ? Number(localStorage.getItem('settings.svgExportPixelSize')) : NaN;
+
+const defaultUnit = SVG_EXPORT_UNITS.includes(storedUnit) ? storedUnit : 'px';
+const defaultPixelSize = Number.isFinite(storedPixelSize) && storedPixelSize > 0 ? storedPixelSize : 1;
+
+export const SVG_EXPORT_CONFIG = {
+  UNIT: defaultUnit,
+  PIXEL_SIZE: defaultPixelSize
+};

--- a/src/stores/output.js
+++ b/src/stores/output.js
@@ -6,6 +6,7 @@ import { useFileSystemStore } from './fileSystem';
 import { rgbaToHexU32, alphaU32 } from '../utils';
 import { indexToCoord, buildStarPath } from '../utils/pixels.js';
 import { OT, ORIENTATION_OVERFLOW_CONFIG } from '../constants/orientation.js';
+import { SVG_EXPORT_CONFIG } from '../constants/svg.js';
 
 export const useOutputStore = defineStore('output', {
     state: () => ({
@@ -245,7 +246,13 @@ export const useOutputStore = defineStore('output', {
                 return result;
             };
             const { stage, viewBox } = viewport;
-            return `<svg xmlns="http://www.w3.org/2000/svg" width="${stage.width}" height="${stage.height}" viewBox="${viewBox}">${serialize(nodeTree.tree)}</svg>`;
+            const unit = SVG_EXPORT_CONFIG.UNIT;
+            const pixelSize = SVG_EXPORT_CONFIG.PIXEL_SIZE;
+            const formatSize = value => {
+                const scaled = Math.round(value * pixelSize * 1000) / 1000;
+                return `${scaled}${unit}`;
+            };
+            return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatSize(stage.width)}" height="${formatSize(stage.height)}" viewBox="${viewBox}">${serialize(nodeTree.tree)}</svg>`;
         },
         download(format = 'json') {
             const content = format === 'json' ? this.exportToJSON() : this.exportToSVG();


### PR DESCRIPTION
## Summary
- add SVG pixel size and unit controls to the Stage settings popup
- persist SVG export preferences and reuse them during exports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae763cef8832c89de1a747354ad3f